### PR TITLE
fix: remove duplicate root renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
## Changes
Delete root `renovate.json`.

## Motivation
Renovate scans config locations in precedence order, with root `renovate.json` taking priority over `.github/renovate.json`. The root file was auto-created by the Renovate onboarding PR (commit be17580, renovate[bot]) before `.github/renovate.json` landed on main. It contained only `config:recommended`, shadowing the richer `.github/renovate.json` (github-actions grouping, `prConcurrentLimit`, `minimumReleaseAge`, timezone). Those settings were inactive.

Removing the root file lets `.github/renovate.json` take effect.

## Verification
- `.github/renovate.json` remains as the single active config.
- After merge, confirm next Renovate run logs reference `.github/renovate.json` and apply grouping/concurrency rules.