### PR TITLE
fix: harden renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,9 @@
 {
-  "extends": ["config:recommended"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":configMigration"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
@@ -9,13 +11,10 @@
       "groupSlug": "github-actions"
     },
     {
+      "matchManagers": ["!github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "chore(deps): minor & patch updates",
+      "groupName": "minor & patch updates",
       "groupSlug": "minor-patch"
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "minimumReleaseAge": "3 days"
     }
   ],
   "timezone": "UTC"


### PR DESCRIPTION
## Changes

- Add `$schema` for editor validation/autocomplete.
- Add `:configMigration` preset — Renovate auto-opens PRs to fix deprecated config keys. Not included in `config:recommended`.
- Make `minimumReleaseAge: "3 days"` global (all update types) instead of major-only. Patch/minor releases are the primary supply-chain attack surface, so the buffer now covers them.
- Fix grouping bug: previously a github-actions minor/patch update matched both the github-actions rule and the minor/patch rule. Since later `packageRules` override earlier ones on non-mergeable fields (`groupName`/`groupSlug`), gh-actions minor/patch PRs were landing in the `minor-patch` group instead of their own group. Added `matchManagers: ["!github-actions"]` to the minor/patch rule to isolate them.
- Rename minor/patch `groupName` from `chore(deps): minor & patch updates` to `minor & patch updates`. The conventional prefix is Renovate's job via `semanticCommits` (auto-enabled given this repo's commit history); embedding it in the group label risked a doubled prefix in grouped PR titles.

The removed `major`-only rule had no `groupName` (it only set `minimumReleaseAge`), so dropping it does not change major-update grouping — majors remain individual PRs, now also covered by the global 3-day age.

## Motivation

Current config had a silent grouping bug (gh-actions updates mis-grouped) and applied the release-age safety buffer only to major bumps, leaving the higher-risk patch/minor stream unguarded. This tightens both while keeping the maintainer's choices (no schedule, no throttle, no digest pinning) intact.

## Test plan

- `python3 -m json.tool .github/renovate.json` — JSON valid.
- Config behaviors verified against official Renovate docs: `!`-negation in `matchManagers`, `:configMigration` validity/non-redundancy, last-match-wins for `packageRules` non-mergeable fields, `semanticCommits: auto` detection.
- Live grouping/commit-prefix behavior only fully observable once Renovate runs against this branch — confirm gh-actions vs minor/patch grouping and PR-title prefixes on the first post-merge Renovate run.

## In-depth

Deliberately excluded (maintainer preference for a small OSS repo): weekly schedule, hourly throttle (`prHourlyLimit: 0` kept), Docker/action digest pinning, and breaking-change (`!`) commit prefixes for major dep bumps. These can be revisited if PR noise or supply-chain posture changes.