### PR TITLE
fix: harden CI, build flags, and dev tooling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     // features: https://github.com/devcontainers/features?tab=readme-ov-file
     "image": "mcr.microsoft.com/devcontainers/go:2.1-bookworm",
     "features": {
-            "ghcr.io/devcontainers/features/go:latest": {
+            "ghcr.io/devcontainers/features/go:1": {
                 "version": "1.26.3"
             }
     },

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ README.md
 local/
 coverage.out
 .goreleaser.yml
+tmp/

--- a/.github/actions/go/action.yml
+++ b/.github/actions/go/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v7
       with:
-        version: latest
+        version: v2.15.4
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -7,11 +7,11 @@ description: Runs actions to test go code
 runs:
   using: "composite" # allows inputs/outputs to be passed between steps
   steps:
-    - uses: actions/checkout@v4
+    # calling workflows already checkout; no redundant checkout here
     # https://github.com/actions/runner/issues/2238
     # use `fromJSON`
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'
     # get version
@@ -34,9 +34,9 @@ runs:
     - name: Lint code
       uses: golangci/golangci-lint-action@v9
       with:
-        version: latest
+        version: v2.12.2
         args: --timeout 5m
-    # run unit tests
+    # run unit tests with race detector
     - name: Run Go Tests
       shell: bash
-      run: go test ./... -count=1
+      run: go test ./... -race -count=1

--- a/.github/workflows/on_pr_merged.yml
+++ b/.github/workflows/on_pr_merged.yml
@@ -13,6 +13,11 @@ on:
     branches:
       - main
 
+# cancel a stale in-flight build so :main reflects the newest commit on rapid merges
+concurrency:
+  group: main-image
+  cancel-in-progress: true
+
 # maybe trigger build/push on release tags?
 # but this also works for my use case
 jobs:

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: write
 
+# never cancel a release mid-flight (partial artifacts); tags are unique so this only guards dup runs
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: "tdarr-exporter"
 archives:
   - id: main
@@ -8,8 +9,12 @@ builds:
   - main: "./cmd/exporter"
     binary: "tdarr-exporter"
 
+    # -trimpath: strip absolute build paths for reproducible builds
+    flags:
+      - -trimpath
+    # CGO disabled (env below) -> pure-Go static binary, so -extldflags is not needed
     ldflags:
-      - -w -s -extldflags '-static' -X main.version={{.Version}} -X main.revision={{.Commit}} -X main.buildTime={{.CommitTimestamp}}
+      - -w -s -X main.version={{.Version}} -X main.revision={{.Commit}} -X main.buildTime={{.Date}}
 
     goarch:
       - "386"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ RUN go mod download
 
 COPY . .
 RUN go build \
-    # ldlflags: `-w -s` disable debugging and `pprof` for minimal binary, 
+    # -trimpath: strip absolute build paths for reproducible builds
+    -trimpath \
+    # ldlflags: `-w -s` disable debugging and `pprof` for minimal binary,
     -ldflags "-w -s -X main.version=${VERSION} -X main.buildTime=${BUILDTIME} -X main.revision=${REVISION}" \
     -o exporter /build/cmd/exporter/.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Create `local/local.env` (gitignored) with any env vars needed for local runs, e
 | ---- | ----------- |
 | `task dev` | Live-reload dev loop (requires `local/local.env` with `TDARR_URL`) |
 | `task dev:docker` | Build local image image and run for live testing |
-| `task test:all` | Run all tests |
+| `task test` | Run all tests |
 | `task ci` | Run fmt, mod-tidy check, lint, and race+coverage tests (CI aggregate) |
 
 Run `task --list` to see all available tasks.

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ Create `local/local.env` (gitignored) with any env vars needed for local runs, e
 | Task | Description |
 | ---- | ----------- |
 | `task dev` | Live-reload dev loop (requires `local/local.env` with `TDARR_URL`) |
-| `task dev_docker` | Build local image image and run for live testing |
-| `task test` | Run all tests |
+| `task dev:docker` | Build local image image and run for live testing |
+| `task test:all` | Run all tests |
 | `task ci` | Run fmt, mod-tidy check, lint, and race+coverage tests (CI aggregate) |
 
 Run `task --list` to see all available tasks.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Create `local/local.env` (gitignored) with any env vars needed for local runs, e
 | `task dev` | Live-reload dev loop (requires `local/local.env` with `TDARR_URL`) |
 | `task dev_docker` | Build local image image and run for live testing |
 | `task test` | Run all tests |
-| `task ci` | Run fmt, lint, test_race, test_cover (CI aggregate) |
+| `task ci` | Run fmt, mod-tidy check, lint, and race+coverage tests (CI aggregate) |
 
 Run `task --list` to see all available tasks.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,7 +16,7 @@ vars:
   TEST_IMAGE_TAG: test
   PORT: '9090'
   CONTAINER: tdarr-exporter-smoke
-  
+
   # Git info for build args
   VERSION:
     sh: git describe --tags --always --dirty
@@ -31,10 +31,10 @@ tasks:
     cmds:
       - air
 
-  dev_docker:
+  dev:docker:
     desc: Build image, run detached, curl /metrics once, then tear down
     deps:
-      - task: docker_build_local
+      - task: docker:build-local
     cmds:
       - docker run -it -p {{.PORT}}:{{.PORT}} --rm --name {{.CONTAINER}}  -e TDARR_URL={{.TDARR_URL}} {{.TEST_IMAGE_NAME}}:{{.TEST_IMAGE_TAG}}
 
@@ -53,7 +53,7 @@ tasks:
     cmds:
       - go fmt ./...
 
-  update_deps:
+  update-deps:
     desc: Upgrade all dependencies to latest then tidy
     cmds:
       - go get -u ./...
@@ -64,39 +64,39 @@ tasks:
     cmds:
       - docker run --rm -i -v {{.TASKFILE_DIR}}:/app -w /app golangci/golangci-lint:v2.12.2 golangci-lint run
 
-  test:
+  test:all:
     desc: Run all tests
     cmds:
       - go test ./... -count=1
 
-  test_verbose:
+  test:verbose:
     desc: Run all tests with verbose output
     cmds:
       - go test ./... -v -count=1
 
-  test_race:
+  test:race:
     desc: Run all tests with race detector
     cmds:
       - go test ./... -race -count=1
 
-  test_cover:
+  test:cover:
     desc: Run all tests with coverage and print per-function summary
     cmds:
       - go test ./... -count=1 -coverprofile=coverage.out
       - go tool cover -func=coverage.out
 
-  test_all:
+  test:full:
     desc: Run all tests once with both race detector and coverage, then print summary
     cmds:
       - go test ./... -race -count=1 -coverprofile=coverage.out
       - go tool cover -func=coverage.out
 
-  test_collector:
+  test:collector:
     desc: Run collector package tests with verbose output
     cmds:
       - go test ./internal/collector/... -v -count=1
 
-  docker_build_local:
+  docker:build-local:
     desc: Build image for local platform only (linux/amd64 or linux/arm64) without pushing
     cmds:
       - docker build
@@ -109,10 +109,10 @@ tasks:
           --build-arg BUILDTIME={{.BUILDTIME}}
           -t {{.TEST_IMAGE_NAME}}:{{.TEST_IMAGE_TAG}} .
 
-  docker_build:
+  docker:build:
     desc: Build multi-arch image (linux/amd64,linux/arm64) without pushing
     cmds:
-      - task: buildx_setup
+      - task: docker:buildx-setup
       - docker buildx build
           --platform linux/amd64,linux/arm64
           --output "type=image,push=false"
@@ -126,10 +126,10 @@ tasks:
           -t {{.TEST_IMAGE_NAME}}:{{.TEST_IMAGE_TAG}}
           --no-cache .
 
-  docker_build_latest:
+  docker:build-latest:
     desc: Build multi-arch image (linux/amd64,linux/arm64) and PUSH to registry with :test and :latest tags
     cmds:
-      - task: buildx_setup
+      - task: docker:buildx-setup
       - docker buildx build
           --platform linux/amd64,linux/arm64
           --output "type=image,push=false"
@@ -144,13 +144,13 @@ tasks:
           -t {{.TEST_IMAGE_NAME}}:latest
           --no-cache .
 
-  buildx_setup:
+  docker:buildx-setup:
     desc: Create and activate the crossplat buildx builder (internal)
     internal: true
     cmds:
       - docker buildx create --use --name=crossplat --node=crossplat || true
 
-  docker_cleanup:
+  docker:cleanup:
     desc: Remove the crossplat buildx builder
     cmds:
       - docker buildx rm crossplat
@@ -164,4 +164,4 @@ tasks:
       # scoped to go artifacts so unrelated WIP doesn't trip the local run
       - git diff --exit-code -- '*.go' go.mod go.sum
       - task: lint
-      - task: test_all
+      - task: test:full

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -85,6 +85,12 @@ tasks:
       - go test ./... -count=1 -coverprofile=coverage.out
       - go tool cover -func=coverage.out
 
+  test_all:
+    desc: Run all tests once with both race detector and coverage, then print summary
+    cmds:
+      - go test ./... -race -count=1 -coverprofile=coverage.out
+      - go tool cover -func=coverage.out
+
   test_collector:
     desc: Run collector package tests with verbose output
     cmds:
@@ -150,7 +156,7 @@ tasks:
       - docker buildx rm crossplat
 
   ci:
-    desc: Run fmt, mod-tidy check, lint, test_race, and test_cover in order (CI aggregate)
+    desc: Run fmt, mod-tidy check, lint, and race+coverage tests in order (CI aggregate)
     cmds:
       - task: fmt
       - task: tidy
@@ -158,5 +164,4 @@ tasks:
       # scoped to go artifacts so unrelated WIP doesn't trip the local run
       - git diff --exit-code -- '*.go' go.mod go.sum
       - task: lint
-      - task: test_race
-      - task: test_cover
+      - task: test_all

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,7 +34,7 @@ tasks:
   dev:docker:
     desc: Build image, run detached, curl /metrics once, then tear down
     deps:
-      - task: docker:build-local
+      - task: docker:build:local
     cmds:
       - docker run -it -p {{.PORT}}:{{.PORT}} --rm --name {{.CONTAINER}}  -e TDARR_URL={{.TDARR_URL}} {{.TEST_IMAGE_NAME}}:{{.TEST_IMAGE_TAG}}
 
@@ -64,7 +64,7 @@ tasks:
     cmds:
       - docker run --rm -i -v {{.TASKFILE_DIR}}:/app -w /app golangci/golangci-lint:v2.12.2 golangci-lint run
 
-  test:all:
+  test:
     desc: Run all tests
     cmds:
       - go test ./... -count=1
@@ -96,7 +96,7 @@ tasks:
     cmds:
       - go test ./internal/collector/... -v -count=1
 
-  docker:build-local:
+  docker:build:local:
     desc: Build image for local platform only (linux/amd64 or linux/arm64) without pushing
     cmds:
       - docker build
@@ -126,7 +126,7 @@ tasks:
           -t {{.TEST_IMAGE_NAME}}:{{.TEST_IMAGE_TAG}}
           --no-cache .
 
-  docker:build-latest:
+  docker:build:latest:
     desc: Build multi-arch image (linux/amd64,linux/arm64) and PUSH to registry with :test and :latest tags
     cmds:
       - task: docker:buildx-setup

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,9 +60,9 @@ tasks:
       - go mod tidy
 
   lint:
-    desc: Run golangci-lint via Docker (latest image)
+    desc: Run golangci-lint via Docker (pinned, matches CI)
     cmds:
-      - docker run --rm -i -v {{.TASKFILE_DIR}}:/app -w /app golangci/golangci-lint:latest golangci-lint run
+      - docker run --rm -i -v {{.TASKFILE_DIR}}:/app -w /app golangci/golangci-lint:v2.12.2 golangci-lint run
 
   test:
     desc: Run all tests
@@ -150,9 +150,13 @@ tasks:
       - docker buildx rm crossplat
 
   ci:
-    desc: Run fmt, lint, test_race, and test_cover in order (CI aggregate)
+    desc: Run fmt, mod-tidy check, lint, test_race, and test_cover in order (CI aggregate)
     cmds:
       - task: fmt
+      - task: tidy
+      # fail if fmt/tidy changed go sources or modules, matching CI's git diff --exit-code gate
+      # scoped to go artifacts so unrelated WIP doesn't trip the local run
+      - git diff --exit-code -- '*.go' go.mod go.sum
       - task: lint
       - task: test_race
       - task: test_cover


### PR DESCRIPTION
## Changes
- **CI tests action**: run tests with `-race`; bump `setup-go` v5→v6; drop redundant `checkout` (calling workflows already check out); pin `golangci-lint` to `v2.12.2` (was `latest`).
- **go release action**: pin `goreleaser` to `v2.15.4` (was `latest`).
- **goreleaser**: add `version: 2`; add `-trimpath`; drop dead `-extldflags '-static'` (no-op with `CGO_ENABLED=0`); switch `buildTime` from `{{.CommitTimestamp}}` (unix epoch) to `{{.Date}}` (RFC3339) so it matches the docker image's build time.
- **Dockerfile**: add `-trimpath`.
- **Taskfile**: `ci:` adds `tidy` + go-artifact diff gate (mirrors CI); pin lint image to `v2.12.2`; collapse the double test run into a single `test:full` (race + coverage in one pass); **namespace tasks with colon grouping** (`test:*`, `docker:build:*`, `dev:docker`, `update-deps`) following a default-action + subcommand convention (bare `test`/`docker:build` = default, `:variant` = specialization) for discoverability/tab-completion.
- **workflows**: add `concurrency` to `on_pr_merged` (cancel-in-progress — keeps `:main` on newest commit during rapid merges) and `on_release` (no cancel — never interrupt a release mid-flight; tags are unique).
- **.dockerignore**: exclude `tmp/` (air build output, was leaking into build context).
- **devcontainer**: pin go feature ref `:latest` → `:1`.
- **README**: task table updated to the new task names + `ci:` description.

No ticket. No product/runtime behavior change.

### Task renames (Taskfile public interface)
`test_verbose`→`test:verbose`, `test_race`→`test:race`, `test_cover`→`test:cover`, `test_all`→`test:full`, `test_collector`→`test:collector`, `docker_build`→`docker:build`, `docker_build_local`→`docker:build:local`, `docker_build_latest`→`docker:build:latest`, `buildx_setup`→`docker:buildx-setup`, `docker_cleanup`→`docker:cleanup`, `dev_docker`→`dev:docker`, `update_deps`→`update-deps`. Plain `test` and `docker:build` stay bare as the default actions, with `:variant` children. Flat unchanged: `dev`, `curl`, `fmt`, `tidy`, `lint`, `ci`.

## Motivation
- Reproducible builds via `-trimpath` (strips absolute build paths).
- Deterministic CI: pinned tool versions instead of `latest`, plus `-race` to catch data races.
- Parity between local `task ci` and GitHub Actions (same fmt/tidy/lint/test gates).
- Taskfile namespacing scales as task count grows and groups cleanly in `task --list`.

## Test plan
- `task ci` passes locally (fmt, tidy, diff gate, lint @ v2.12.2, `test:full` race+coverage) — exit 0.
- `task --list` renders namespaced tasks grouped; `docker:buildx-setup` stays internal/hidden.
- `goreleaser check` validates `.goreleaser.yml` against the v2.15.4 schema.
- All workflow/action YAML parses.
- CI on this PR exercises the updated tests action.

## In-depth
- **`buildTime` semantic change**: now reports *build* time (RFC3339), not commit timestamp. Aligns release binaries with docker image labels.
- **provenance/SBOM considered, dropped**: provenance already ships by default (mode=max for public repos); SBOM adds little for a single static-Go-binary distroless image (deps already in `go.sum` + embedded Go build info).
- **SHA-pinning considered, dropped**: kept float `@vN` action tags for now; renovate continues managing major bumps.
- **Local diff gate scoped to `*.go go.mod go.sum`** (not bare `git diff`) so unrelated WIP doesn't trip `task ci`. CI keeps the full gate since it runs on a clean checkout.
- **CI vs Taskfile kept separate** (not routed through `task`): preserves golangci-lint-action's PR annotations + caching and avoids a go-task install dependency in CI.
- **Task naming convention**: bare name = default action, colon children = variants (like `git stash` vs `git stash list`). go-task accepts a task name that is a prefix of others (`docker:build` + `docker:build:local`).
