### PR TITLE
refactor: collector/client/config testability + latent bug fixes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
       - -trimpath
     # CGO disabled (env below) -> pure-Go static binary, so -extldflags is not needed
     ldflags:
-      - -w -s -X main.version={{.Version}} -X main.revision={{.Commit}} -X main.buildTime={{.Date}}
+      - -w -s -X github.com/prometheus/common/version.Version={{.Version}} -X github.com/prometheus/common/version.Revision={{.Commit}} -X github.com/prometheus/common/version.BuildDate={{.Date}}
 
     goarch:
       - "386"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN go build \
     # -trimpath: strip absolute build paths for reproducible builds
     -trimpath \
     # ldlflags: `-w -s` disable debugging and `pprof` for minimal binary,
-    -ldflags "-w -s -X main.version=${VERSION} -X main.buildTime=${BUILDTIME} -X main.revision=${REVISION}" \
+    -ldflags "-w -s -X github.com/prometheus/common/version.Version=${VERSION} -X github.com/prometheus/common/version.Revision=${REVISION} -X github.com/prometheus/common/version.BuildDate=${BUILDTIME}" \
     -o exporter /build/cmd/exporter/.
 
 FROM ${RUN_IMAGE}:${RUN_IMAGE_TAG}

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"sync"
@@ -13,22 +14,26 @@ import (
 	"github.com/homeylab/tdarr-exporter/internal/server"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
+	"github.com/prometheus/common/version"
 
 	"github.com/rs/zerolog/log"
 )
 
-// Build metadata injected by the linker via -X flags.
-var (
-	version   string
-	buildTime string
-	revision  string
-)
-
 func main() {
+	// Handle --version before config parsing so it doesn't interfere with
+	// config.NewConfig's own flag set.
+	for _, arg := range os.Args[1:] {
+		if arg == "--version" || arg == "-version" {
+			fmt.Println(version.Print("tdarr_exporter"))
+			os.Exit(0)
+		}
+	}
+
 	defer os.Exit(0)
 	userConfig := config.NewConfig()
 	log.Debug().Interface("config", userConfig).Msg("Using generated configuration")
-	log.Info().Str("version", version).Str("buildTime", buildTime).Str("revision", revision).Msg("Starting tdarr-exporter")
+	log.Info().Str("version", version.Version).Str("revision", version.Revision).Str("buildDate", version.BuildDate).Str("goVersion", version.GoVersion).Msg("Starting tdarr-exporter")
 
 	// prometheus set up
 	tdarrCollector, err := collector.NewTdarrCollector(userConfig)
@@ -41,6 +46,8 @@ func main() {
 	// standard Go runtime + process metrics (go_*, process_*)
 	registry.MustRegister(collectors.NewGoCollector())
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	// build info metric (tdarr_exporter_build_info)
+	registry.MustRegister(versioncollector.NewCollector("tdarr_exporter"))
 
 	// http server
 	stopHttpChan := make(chan bool)

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -30,7 +30,10 @@ func main() {
 	log.Info().Str("version", version).Str("buildTime", buildTime).Str("revision", revision).Msg("Starting tdarr-exporter")
 
 	// prometheus set up
-	tdarrCollector := collector.NewTdarrCollector(userConfig)
+	tdarrCollector, err := collector.NewTdarrCollector(userConfig)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to create Tdarr collector")
+	}
 	registry := prometheus.NewRegistry()
 	// registering a collector uses JIT and first scrape will be slower
 	registry.MustRegister(tdarrCollector)

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/homeylab/tdarr-exporter/internal/config"
 	"github.com/homeylab/tdarr-exporter/internal/server"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 
 	"github.com/rs/zerolog/log"
 )
@@ -37,6 +38,9 @@ func main() {
 	registry := prometheus.NewRegistry()
 	// registering a collector uses JIT and first scrape will be slower
 	registry.MustRegister(tdarrCollector)
+	// standard Go runtime + process metrics (go_*, process_*)
+	registry.MustRegister(collectors.NewGoCollector())
+	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 
 	// http server
 	stopHttpChan := make(chan bool)

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -35,8 +36,14 @@ func main() {
 	log.Debug().Interface("config", userConfig).Msg("Using generated configuration")
 	log.Info().Str("version", version.Version).Str("revision", version.Revision).Str("buildDate", version.BuildDate).Str("goVersion", version.GoVersion).Msg("Starting tdarr-exporter")
 
+	// scrapeCtx is the parent context for all collector HTTP requests; cancelling
+	// it (on shutdown, below) aborts any scrape in flight instead of letting it
+	// run to completion against a Tdarr instance we are disconnecting from.
+	scrapeCtx, cancelScrapes := context.WithCancel(context.Background())
+	defer cancelScrapes()
+
 	// prometheus set up
-	tdarrCollector, err := collector.NewTdarrCollector(userConfig)
+	tdarrCollector, err := collector.NewTdarrCollector(scrapeCtx, userConfig)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create Tdarr collector")
 	}
@@ -87,6 +94,8 @@ func main() {
 		<-quitServer
 		log.Fatal().Msg("Killing app on 2nd forced interrupt...")
 	}()
+	// Abort any in-flight scrape before tearing down the HTTP server.
+	cancelScrapes()
 	stopHttpChan <- true
 	httpWg.Wait()
 	log.Info().Msg("Gracefully shutdown tdarr exporter")

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -40,6 +40,9 @@ func main() {
 
 	// http server
 	stopHttpChan := make(chan bool)
+	// Buffered so the server goroutine never blocks sending an error (e.g. a
+	// late Shutdown error after main has stopped selecting on errChan).
+	errHttpChan := make(chan error, 1)
 	httpWg := &sync.WaitGroup{}
 	httpServerConfig := server.HttpServerConfig{
 		TdarrInstance:   userConfig.InstanceName,
@@ -49,7 +52,7 @@ func main() {
 		GracefulTimeout: 30 * time.Second,
 	}
 	httpWg.Add(1)
-	go server.ServeHttp(httpWg, registry, httpServerConfig, stopHttpChan)
+	go server.ServeHttp(httpWg, registry, httpServerConfig, stopHttpChan, errHttpChan)
 
 	// graceful shutdown
 	quitServer := make(chan os.Signal, 1)
@@ -61,8 +64,14 @@ func main() {
 		syscall.SIGQUIT,
 		syscall.SIGTERM,
 	)
-	<-quitServer
-	log.Info().Msg("Received Interrupt - shutting down...")
+	// Shut down on either an OS signal or a fatal server error. A server error
+	// triggers the same graceful-shutdown path instead of hanging silently.
+	select {
+	case <-quitServer:
+		log.Info().Msg("Received Interrupt - shutting down...")
+	case err := <-errHttpChan:
+		log.Error().Err(err).Msg("HTTP server error - shutting down...")
+	}
 	go func() {
 		<-quitServer
 		log.Fatal().Msg("Killing app on 2nd forced interrupt...")

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.67.5
 	github.com/rs/zerolog v1.35.1
 )
 
@@ -36,7 +37,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -21,6 +21,10 @@ type RequestClient struct {
 	httpClient http.Client
 	apiKey     string
 	URL        url.URL
+	// logger is the client's logger, defaulting to the package-global log.Logger.
+	// Injected (not read from the global at each call) so tests can silence or
+	// capture client logs deterministically.
+	logger zerolog.Logger
 }
 
 type QueryParams = url.Values
@@ -48,6 +52,7 @@ func NewRequestClient(parsedUrl *url.URL, verifySsl bool, timeoutSeconds int, ap
 		},
 		URL:    *parsedUrl,
 		apiKey: apiKeyAuth,
+		logger: log.Logger,
 	}, nil
 }
 
@@ -57,16 +62,16 @@ func (c *RequestClient) unmarshalBody(body io.Reader, target any) (err error) {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("recovered from panic: %s", r)
 			// if debug, log body
-			if log.Logger.GetLevel() == zerolog.DebugLevel {
+			if c.logger.GetLevel() == zerolog.DebugLevel {
 				// try to copy io.Reader to string for troubleshooting
 				s := new(strings.Builder)
 				_, copyErr := io.Copy(s, body)
 				if copyErr != nil {
-					log.Error().Err(copyErr).Interface("recover", r).Msg("Failed to copy body to string in recover for troubleshooting")
+					c.logger.Error().Err(copyErr).Interface("recover", r).Msg("Failed to copy body to string in recover for troubleshooting")
 				}
-				log.Error().Str("body", s.String()).Msg("Problem body")
+				c.logger.Error().Str("body", s.String()).Msg("Problem body")
 			}
-			log.Error().Err(err).Interface("recover", r).Msg("Recovered while unmarshalling response")
+			c.logger.Error().Err(err).Interface("recover", r).Msg("Recovered while unmarshalling response")
 		}
 	}()
 	// read body into target
@@ -89,14 +94,14 @@ func (c *RequestClient) DoRequest(ctx context.Context, path string, target any, 
 	url := c.URL.JoinPath(path)
 	url.RawQuery = values.Encode()
 
-	log.Debug().Str("url", url.String()).Msg("Sending HTTP request")
+	c.logger.Debug().Str("url", url.String()).Msg("Sending HTTP request")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
-		log.Error().Err(err).Str("url", url.String()).Msg("Failed to create HTTP Request")
+		c.logger.Error().Err(err).Str("url", url.String()).Msg("Failed to create HTTP Request")
 		return fmt.Errorf("failed to create HTTP Request(%s): %w", url, err)
 	}
 	if c.apiKey != "" {
-		log.Debug().Str("authHeaderField", "x-api-key").Msg("Setting Authorization header - api token is set")
+		c.logger.Debug().Str("authHeaderField", "x-api-key").Msg("Setting Authorization header - api token is set")
 		req.Header.Set("x-api-key", c.apiKey)
 	}
 	resp, err := c.httpClient.Do(req)
@@ -106,7 +111,7 @@ func (c *RequestClient) DoRequest(ctx context.Context, path string, target any, 
 
 	defer func() {
 		if cErr := resp.Body.Close(); cErr != nil {
-			log.Error().Err(cErr).Msg("Failed to close response body")
+			c.logger.Error().Err(cErr).Msg("Failed to close response body")
 		}
 	}()
 	return c.unmarshalBody(resp.Body, target)
@@ -116,7 +121,7 @@ func (c *RequestClient) DoRequest(ctx context.Context, path string, target any, 
 // attached to the request so a cancelled/expired context aborts it in flight.
 func (c *RequestClient) DoPostRequest(ctx context.Context, path string, target any, payload []byte) error {
 	url := c.URL.JoinPath(path)
-	log.Debug().Str("url", url.String()).Msg("Sending HTTP POST request")
+	c.logger.Debug().Str("url", url.String()).Msg("Sending HTTP POST request")
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP Request(%s): %w", url, err)
@@ -125,7 +130,7 @@ func (c *RequestClient) DoPostRequest(ctx context.Context, path string, target a
 	// json content
 	req.Header.Set("Content-Type", "application/json")
 	if c.apiKey != "" {
-		log.Debug().Str("authHeaderField", "x-api-key").Msg("Setting Authorization header - api token is set")
+		c.logger.Debug().Str("authHeaderField", "x-api-key").Msg("Setting Authorization header - api token is set")
 		req.Header.Set("x-api-key", c.apiKey)
 	}
 	resp, err := c.httpClient.Do(req)
@@ -134,7 +139,7 @@ func (c *RequestClient) DoPostRequest(ctx context.Context, path string, target a
 	}
 	defer func() {
 		if cErr := resp.Body.Close(); cErr != nil {
-			log.Error().Err(cErr).Msg("Failed to close response body")
+			c.logger.Error().Err(cErr).Msg("Failed to close response body")
 		}
 	}()
 	return c.unmarshalBody(resp.Body, target)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -24,9 +24,14 @@ type RequestClient struct {
 
 type QueryParams = url.Values
 
-func NewRequestClient(parsedUrl *url.URL, insecureSkipVerify bool, apiKeyAuth string) (*RequestClient, error) {
-	baseTransport := http.DefaultTransport
-	baseTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: !insecureSkipVerify}
+// NewRequestClient constructs an HTTP client for Tdarr requests.
+//   - verifySsl: when true, TLS certificates are verified (InsecureSkipVerify=false).
+//   - timeoutSeconds: HTTP client timeout; use config.HttpTimeoutSeconds (default 15).
+//
+// The global http.DefaultTransport is never mutated; a fresh clone is created per call.
+func NewRequestClient(parsedUrl *url.URL, verifySsl bool, timeoutSeconds int, apiKeyAuth string) (*RequestClient, error) {
+	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
+	baseTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: !verifySsl}
 
 	return &RequestClient{
 		httpClient: http.Client{
@@ -38,7 +43,7 @@ func NewRequestClient(parsedUrl *url.URL, insecureSkipVerify bool, apiKeyAuth st
 			// },
 			// TdarrTransport implements `RoundTrip`
 			Transport: NewClientTransport(baseTransport),
-			Timeout:   time.Duration(time.Duration(15) * time.Second),
+			Timeout:   time.Duration(timeoutSeconds) * time.Second,
 		},
 		URL:    *parsedUrl,
 		apiKey: apiKeyAuth,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -50,7 +50,7 @@ func NewRequestClient(parsedUrl *url.URL, verifySsl bool, timeoutSeconds int, ap
 	}, nil
 }
 
-func (c *RequestClient) unmarshalBody(body io.Reader, target interface{}) (err error) {
+func (c *RequestClient) unmarshalBody(body io.Reader, target any) (err error) {
 	// return error instead of panic
 	defer func() {
 		if r := recover(); r != nil {
@@ -74,7 +74,7 @@ func (c *RequestClient) unmarshalBody(body io.Reader, target interface{}) (err e
 }
 
 // DoRequest - Take a HTTP Request and return Unmarshaled data
-func (c *RequestClient) DoRequest(path string, target interface{}, queryParams ...QueryParams) error {
+func (c *RequestClient) DoRequest(path string, target any, queryParams ...QueryParams) error {
 	values := c.URL.Query()
 	// add query params
 	for _, m := range queryParams {
@@ -111,7 +111,7 @@ func (c *RequestClient) DoRequest(path string, target interface{}, queryParams .
 }
 
 // DoRequest - Take a HTTP Request and return Unmarshaled data
-func (c *RequestClient) DoPostRequest(path string, target interface{}, payload []byte) error {
+func (c *RequestClient) DoPostRequest(path string, target any, payload []byte) error {
 	url := c.URL.JoinPath(path)
 	log.Debug().Str("url", url.String()).Msg("Sending HTTP POST request")
 	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(payload))

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -73,8 +74,9 @@ func (c *RequestClient) unmarshalBody(body io.Reader, target any) (err error) {
 	return
 }
 
-// DoRequest - Take a HTTP Request and return Unmarshaled data
-func (c *RequestClient) DoRequest(path string, target any, queryParams ...QueryParams) error {
+// DoRequest - Take a HTTP Request and return Unmarshaled data. The ctx is
+// attached to the request so a cancelled/expired context aborts it in flight.
+func (c *RequestClient) DoRequest(ctx context.Context, path string, target any, queryParams ...QueryParams) error {
 	values := c.URL.Query()
 	// add query params
 	for _, m := range queryParams {
@@ -88,7 +90,7 @@ func (c *RequestClient) DoRequest(path string, target any, queryParams ...QueryP
 	url.RawQuery = values.Encode()
 
 	log.Debug().Str("url", url.String()).Msg("Sending HTTP request")
-	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		log.Error().Err(err).Str("url", url.String()).Msg("Failed to create HTTP Request")
 		return fmt.Errorf("failed to create HTTP Request(%s): %w", url, err)
@@ -110,11 +112,12 @@ func (c *RequestClient) DoRequest(path string, target any, queryParams ...QueryP
 	return c.unmarshalBody(resp.Body, target)
 }
 
-// DoRequest - Take a HTTP Request and return Unmarshaled data
-func (c *RequestClient) DoPostRequest(path string, target any, payload []byte) error {
+// DoPostRequest - Take a HTTP Request and return Unmarshaled data. The ctx is
+// attached to the request so a cancelled/expired context aborts it in flight.
+func (c *RequestClient) DoPostRequest(ctx context.Context, path string, target any, payload []byte) error {
 	url := c.URL.JoinPath(path)
 	log.Debug().Str("url", url.String()).Msg("Sending HTTP POST request")
-	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP Request(%s): %w", url, err)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+// TestNewRequestClient_DoesNotLeakInsecureIntoDefaultTransport proves that
+// constructing a RequestClient with verifySsl=false (InsecureSkipVerify=true) does
+// NOT leak that insecure setting into the process-global http.DefaultTransport.
+// This is the regression test for the global-transport mutation bug fixed in Task 4:
+// the old code assigned a {InsecureSkipVerify: true} config directly onto
+// http.DefaultTransport, silently disabling TLS verification process-wide.
+//
+// Note: we assert on InsecureSkipVerify specifically rather than object identity,
+// because http.Transport.Clone() itself lazily initializes DefaultTransport's
+// TLSClientConfig with HTTP/2 defaults (InsecureSkipVerify=false). That is benign;
+// the bug we guard against is our InsecureSkipVerify=true leaking out.
+func TestNewRequestClient_DoesNotLeakInsecureIntoDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	u, _ := url.Parse("http://example.com")
+	// verifySsl=false means InsecureSkipVerify=true in the new client — the most
+	// aggressive change; old code would set the global to InsecureSkipVerify=true here.
+	_, err := NewRequestClient(u, false, 15, "")
+	if err != nil {
+		t.Fatalf("NewRequestClient: %v", err)
+	}
+
+	// The global transport must never end up with our insecure setting.
+	if cfg := http.DefaultTransport.(*http.Transport).TLSClientConfig; cfg != nil && cfg.InsecureSkipVerify {
+		t.Errorf("http.DefaultTransport leaked InsecureSkipVerify=true; the global transport was mutated")
+	}
+}
+
+// TestNewRequestClient_ConcurrentConstruction verifies that constructing many
+// RequestClients concurrently does not trigger a data race on http.DefaultTransport.
+// Run with: go test -race ./internal/client/
+func TestNewRequestClient_ConcurrentConstruction(t *testing.T) {
+	t.Parallel()
+
+	u, _ := url.Parse("http://example.com")
+	const goroutines = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			verifySsl := i%2 == 0 // alternate true/false for variety
+			_, err := NewRequestClient(u, verifySsl, 15, "test-key")
+			if err != nil {
+				// t.Error is goroutine-safe; t.Fatal is not.
+				t.Error("NewRequestClient concurrent construction error:", err)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/rs/zerolog"
 )
 
 // panicReader is an io.Reader whose Read method panics, used to drive the
@@ -23,7 +25,10 @@ func (panicReader) Read([]byte) (int, error) {
 func TestUnmarshalBody(t *testing.T) {
 	t.Parallel()
 
-	c := &RequestClient{}
+	// Explicit logger so the test does not depend on ambient log level. Nop()
+	// keeps the debug-only body-copy branch (which would re-read the panicking
+	// body) disabled; the recover-into-error behavior is what this test asserts.
+	c := &RequestClient{logger: zerolog.Nop()}
 
 	tests := []struct {
 		name      string

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,11 +1,86 @@
 package client
 
 import (
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 )
+
+// panicReader is an io.Reader whose Read method panics, used to drive the
+// defer/recover branch in unmarshalBody.
+type panicReader struct{}
+
+func (panicReader) Read([]byte) (int, error) {
+	panic("boom from Read")
+}
+
+// TestUnmarshalBody exercises unmarshalBody's three branches: a successful
+// decode, a malformed-JSON decode error, and the panic-recover path where the
+// body's Read panics and must be converted into an error rather than crashing.
+func TestUnmarshalBody(t *testing.T) {
+	t.Parallel()
+
+	c := &RequestClient{}
+
+	tests := []struct {
+		name      string
+		body      io.Reader
+		wantErr   bool
+		errSubstr string // checked only when wantErr is true
+		wantField string // checked only on success
+	}{
+		{
+			name:      "valid json decodes into target",
+			body:      strings.NewReader(`{"name":"tdarr"}`),
+			wantErr:   false,
+			wantField: "tdarr",
+		},
+		{
+			name:      "malformed json returns error",
+			body:      strings.NewReader(`{not-json`),
+			wantErr:   true,
+			errSubstr: "", // any decode error is acceptable
+		},
+		{
+			name:      "panicking reader is recovered into an error",
+			body:      panicReader{},
+			wantErr:   true,
+			errSubstr: "recovered",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var target struct {
+				Name string `json:"name"`
+			}
+			err := c.unmarshalBody(tt.body, &target)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("unmarshalBody: expected error, got nil")
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("unmarshalBody error = %q, want substring %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unmarshalBody: unexpected error: %v", err)
+			}
+			if target.Name != tt.wantField {
+				t.Fatalf("decoded Name = %q, want %q", target.Name, tt.wantField)
+			}
+		})
+	}
+}
 
 // TestNewRequestClient_DoesNotLeakInsecureIntoDefaultTransport proves that
 // constructing a RequestClient with verifySsl=false (InsecureSkipVerify=true) does

--- a/internal/client/request_test.go
+++ b/internal/client/request_test.go
@@ -1,0 +1,221 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// payloadTarget is a small struct the request methods unmarshal JSON into.
+type payloadTarget struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+// newTestClient builds a RequestClient pointed at the given server URL with a
+// short timeout, TLS verification disabled, and the provided api key.
+func newTestClient(t *testing.T, serverURL, apiKey string) *RequestClient {
+	t.Helper()
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", serverURL, err)
+	}
+	c, err := NewRequestClient(u, false, 5, apiKey)
+	if err != nil {
+		t.Fatalf("NewRequestClient: %v", err)
+	}
+	return c
+}
+
+// TestDoRequest_HappyPath verifies a GET to a path: the server sees method GET
+// and the JoinPath'd request path, and the JSON response unmarshals into target.
+func TestDoRequest_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"name":"tdarr","count":7}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL, "secret-key")
+
+	var target payloadTarget
+	if err := c.DoRequest("/api/v2/status", &target); err != nil {
+		t.Fatalf("DoRequest: unexpected error: %v", err)
+	}
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("method: want %s, got %s", http.MethodGet, gotMethod)
+	}
+	if gotPath != "/api/v2/status" {
+		t.Errorf("path: want %q, got %q", "/api/v2/status", gotPath)
+	}
+	if target.Name != "tdarr" || target.Count != 7 {
+		t.Errorf("target: want {tdarr 7}, got %+v", target)
+	}
+}
+
+// TestDoRequest_QueryParams verifies that multiple QueryParams keys/values are
+// sent on the request URL, merged with any query already present on the base URL.
+func TestDoRequest_QueryParams(t *testing.T) {
+	t.Parallel()
+
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer srv.Close()
+
+	// Base URL carries an existing query param that must be preserved.
+	c := newTestClient(t, srv.URL+"?base=preserved", "secret-key")
+
+	params := QueryParams{
+		"table":  []string{"library"},
+		"fields": []string{"id", "name"},
+	}
+	var target payloadTarget
+	if err := c.DoRequest("/api/v2/list", &target, params); err != nil {
+		t.Fatalf("DoRequest: unexpected error: %v", err)
+	}
+
+	if got := gotQuery.Get("base"); got != "preserved" {
+		t.Errorf("query base: want %q, got %q", "preserved", got)
+	}
+	if got := gotQuery.Get("table"); got != "library" {
+		t.Errorf("query table: want %q, got %q", "library", got)
+	}
+	gotFields := gotQuery["fields"]
+	if len(gotFields) != 2 || gotFields[0] != "id" || gotFields[1] != "name" {
+		t.Errorf("query fields: want [id name], got %v", gotFields)
+	}
+}
+
+// TestDoRequest_ApiKeyHeader verifies the x-api-key header is present when a key
+// is configured and absent when the key is empty.
+func TestDoRequest_ApiKeyHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		apiKey      string
+		wantPresent bool
+	}{
+		{name: "key set sends header", apiKey: "secret-key", wantPresent: true},
+		{name: "empty key omits header", apiKey: "", wantPresent: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotHeader string
+			var headerPresent bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotHeader = r.Header.Get("x-api-key")
+				_, headerPresent = r.Header["X-Api-Key"]
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{}`)
+			}))
+			defer srv.Close()
+
+			c := newTestClient(t, srv.URL, tt.apiKey)
+
+			var target payloadTarget
+			if err := c.DoRequest("/api/v2/status", &target); err != nil {
+				t.Fatalf("DoRequest: unexpected error: %v", err)
+			}
+
+			if tt.wantPresent {
+				if !headerPresent {
+					t.Fatalf("x-api-key header: want present, got absent")
+				}
+				if gotHeader != tt.apiKey {
+					t.Errorf("x-api-key: want %q, got %q", tt.apiKey, gotHeader)
+				}
+			} else if headerPresent {
+				t.Errorf("x-api-key header: want absent, got %q", gotHeader)
+			}
+		})
+	}
+}
+
+// TestDoRequest_UnmarshalError verifies that invalid JSON from the server
+// surfaces as a non-nil error from DoRequest.
+func TestDoRequest_UnmarshalError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{not-valid-json`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL, "secret-key")
+
+	var target payloadTarget
+	if err := c.DoRequest("/api/v2/status", &target); err == nil {
+		t.Fatal("DoRequest: want error for invalid JSON, got nil")
+	}
+}
+
+// TestDoPostRequest_HappyPath verifies a POST: method POST, JSON content type,
+// the x-api-key header, the request body equals the payload, and the response
+// unmarshals into target.
+func TestDoPostRequest_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotMethod      string
+		gotContentType string
+		gotApiKey      string
+		gotBody        string
+		gotPath        string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		gotApiKey = r.Header.Get("x-api-key")
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"name":"posted","count":3}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL, "secret-key")
+
+	payload := []byte(`{"query":"value"}`)
+	var target payloadTarget
+	if err := c.DoPostRequest("/api/v2/cruddb", &target, payload); err != nil {
+		t.Fatalf("DoPostRequest: unexpected error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method: want %s, got %s", http.MethodPost, gotMethod)
+	}
+	if gotPath != "/api/v2/cruddb" {
+		t.Errorf("path: want %q, got %q", "/api/v2/cruddb", gotPath)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("content-type: want application/json, got %q", gotContentType)
+	}
+	if gotApiKey != "secret-key" {
+		t.Errorf("x-api-key: want secret-key, got %q", gotApiKey)
+	}
+	if gotBody != string(payload) {
+		t.Errorf("body: want %q, got %q", string(payload), gotBody)
+	}
+	if target.Name != "posted" || target.Count != 3 {
+		t.Errorf("target: want {posted 3}, got %+v", target)
+	}
+}

--- a/internal/client/request_test.go
+++ b/internal/client/request_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -46,7 +47,7 @@ func TestDoRequest_HappyPath(t *testing.T) {
 	c := newTestClient(t, srv.URL, "secret-key")
 
 	var target payloadTarget
-	if err := c.DoRequest("/api/v2/status", &target); err != nil {
+	if err := c.DoRequest(context.Background(), "/api/v2/status", &target); err != nil {
 		t.Fatalf("DoRequest: unexpected error: %v", err)
 	}
 
@@ -82,7 +83,7 @@ func TestDoRequest_QueryParams(t *testing.T) {
 		"fields": []string{"id", "name"},
 	}
 	var target payloadTarget
-	if err := c.DoRequest("/api/v2/list", &target, params); err != nil {
+	if err := c.DoRequest(context.Background(), "/api/v2/list", &target, params); err != nil {
 		t.Fatalf("DoRequest: unexpected error: %v", err)
 	}
 
@@ -130,7 +131,7 @@ func TestDoRequest_ApiKeyHeader(t *testing.T) {
 			c := newTestClient(t, srv.URL, tt.apiKey)
 
 			var target payloadTarget
-			if err := c.DoRequest("/api/v2/status", &target); err != nil {
+			if err := c.DoRequest(context.Background(), "/api/v2/status", &target); err != nil {
 				t.Fatalf("DoRequest: unexpected error: %v", err)
 			}
 
@@ -162,7 +163,7 @@ func TestDoRequest_UnmarshalError(t *testing.T) {
 	c := newTestClient(t, srv.URL, "secret-key")
 
 	var target payloadTarget
-	if err := c.DoRequest("/api/v2/status", &target); err == nil {
+	if err := c.DoRequest(context.Background(), "/api/v2/status", &target); err == nil {
 		t.Fatal("DoRequest: want error for invalid JSON, got nil")
 	}
 }
@@ -196,7 +197,7 @@ func TestDoPostRequest_HappyPath(t *testing.T) {
 
 	payload := []byte(`{"query":"value"}`)
 	var target payloadTarget
-	if err := c.DoPostRequest("/api/v2/cruddb", &target, payload); err != nil {
+	if err := c.DoPostRequest(context.Background(), "/api/v2/cruddb", &target, payload); err != nil {
 		t.Fatalf("DoPostRequest: unexpected error: %v", err)
 	}
 

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -61,6 +61,19 @@ func NewClientTransport(inner http.RoundTripper, opts ...ClientTransportOption) 
 	return t
 }
 
+// drainClose drains and closes a response body that the transport is about to
+// discard (an error/retry path where the response is not returned to the caller).
+// Without this the underlying connection is never returned to the pool and leaks,
+// since a RoundTripper that returns a nil response gives the http.Client nothing
+// to close. nil-safe.
+func drainClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
 // middleware for http to handle retries
 func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// read it first since once sent on first try it will be already streamed
@@ -84,6 +97,10 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 				Interface("backoff_seconds", backoffDur).
 				Str("url", req.URL.String()).
 				Msg("Retrying HTTP Request")
+			// Free the previous failed response before retrying so its connection
+			// returns to the pool instead of leaking (nil-safe on the first
+			// iteration when the initial attempt errored with no response).
+			drainClose(resp)
 			// first try already failed so wait before retrying
 			t.sleep(backoffDur)
 			// re-add body to request
@@ -104,21 +121,25 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			if err != nil {
 				return nil, fmt.Errorf("error sending HTTP Request: %w", err)
 			}
+			drainClose(resp)
 			return nil, fmt.Errorf("received Server Error Status Code: %d", resp.StatusCode)
 		}
 		// fall through: resp is now a <500 response, classify it like any other
 	}
 	if resp.StatusCode >= 400 && resp.StatusCode <= 499 {
 		t.logger.Error().Int("status_code", resp.StatusCode).Str("url", req.URL.String()).Msgf("Received 40X Status Code: %d", resp.StatusCode)
+		drainClose(resp)
 		return nil, fmt.Errorf("received 40x Status Code: %d", resp.StatusCode)
 	}
 	if resp.StatusCode >= 300 && resp.StatusCode <= 399 {
 		t.logger.Debug().Int("status_code", resp.StatusCode).Str("url", req.URL.String()).Msgf("Received 30X Status Code: %d", resp.StatusCode)
-		if location, err := resp.Location(); err == nil {
+		// Location() only reads headers, so it is safe to read before closing the body.
+		location, locErr := resp.Location()
+		drainClose(resp)
+		if locErr == nil {
 			return nil, fmt.Errorf("received Redirect Status Code: %d, Location: %s", resp.StatusCode, location.String())
-		} else {
-			return nil, fmt.Errorf("received Redirect Status Code: %d, ", resp.StatusCode)
 		}
+		return nil, fmt.Errorf("received Redirect Status Code: %d, ", resp.StatusCode)
 	}
 	return resp, nil
 }

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -10,19 +10,45 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// ClientTransportOption is a functional option for NewClientTransport.
+type ClientTransportOption func(*ClientTransport)
+
+// WithBackoff sets the retry backoff durations. The number of retries equals
+// len(durations). Default: [1s, 3s] (2 retries).
+func WithBackoff(durations []time.Duration) ClientTransportOption {
+	return func(t *ClientTransport) {
+		t.backoff = durations
+	}
+}
+
+// WithSleep injects a custom sleep function, replacing time.Sleep.
+// Intended for tests to avoid real wall-clock delays.
+func WithSleep(fn func(time.Duration)) ClientTransportOption {
+	return func(t *ClientTransport) {
+		t.sleep = fn
+	}
+}
+
 // Set up as http.RoundTripper that can retry, add auth in future, etc.
 type ClientTransport struct {
 	inner   http.RoundTripper
-	retries int
 	backoff []time.Duration
+	sleep   func(time.Duration)
 }
 
-func NewClientTransport(inner http.RoundTripper) *ClientTransport {
-	return &ClientTransport{
+// NewClientTransport constructs a ClientTransport wrapping inner.
+// Default: 2 retries with backoff [1s, 3s], using time.Sleep.
+// The existing call site NewClientTransport(baseTransport) keeps working unchanged.
+func NewClientTransport(inner http.RoundTripper, opts ...ClientTransportOption) *ClientTransport {
+	t := &ClientTransport{
 		inner:   inner,
-		retries: 2,
 		backoff: []time.Duration{1 * time.Second, 3 * time.Second},
+		sleep:   time.Sleep,
 	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
 }
 
 // middleware for http to handle retries
@@ -41,13 +67,14 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// `req.Body` is streamed when used in `RoundTrip()`, so we need to re-create the `req.Body` with the copied data when retrying
 	resp, err := t.inner.RoundTrip(req)
 	if err != nil || resp.StatusCode >= 500 {
-		for i := 0; i < t.retries; i++ {
+		// retries = len(backoff); index i is always in range — no panic possible.
+		for i, backoffDur := range t.backoff {
 			log.Debug().Int("retry_count", i+1).
-				Interface("backoff_seconds", t.backoff[i]).
+				Interface("backoff_seconds", backoffDur).
 				Str("url", req.URL.String()).
 				Msg("Retrying HTTP Request")
 			// first try already failed so wait before retrying
-			time.Sleep(t.backoff[i])
+			t.sleep(backoffDur)
 			// re-add body to request
 			if req.Body != nil {
 				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -68,6 +68,7 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.inner.RoundTrip(req)
 	if err != nil || resp.StatusCode >= 500 {
 		// retries = len(backoff); index i is always in range — no panic possible.
+		recovered := false
 		for i, backoffDur := range t.backoff {
 			log.Debug().Int("retry_count", i+1).
 				Interface("backoff_seconds", backoffDur).
@@ -81,14 +82,21 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			}
 			resp, err = t.inner.RoundTrip(req)
 			if err == nil && resp.StatusCode < 500 {
-				return resp, nil
+				// Got a non-5xx response. Don't short-circuit to success here:
+				// a 4xx/3xx still has to go through the same classification below
+				// as a first-attempt response would. Break and fall through.
+				recovered = true
+				break
 			}
 		}
-		if err != nil {
-			return nil, fmt.Errorf("error sending HTTP Request: %w", err)
-		} else {
+		if !recovered {
+			// every attempt errored or returned 5xx
+			if err != nil {
+				return nil, fmt.Errorf("error sending HTTP Request: %w", err)
+			}
 			return nil, fmt.Errorf("received Server Error Status Code: %d", resp.StatusCode)
 		}
+		// fall through: resp is now a <500 response, classify it like any other
 	}
 	if resp.StatusCode >= 400 && resp.StatusCode <= 499 {
 		log.Error().Int("status_code", resp.StatusCode).Str("url", req.URL.String()).Msgf("Received 40X Status Code: %d", resp.StatusCode)

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -29,11 +30,19 @@ func WithSleep(fn func(time.Duration)) ClientTransportOption {
 	}
 }
 
+// WithLogger injects the logger the transport uses. Defaults to log.Logger.
+func WithLogger(logger zerolog.Logger) ClientTransportOption {
+	return func(t *ClientTransport) {
+		t.logger = logger
+	}
+}
+
 // Set up as http.RoundTripper that can retry, add auth in future, etc.
 type ClientTransport struct {
 	inner   http.RoundTripper
 	backoff []time.Duration
 	sleep   func(time.Duration)
+	logger  zerolog.Logger
 }
 
 // NewClientTransport constructs a ClientTransport wrapping inner.
@@ -44,6 +53,7 @@ func NewClientTransport(inner http.RoundTripper, opts ...ClientTransportOption) 
 		inner:   inner,
 		backoff: []time.Duration{1 * time.Second, 3 * time.Second},
 		sleep:   time.Sleep,
+		logger:  log.Logger,
 	}
 	for _, opt := range opts {
 		opt(t)
@@ -70,7 +80,7 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// retries = len(backoff); index i is always in range — no panic possible.
 		recovered := false
 		for i, backoffDur := range t.backoff {
-			log.Debug().Int("retry_count", i+1).
+			t.logger.Debug().Int("retry_count", i+1).
 				Interface("backoff_seconds", backoffDur).
 				Str("url", req.URL.String()).
 				Msg("Retrying HTTP Request")
@@ -99,11 +109,11 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// fall through: resp is now a <500 response, classify it like any other
 	}
 	if resp.StatusCode >= 400 && resp.StatusCode <= 499 {
-		log.Error().Int("status_code", resp.StatusCode).Str("url", req.URL.String()).Msgf("Received 40X Status Code: %d", resp.StatusCode)
+		t.logger.Error().Int("status_code", resp.StatusCode).Str("url", req.URL.String()).Msgf("Received 40X Status Code: %d", resp.StatusCode)
 		return nil, fmt.Errorf("received 40x Status Code: %d", resp.StatusCode)
 	}
 	if resp.StatusCode >= 300 && resp.StatusCode <= 399 {
-		log.Debug().Int("status_code", resp.StatusCode).Str("url", req.URL.String()).Msgf("Received 30X Status Code: %d", resp.StatusCode)
+		t.logger.Debug().Int("status_code", resp.StatusCode).Str("url", req.URL.String()).Msgf("Received 30X Status Code: %d", resp.StatusCode)
 		if location, err := resp.Location(); err == nil {
 			return nil, fmt.Errorf("received Redirect Status Code: %d, Location: %s", resp.StatusCode, location.String())
 		} else {

--- a/internal/client/transport_leak_test.go
+++ b/internal/client/transport_leak_test.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// trackedBody records whether Close was called on a response body.
+type trackedBody struct {
+	io.Reader
+	closed *atomic.Bool
+}
+
+func (b trackedBody) Close() error {
+	b.closed.Store(true)
+	return nil
+}
+
+// seqRoundTripper returns one response per call from a fixed status sequence
+// (repeating the last status once exhausted) and records each response body's
+// close state so a test can assert no discarded body is leaked.
+type seqRoundTripper struct {
+	statuses []int
+	idx      int
+	closes   []*atomic.Bool
+}
+
+func (s *seqRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	code := s.statuses[s.idx]
+	if s.idx < len(s.statuses)-1 {
+		s.idx++
+	}
+	closed := &atomic.Bool{}
+	s.closes = append(s.closes, closed)
+	return &http.Response{
+		StatusCode: code,
+		Body:       trackedBody{Reader: strings.NewReader("body"), closed: closed},
+		Header:     make(http.Header),
+	}, nil
+}
+
+// TestRoundTrip_ClosesDiscardedBodies verifies that every response the transport
+// discards on an error/retry path has its body closed, so connections are not
+// leaked when Tdarr returns 5xx/4xx/3xx.
+func TestRoundTrip_ClosesDiscardedBodies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statuses   []int
+		wantBodies int
+	}{
+		{"4xx", []int{404}, 1},
+		{"3xx", []int{301}, 1},
+		{"5xx exhausted", []int{500, 500}, 2},
+		{"5xx then 4xx", []int{500, 404}, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rt := &seqRoundTripper{statuses: tt.statuses}
+			transport := NewClientTransport(rt,
+				WithBackoff([]time.Duration{0}), // one retry, no real delay
+				WithSleep(func(time.Duration) {}),
+			)
+
+			req, err := http.NewRequest(http.MethodGet, "http://example.test", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+
+			resp, rtErr := transport.RoundTrip(req)
+			if rtErr == nil {
+				t.Fatalf("expected error for statuses %v, got response %+v", tt.statuses, resp)
+			}
+			if resp != nil {
+				t.Fatalf("expected nil response on error, got %+v", resp)
+			}
+			if len(rt.closes) != tt.wantBodies {
+				t.Fatalf("expected %d response bodies created, got %d", tt.wantBodies, len(rt.closes))
+			}
+			for i, c := range rt.closes {
+				if !c.Load() {
+					t.Errorf("response body %d was not closed (connection leak)", i)
+				}
+			}
+		})
+	}
+}

--- a/internal/client/transport_test.go
+++ b/internal/client/transport_test.go
@@ -1,0 +1,287 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeRoundTripper records calls and returns pre-configured responses/errors.
+type fakeRoundTripper struct {
+	responses []fakeResponse
+	calls     int
+}
+
+type fakeResponse struct {
+	statusCode int
+	err        error
+	// captureBody captures what was read from req.Body on this call (for POST body reuse tests).
+	captureBody *string
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if f.calls >= len(f.responses) {
+		return nil, fmt.Errorf("fakeRoundTripper: unexpected call %d (configured %d)", f.calls+1, len(f.responses))
+	}
+	r := f.responses[f.calls]
+	f.calls++
+	// Capture body if the test asked for it.
+	if r.captureBody != nil && req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		*r.captureBody = string(b)
+		req.Body = io.NopCloser(strings.NewReader(string(b)))
+	}
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &http.Response{
+		StatusCode: r.statusCode,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// noopSleep is a sleep func that never blocks and records nothing.
+func noopSleep(_ time.Duration) {}
+
+// collectingSleep returns a sleep func that appends durations to *out.
+func collectingSleep(out *[]time.Duration) func(time.Duration) {
+	return func(d time.Duration) {
+		*out = append(*out, d)
+	}
+}
+
+func newRequest(t *testing.T, method, url, body string) *http.Request {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		t.Fatalf("newRequest: %v", err)
+	}
+	return req
+}
+
+func TestClientTransport_RetryBehavior(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		responses     []fakeResponse
+		backoff       []time.Duration
+		wantCallCount int
+		wantSleeps    []time.Duration
+		wantErrSubstr string // non-empty: expect error containing this string
+		wantStatus    int    // 0 means we expect an error (no response)
+	}{
+		{
+			name: "success on first try — no retries, no sleep",
+			responses: []fakeResponse{
+				{statusCode: 200},
+			},
+			backoff:       []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantCallCount: 1,
+			wantSleeps:    nil,
+			wantStatus:    200,
+		},
+		{
+			name: "5xx then 200 — one retry with first backoff sleep",
+			responses: []fakeResponse{
+				{statusCode: 500},
+				{statusCode: 200},
+			},
+			backoff:       []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantCallCount: 2,
+			wantSleeps:    []time.Duration{10 * time.Millisecond},
+			wantStatus:    200,
+		},
+		{
+			name: "5xx exhausting all retries — returns error",
+			responses: []fakeResponse{
+				{statusCode: 500},
+				{statusCode: 500},
+				{statusCode: 500},
+			},
+			backoff:       []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantCallCount: 3, // 1 initial + 2 retries
+			wantSleeps:    []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantErrSubstr: "Server Error Status Code: 500",
+		},
+		{
+			name: "4xx — immediate error, no retry",
+			responses: []fakeResponse{
+				{statusCode: 404},
+			},
+			backoff:       []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantCallCount: 1,
+			wantSleeps:    nil,
+			wantErrSubstr: "40x Status Code: 404",
+		},
+		{
+			name: "3xx redirect — error, no retry",
+			responses: []fakeResponse{
+				{statusCode: 301},
+			},
+			backoff:       []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantCallCount: 1,
+			wantSleeps:    nil,
+			wantErrSubstr: "Redirect Status Code: 301",
+		},
+		{
+			name: "retries > len(backoff) — no panic, retries clamped to len(backoff)",
+			responses: []fakeResponse{
+				{statusCode: 500},
+				{statusCode: 500},
+			},
+			// Only 1 backoff entry: expect exactly 1 retry (1 sleep), then error.
+			backoff:       []time.Duration{10 * time.Millisecond},
+			wantCallCount: 2,
+			wantSleeps:    []time.Duration{10 * time.Millisecond},
+			wantErrSubstr: "Server Error Status Code: 500",
+		},
+		{
+			name: "network error then success — one retry",
+			responses: []fakeResponse{
+				{err: fmt.Errorf("connection refused")},
+				{statusCode: 200},
+			},
+			backoff:       []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantCallCount: 2,
+			wantSleeps:    []time.Duration{10 * time.Millisecond},
+			wantStatus:    200,
+		},
+		{
+			name: "network error exhausting retries — error wrapped",
+			responses: []fakeResponse{
+				{err: fmt.Errorf("timeout")},
+				{err: fmt.Errorf("timeout")},
+				{err: fmt.Errorf("timeout")},
+			},
+			backoff:       []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantCallCount: 3,
+			wantSleeps:    []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantErrSubstr: "error sending HTTP Request",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var sleeps []time.Duration
+			inner := &fakeRoundTripper{responses: tc.responses}
+			tr := NewClientTransport(inner, WithBackoff(tc.backoff), WithSleep(collectingSleep(&sleeps)))
+
+			req := newRequest(t, http.MethodGet, "http://example.com/test", "")
+			resp, err := tr.RoundTrip(req)
+
+			// Verify call count.
+			if inner.calls != tc.wantCallCount {
+				t.Errorf("call count: want %d, got %d", tc.wantCallCount, inner.calls)
+			}
+
+			// Verify sleep durations.
+			if len(sleeps) != len(tc.wantSleeps) {
+				t.Errorf("sleep calls: want %v, got %v", tc.wantSleeps, sleeps)
+			} else {
+				for i, want := range tc.wantSleeps {
+					if sleeps[i] != want {
+						t.Errorf("sleep[%d]: want %v, got %v", i, want, sleeps[i])
+					}
+				}
+			}
+
+			// Verify error presence/absence.
+			if tc.wantErrSubstr != "" {
+				if err == nil {
+					t.Errorf("want error containing %q, got nil (status %d)", tc.wantErrSubstr, resp.StatusCode)
+				} else if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+					t.Errorf("want error containing %q, got %q", tc.wantErrSubstr, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("want no error, got: %v", err)
+				}
+				if resp == nil {
+					t.Fatal("want non-nil response")
+				}
+				if resp.StatusCode != tc.wantStatus {
+					t.Errorf("status: want %d, got %d", tc.wantStatus, resp.StatusCode)
+				}
+			}
+		})
+	}
+}
+
+// TestClientTransport_PostBodyReusedAcrossRetries verifies that POST body bytes
+// are readable on every retry attempt, not just the first.
+func TestClientTransport_PostBodyReusedAcrossRetries(t *testing.T) {
+	t.Parallel()
+
+	body1 := ""
+	body2 := ""
+	body3 := ""
+	inner := &fakeRoundTripper{
+		responses: []fakeResponse{
+			{statusCode: 500, captureBody: &body1},
+			{statusCode: 500, captureBody: &body2},
+			{statusCode: 200, captureBody: &body3},
+		},
+	}
+	tr := NewClientTransport(inner,
+		WithBackoff([]time.Duration{0, 0}),
+		WithSleep(noopSleep),
+	)
+
+	req := newRequest(t, http.MethodPost, "http://example.com/post", `{"key":"value"}`)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	want := `{"key":"value"}`
+	for i, got := range []string{body1, body2, body3} {
+		if got != want {
+			t.Errorf("attempt %d body: want %q, got %q", i+1, want, got)
+		}
+	}
+}
+
+// TestClientTransport_DefaultsArePreserved verifies the default sleep function is
+// wired up and the default backoff is [1s, 3s], without invoking a real sleep.
+func TestClientTransport_DefaultsArePreserved(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeRoundTripper{responses: []fakeResponse{{statusCode: 200}}}
+	tr := NewClientTransport(inner) // no options — use defaults
+
+	if tr.sleep == nil {
+		t.Error("default sleep should be non-nil")
+	}
+	// Default backoff should be [1s, 3s].
+	want := []time.Duration{1 * time.Second, 3 * time.Second}
+	if len(tr.backoff) != len(want) {
+		t.Fatalf("default backoff len: want %d, got %d", len(want), len(tr.backoff))
+	}
+	for i, d := range want {
+		if tr.backoff[i] != d {
+			t.Errorf("default backoff[%d]: want %v, got %v", i, d, tr.backoff[i])
+		}
+	}
+
+	// Smoke-test: should succeed without panic.
+	req := newRequest(t, http.MethodGet, "http://example.com", "")
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp != nil {
+		resp.Body.Close()
+	}
+}

--- a/internal/client/transport_test.go
+++ b/internal/client/transport_test.go
@@ -145,6 +145,31 @@ func TestClientTransport_RetryBehavior(t *testing.T) {
 			wantErrSubstr: "Server Error Status Code: 500",
 		},
 		{
+			// A 4xx arriving after a 5xx retry must be classified as an error, not
+			// returned as a success response (regression guard for the post-retry
+			// fall-through to the shared 4xx/3xx classification).
+			name: "5xx then 4xx — classified as error, not returned as success",
+			responses: []fakeResponse{
+				{statusCode: 500},
+				{statusCode: 404},
+			},
+			backoff:       []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantCallCount: 2,
+			wantSleeps:    []time.Duration{10 * time.Millisecond},
+			wantErrSubstr: "40x Status Code: 404",
+		},
+		{
+			name: "5xx then 3xx — classified as redirect error, not returned as success",
+			responses: []fakeResponse{
+				{statusCode: 500},
+				{statusCode: 302},
+			},
+			backoff:       []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantCallCount: 2,
+			wantSleeps:    []time.Duration{10 * time.Millisecond},
+			wantErrSubstr: "Redirect Status Code: 302",
+		},
+		{
 			name: "network error then success — one retry",
 			responses: []fakeResponse{
 				{err: fmt.Errorf("connection refused")},

--- a/internal/client/transport_test.go
+++ b/internal/client/transport_test.go
@@ -243,7 +243,7 @@ func TestClientTransport_PostBodyReusedAcrossRetries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	want := `{"key":"value"}`
 	for i, got := range []string{body1, body2, body3} {
@@ -282,6 +282,6 @@ func TestClientTransport_DefaultsArePreserved(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if resp != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 }

--- a/internal/collector/fake_api_test.go
+++ b/internal/collector/fake_api_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -71,7 +72,12 @@ func keyForPost(path string, payload []byte) (fakeKey, error) {
 	return fakeKey{}, fmt.Errorf("fakeTdarrAPI: could not derive key for POST %s payload %s", path, payload)
 }
 
-func (f *fakeTdarrAPI) DoPostRequest(path string, target any, payload []byte) error {
+func (f *fakeTdarrAPI) DoPostRequest(ctx context.Context, path string, target any, payload []byte) error {
+	// Honor a cancelled/expired context like the real client does, so cancellation
+	// propagation through the collector is testable without a network.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	key, err := keyForPost(path, payload)
 	if err != nil {
 		return err
@@ -86,7 +92,10 @@ func (f *fakeTdarrAPI) DoPostRequest(path string, target any, payload []byte) er
 	return json.Unmarshal(body, target)
 }
 
-func (f *fakeTdarrAPI) DoRequest(path string, target any, queryParams ...client.QueryParams) error {
+func (f *fakeTdarrAPI) DoRequest(ctx context.Context, path string, target any, queryParams ...client.QueryParams) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	key := fakeKey{path: path}
 	if e, ok := f.errors[key]; ok {
 		return e

--- a/internal/collector/fake_api_test.go
+++ b/internal/collector/fake_api_test.go
@@ -71,7 +71,7 @@ func keyForPost(path string, payload []byte) (fakeKey, error) {
 	return fakeKey{}, fmt.Errorf("fakeTdarrAPI: could not derive key for POST %s payload %s", path, payload)
 }
 
-func (f *fakeTdarrAPI) DoPostRequest(path string, target interface{}, payload []byte) error {
+func (f *fakeTdarrAPI) DoPostRequest(path string, target any, payload []byte) error {
 	key, err := keyForPost(path, payload)
 	if err != nil {
 		return err
@@ -86,7 +86,7 @@ func (f *fakeTdarrAPI) DoPostRequest(path string, target interface{}, payload []
 	return json.Unmarshal(body, target)
 }
 
-func (f *fakeTdarrAPI) DoRequest(path string, target interface{}, queryParams ...client.QueryParams) error {
+func (f *fakeTdarrAPI) DoRequest(path string, target any, queryParams ...client.QueryParams) error {
 	key := fakeKey{path: path}
 	if e, ok := f.errors[key]; ok {
 		return e

--- a/internal/collector/fake_api_test.go
+++ b/internal/collector/fake_api_test.go
@@ -1,0 +1,99 @@
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/homeylab/tdarr-exporter/internal/client"
+)
+
+// fakeKey identifies a logical Tdarr request so the fake can route to a fixture
+// and/or inject an error. For cruddb POSTs the discriminator is the payload's
+// collection field; for get-pies POSTs it is the libraryId; for GET requests it
+// is the path itself.
+type fakeKey struct {
+	path string
+	// disc is the secondary discriminator: the cruddb collection name
+	// (StatisticsJSONDB / LibrarySettingsJSONDB) or the get-pies libraryId.
+	// Empty for plain GET requests keyed only on path.
+	disc string
+}
+
+// fakeTdarrAPI is an in-memory tdarrAPI implementation backed by raw JSON fixture
+// bytes. It mimics the real client by json.Unmarshal-ing the fixture into target.
+// It replaces the real client + httptest server in collector tests, removing the
+// multi-second retry/backoff incurred when a real client hits a failing endpoint.
+type fakeTdarrAPI struct {
+	// responses maps a request key to the raw JSON fixture returned for it.
+	responses map[fakeKey][]byte
+	// errors maps a request key to an error that should be returned instead of a
+	// response, used to drive tdarr_up=0 / partial-failure paths.
+	errors map[fakeKey]error
+}
+
+// statErr is returned by the fake to mimic a non-2xx / transport failure from the
+// real client without any network or backoff.
+type statErr struct{ msg string }
+
+func (e statErr) Error() string { return e.msg }
+
+func newFakeTdarrAPI() *fakeTdarrAPI {
+	return &fakeTdarrAPI{
+		responses: make(map[fakeKey][]byte),
+		errors:    make(map[fakeKey]error),
+	}
+}
+
+// setResponse registers fixture bytes for a request key.
+func (f *fakeTdarrAPI) setResponse(key fakeKey, body []byte) {
+	f.responses[key] = body
+}
+
+// setError registers an error for a request key; it takes precedence over any
+// configured response for that key.
+func (f *fakeTdarrAPI) setError(key fakeKey, err error) {
+	f.errors[key] = err
+}
+
+// keyForPost derives the routing key for a DoPostRequest payload. It inspects the
+// JSON payload to extract the cruddb collection name or the get-pies libraryId.
+func keyForPost(path string, payload []byte) (fakeKey, error) {
+	// Try cruddb shape first (has data.collection).
+	var cruddb TdarrMetricRequest
+	if err := json.Unmarshal(payload, &cruddb); err == nil && cruddb.Data.Collection != "" {
+		return fakeKey{path: path, disc: cruddb.Data.Collection}, nil
+	}
+	// Fall back to get-pies shape (has data.libraryId).
+	var pie TdarrPieDataRequest
+	if err := json.Unmarshal(payload, &pie); err == nil {
+		return fakeKey{path: path, disc: pie.Data.LibraryId}, nil
+	}
+	return fakeKey{}, fmt.Errorf("fakeTdarrAPI: could not derive key for POST %s payload %s", path, payload)
+}
+
+func (f *fakeTdarrAPI) DoPostRequest(path string, target interface{}, payload []byte) error {
+	key, err := keyForPost(path, payload)
+	if err != nil {
+		return err
+	}
+	if e, ok := f.errors[key]; ok {
+		return e
+	}
+	body, ok := f.responses[key]
+	if !ok {
+		return fmt.Errorf("fakeTdarrAPI: no response registered for POST %s disc=%q", key.path, key.disc)
+	}
+	return json.Unmarshal(body, target)
+}
+
+func (f *fakeTdarrAPI) DoRequest(path string, target interface{}, queryParams ...client.QueryParams) error {
+	key := fakeKey{path: path}
+	if e, ok := f.errors[key]; ok {
+		return e
+	}
+	body, ok := f.responses[key]
+	if !ok {
+		return fmt.Errorf("fakeTdarrAPI: no response registered for GET %s", path)
+	}
+	return json.Unmarshal(body, target)
+}

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -389,6 +389,59 @@ func (c *TdarrCollector) getLibStats(wg *sync.WaitGroup, inChan <-chan TdarrPieD
 	}
 }
 
+// fetchPies fans the per-library pie requests across HttpMaxConcurrency workers and
+// fans the results back in. Per-library fetch failures are handled inside getLibStats
+// (it sets partialFailure and skips that library), so this returns only the gathered
+// pie stats — the same set collect() previously assembled inline before caching.
+func (c *TdarrCollector) fetchPies(allLibs []TdarrLibraryInfo) []*TdarrPieStats {
+	var pieData []*TdarrPieStats
+
+	dataWg := &sync.WaitGroup{}
+	inChan := make(chan TdarrPieDataRequest, len(allLibs))
+	outChan := make(chan *TdarrPieStats, len(allLibs))
+	// start workers
+	for i := 0; i < c.config.HttpMaxConcurrency; i++ {
+		dataWg.Add(1)
+		go c.getLibStats(dataWg, inChan, outChan)
+	}
+
+	// send data to workers
+	for _, lib := range allLibs {
+		inChan <- TdarrPieDataRequest{
+			Data: struct {
+				LibraryId   string `json:"libraryId"`
+				libraryName string `json:"-"`
+			}{
+				LibraryId:   lib.LibraryId,
+				libraryName: lib.Name,
+			},
+		}
+	}
+
+	// close channel to signal workers to stop
+	close(inChan)
+
+	// wait for workers to finish
+	dataWg.Wait()
+
+	// collect results
+	resultWg := &sync.WaitGroup{}
+	resultWg.Add(1)
+	go func() {
+		defer resultWg.Done()
+		for pie := range outChan {
+			pieData = append(pieData, pie)
+		}
+	}()
+
+	// close channel no longer needed
+	close(outChan)
+
+	// wait for results to be collected
+	resultWg.Wait()
+	return pieData
+}
+
 func (c *TdarrCollector) Collect(ch chan<- prometheus.Metric) {
 	err := c.collect(ch)
 	// Always reset partialFailure flag — must NOT short-circuit via OR or the flag leaks across scrapes.
@@ -398,6 +451,32 @@ func (c *TdarrCollector) Collect(ch chan<- prometheus.Metric) {
 		v = 0.0
 	}
 	ch <- prometheus.MustNewConstMetric(c.upMetric, prometheus.GaugeValue, v)
+}
+
+// totalsFromMetric builds the cache-totals snapshot from a general-stats metric.
+// Centralizes the field mapping so the totals struct literal lives in exactly one
+// place (used by both the cache-write and the refetch comparison).
+func totalsFromMetric(metric *TdarrMetric) tdarrCacheTotals {
+	return tdarrCacheTotals{
+		totalFileCount:        metric.TotalFileCount,
+		totalTranscodeCount:   metric.TotalTranscodeCount,
+		totalHealthCheckCount: metric.TotalHealthCheckCount,
+		holdQueue:             metric.HoldQueue,
+		transcodeQueue:        metric.TranscodeQueue,
+		transcodeSuccess:      metric.TranscodeSuccess,
+		transcodeFailed:       metric.TranscodeFailed,
+		healthCheckQueue:      metric.HealthCheckQueue,
+		healthCheckSuccess:    metric.HealthCheckSuccess,
+		healthCheckFailed:     metric.HealthCheckFailed,
+	}
+}
+
+// shouldRefetch decides whether library pie stats must be re-fetched. It returns
+// true when the cache is empty (libStatsNil) or any of the 10 cached totals differs
+// from the current metric. tdarrCacheTotals is all-int and thus comparable, so the
+// struct != comparison is equivalent to the prior field-by-field OR chain.
+func shouldRefetch(cached tdarrCacheTotals, libStatsNil bool, metric *TdarrMetric) bool {
+	return libStatsNil || cached != totalsFromMetric(metric)
 }
 
 func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
@@ -437,29 +516,16 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 	log.Debug().Str("path", c.config.TdarrPieStatsPath).Msg("Fetching library pie stats")
 	// already have total file count from general stats (`metric.TotalFileCount`)
 	// check cache for all libraries data
-	shouldCollect := false
-
 	// this won't block other reads when checking
 	cacheTotals := c.statsCache.GetTotals()
-	// if total counts has changed from cache and cache is populated, need to re-collect
-	// also collect if cache is empty (first run)
-	// Compare all 10 totals. table0Count–table6Count cover every per-bucket state transition
-	// (e.g. files queued but not yet transcoded), catching invalidation cases the three top-level
-	// counts miss. Older Tdarr versions that omit tableXCount fields decode to 0; 0==0 means
-	// no spurious refetches — behavior degrades gracefully to original 3-totals logic.
-	if c.statsCache.GetLibStats() == nil ||
-		cacheTotals.totalFileCount != metric.TotalFileCount ||
-		cacheTotals.totalTranscodeCount != metric.TotalTranscodeCount ||
-		cacheTotals.totalHealthCheckCount != metric.TotalHealthCheckCount ||
-		cacheTotals.holdQueue != metric.HoldQueue ||
-		cacheTotals.transcodeQueue != metric.TranscodeQueue ||
-		cacheTotals.transcodeSuccess != metric.TranscodeSuccess ||
-		cacheTotals.transcodeFailed != metric.TranscodeFailed ||
-		cacheTotals.healthCheckQueue != metric.HealthCheckQueue ||
-		cacheTotals.healthCheckSuccess != metric.HealthCheckSuccess ||
-		cacheTotals.healthCheckFailed != metric.HealthCheckFailed {
+	// Refetch if the cache is empty (first run) or any of the 10 totals changed.
+	// table0Count–table6Count cover every per-bucket state transition (e.g. files queued
+	// but not yet transcoded), catching invalidation cases the three top-level counts miss.
+	// Older Tdarr versions that omit tableXCount fields decode to 0; 0==0 means no spurious
+	// refetches — behavior degrades gracefully to original 3-totals logic.
+	shouldCollect := shouldRefetch(cacheTotals, c.statsCache.GetLibStats() == nil, metric)
+	if shouldCollect {
 		log.Debug().Msg("Stats totals mismatch - re-fetching library pie stats")
-		shouldCollect = true
 	}
 	// if counts are the same use cache
 	if !shouldCollect {
@@ -474,120 +540,17 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 			return err
 		}
 
-		dataWg := &sync.WaitGroup{}
-		inChan := make(chan TdarrPieDataRequest, len(allLibs))
-		outChan := make(chan *TdarrPieStats, len(allLibs))
-		// start workers
-		for i := 0; i < c.config.HttpMaxConcurrency; i++ {
-			dataWg.Add(1)
-			go c.getLibStats(dataWg, inChan, outChan)
-		}
-
-		// send data to workers
-		for _, lib := range allLibs {
-			inChan <- TdarrPieDataRequest{
-				Data: struct {
-					LibraryId   string `json:"libraryId"`
-					libraryName string `json:"-"`
-				}{
-					LibraryId:   lib.LibraryId,
-					libraryName: lib.Name,
-				},
-			}
-		}
-
-		// close channel to signal workers to stop
-		close(inChan)
-
-		// wait for workers to finish
-		dataWg.Wait()
-
-		// collect results
-		resultWg := &sync.WaitGroup{}
-		resultWg.Add(1)
-		go func() {
-			defer resultWg.Done()
-			for pie := range outChan {
-				pieData = append(pieData, pie)
-			}
-		}()
-
-		// close channel no longer needed
-		close(outChan)
-
-		// wait for results to be collected
-		resultWg.Wait()
+		pieData = c.fetchPies(allLibs)
 		log.Debug().Msg("All library stats gathered - setting cache")
 		c.statsCache.SetLibStats(pieData)
 
 		// set totals here after all data is collected
-		c.statsCache.SetTotals(tdarrCacheTotals{
-			totalFileCount:        metric.TotalFileCount,
-			totalTranscodeCount:   metric.TotalTranscodeCount,
-			totalHealthCheckCount: metric.TotalHealthCheckCount,
-			holdQueue:             metric.HoldQueue,
-			transcodeQueue:        metric.TranscodeQueue,
-			transcodeSuccess:      metric.TranscodeSuccess,
-			transcodeFailed:       metric.TranscodeFailed,
-			healthCheckQueue:      metric.HealthCheckQueue,
-			healthCheckSuccess:    metric.HealthCheckSuccess,
-			healthCheckFailed:     metric.HealthCheckFailed,
-		})
+		c.statsCache.SetTotals(totalsFromMetric(metric))
 	}
 
 	// add metrics to collector
-	ch <- prometheus.MustNewConstMetric(c.totalFilesMetric, prometheus.GaugeValue, float64(metric.TotalFileCount))
-	ch <- prometheus.MustNewConstMetric(c.totalTranscodeCount, prometheus.GaugeValue, float64(metric.TotalTranscodeCount))
-	ch <- prometheus.MustNewConstMetric(c.totalHealthCheckCount, prometheus.GaugeValue, float64(metric.TotalHealthCheckCount))
-	ch <- prometheus.MustNewConstMetric(c.sizeDiff, prometheus.GaugeValue, metric.SizeDiff)
-	ch <- prometheus.MustNewConstMetric(c.tdarrScore, prometheus.GaugeValue, score)
-	ch <- prometheus.MustNewConstMetric(c.healthCheckScore, prometheus.GaugeValue, healthScore)
-	ch <- prometheus.MustNewConstMetric(c.avgNumStreams, prometheus.GaugeValue, metric.AvgNumStreams)
-	ch <- prometheus.MustNewConstMetric(c.streamStatsDuration, prometheus.GaugeValue, float64(metric.StreamStats.Duration.Average), "average")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsDuration, prometheus.GaugeValue, float64(metric.StreamStats.Duration.Highest), "highest")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsDuration, prometheus.GaugeValue, float64(metric.StreamStats.Duration.Total), "total")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsBitRate, prometheus.GaugeValue, float64(metric.StreamStats.BitRate.Average), "average")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsBitRate, prometheus.GaugeValue, float64(metric.StreamStats.BitRate.Highest), "highest")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsBitRate, prometheus.GaugeValue, float64(metric.StreamStats.BitRate.Total), "total")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsNumFrames, prometheus.GaugeValue, float64(metric.StreamStats.NumFrames.Average), "average")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsNumFrames, prometheus.GaugeValue, float64(metric.StreamStats.NumFrames.Highest), "highest")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsNumFrames, prometheus.GaugeValue, float64(metric.StreamStats.NumFrames.Total), "total")
-	for _, pie := range pieData {
-		ch <- prometheus.MustNewConstMetric(c.pieNumFiles, prometheus.GaugeValue, float64(pie.PieStats.TotalFiles), pie.libraryName, pie.libraryId)
-		ch <- prometheus.MustNewConstMetric(c.pieNumTranscodes, prometheus.GaugeValue, float64(pie.PieStats.TotalTranscodeCount), pie.libraryName, pie.libraryId)
-		ch <- prometheus.MustNewConstMetric(c.pieNumHealthChecks, prometheus.GaugeValue, float64(pie.PieStats.TotalHealthCheckCount), pie.libraryName, pie.libraryId)
-		ch <- prometheus.MustNewConstMetric(c.pieSizeDiff, prometheus.GaugeValue, pie.PieStats.SizeDiff, pie.libraryName, pie.libraryId)
-		// Emit transcode statuses from the normalized map (pre-cleaned labels, full enum coverage).
-		for status, count := range pie.NormalizedTranscodes {
-			ch <- prometheus.MustNewConstMetric(c.pieTranscodes, prometheus.GaugeValue, float64(count),
-				pie.libraryName, pie.libraryId, status)
-		}
-		// Emit health check statuses from the normalized map (pre-cleaned labels, full enum coverage).
-		for status, count := range pie.NormalizedHealthChecks {
-			ch <- prometheus.MustNewConstMetric(c.pieHealthChecks, prometheus.GaugeValue, float64(count),
-				pie.libraryName, pie.libraryId, status)
-		}
-		for _, pieSlice := range pie.PieStats.Video.Codecs {
-			ch <- prometheus.MustNewConstMetric(c.pieVideoCodecs, prometheus.GaugeValue, float64(pieSlice.Value),
-				pie.libraryName, pie.libraryId, strings.ToLower(pieSlice.Name))
-		}
-		for _, pieSlice := range pie.PieStats.Video.Containers {
-			ch <- prometheus.MustNewConstMetric(c.pieVideoContainers, prometheus.GaugeValue, float64(pieSlice.Value),
-				pie.libraryName, pie.libraryId, strings.ToLower(pieSlice.Name))
-		}
-		for _, pieSlice := range pie.PieStats.Video.Resolutions {
-			ch <- prometheus.MustNewConstMetric(c.pieVideoResolutions, prometheus.GaugeValue, float64(pieSlice.Value),
-				pie.libraryName, pie.libraryId, strings.ToLower(pieSlice.Name))
-		}
-		for _, pieSlice := range pie.PieStats.Audio.Codecs {
-			ch <- prometheus.MustNewConstMetric(c.pieAudioCodecs, prometheus.GaugeValue, float64(pieSlice.Value),
-				pie.libraryName, pie.libraryId, strings.ToLower(pieSlice.Name))
-		}
-		for _, pieSlice := range pie.PieStats.Audio.Containers {
-			ch <- prometheus.MustNewConstMetric(c.pieAudioContainers, prometheus.GaugeValue, float64(pieSlice.Value),
-				pie.libraryName, pie.libraryId, strings.ToLower(pieSlice.Name))
-		}
-	}
+	c.emitGeneralMetrics(ch, metric, score, healthScore)
+	c.emitPieMetrics(ch, pieData)
 
 	// Emit unknown-status counters (monotonically increasing across scrapes).
 	// A non-zero value means Tdarr returned a status label the exporter did not pre-init zeros for.
@@ -604,8 +567,82 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 		return err
 	}
 	// get worker data for each node
+	c.emitNodeMetrics(ch, nodeData)
+	return nil
+}
 
-	// node data parsing
+// emitGeneralMetrics emits the top-level server gauges and stream-stats series for a
+// general-stats metric. Pure: it only reads the metric/scores and writes to ch.
+func (c *TdarrCollector) emitGeneralMetrics(ch chan<- prometheus.Metric, metric *TdarrMetric, score, healthScore float64) {
+	ch <- prometheus.MustNewConstMetric(c.totalFilesMetric, prometheus.GaugeValue, float64(metric.TotalFileCount))
+	ch <- prometheus.MustNewConstMetric(c.totalTranscodeCount, prometheus.GaugeValue, float64(metric.TotalTranscodeCount))
+	ch <- prometheus.MustNewConstMetric(c.totalHealthCheckCount, prometheus.GaugeValue, float64(metric.TotalHealthCheckCount))
+	ch <- prometheus.MustNewConstMetric(c.sizeDiff, prometheus.GaugeValue, metric.SizeDiff)
+	ch <- prometheus.MustNewConstMetric(c.tdarrScore, prometheus.GaugeValue, score)
+	ch <- prometheus.MustNewConstMetric(c.healthCheckScore, prometheus.GaugeValue, healthScore)
+	ch <- prometheus.MustNewConstMetric(c.avgNumStreams, prometheus.GaugeValue, metric.AvgNumStreams)
+	ch <- prometheus.MustNewConstMetric(c.streamStatsDuration, prometheus.GaugeValue, float64(metric.StreamStats.Duration.Average), "average")
+	ch <- prometheus.MustNewConstMetric(c.streamStatsDuration, prometheus.GaugeValue, float64(metric.StreamStats.Duration.Highest), "highest")
+	ch <- prometheus.MustNewConstMetric(c.streamStatsDuration, prometheus.GaugeValue, float64(metric.StreamStats.Duration.Total), "total")
+	ch <- prometheus.MustNewConstMetric(c.streamStatsBitRate, prometheus.GaugeValue, float64(metric.StreamStats.BitRate.Average), "average")
+	ch <- prometheus.MustNewConstMetric(c.streamStatsBitRate, prometheus.GaugeValue, float64(metric.StreamStats.BitRate.Highest), "highest")
+	ch <- prometheus.MustNewConstMetric(c.streamStatsBitRate, prometheus.GaugeValue, float64(metric.StreamStats.BitRate.Total), "total")
+	ch <- prometheus.MustNewConstMetric(c.streamStatsNumFrames, prometheus.GaugeValue, float64(metric.StreamStats.NumFrames.Average), "average")
+	ch <- prometheus.MustNewConstMetric(c.streamStatsNumFrames, prometheus.GaugeValue, float64(metric.StreamStats.NumFrames.Highest), "highest")
+	ch <- prometheus.MustNewConstMetric(c.streamStatsNumFrames, prometheus.GaugeValue, float64(metric.StreamStats.NumFrames.Total), "total")
+}
+
+// emitPieSlices emits one gauge per slice in a pie-slice list (codecs/containers/resolutions),
+// lowercasing the slice name as the final label. Shared by the five video/audio loops.
+func emitPieSlices(ch chan<- prometheus.Metric, desc *prometheus.Desc, libName, libId string, slices []TdarrPieSlice) {
+	for _, pieSlice := range slices {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(pieSlice.Value),
+			libName, libId, strings.ToLower(pieSlice.Name))
+	}
+}
+
+// emitPieMetrics emits the per-library pie series (totals, normalized status maps, and the
+// video/audio codec/container/resolution slices). Pure: reads pieData, writes to ch.
+func (c *TdarrCollector) emitPieMetrics(ch chan<- prometheus.Metric, pieData []*TdarrPieStats) {
+	for _, pie := range pieData {
+		ch <- prometheus.MustNewConstMetric(c.pieNumFiles, prometheus.GaugeValue, float64(pie.PieStats.TotalFiles), pie.libraryName, pie.libraryId)
+		ch <- prometheus.MustNewConstMetric(c.pieNumTranscodes, prometheus.GaugeValue, float64(pie.PieStats.TotalTranscodeCount), pie.libraryName, pie.libraryId)
+		ch <- prometheus.MustNewConstMetric(c.pieNumHealthChecks, prometheus.GaugeValue, float64(pie.PieStats.TotalHealthCheckCount), pie.libraryName, pie.libraryId)
+		ch <- prometheus.MustNewConstMetric(c.pieSizeDiff, prometheus.GaugeValue, pie.PieStats.SizeDiff, pie.libraryName, pie.libraryId)
+		// Emit transcode statuses from the normalized map (pre-cleaned labels, full enum coverage).
+		for status, count := range pie.NormalizedTranscodes {
+			ch <- prometheus.MustNewConstMetric(c.pieTranscodes, prometheus.GaugeValue, float64(count),
+				pie.libraryName, pie.libraryId, status)
+		}
+		// Emit health check statuses from the normalized map (pre-cleaned labels, full enum coverage).
+		for status, count := range pie.NormalizedHealthChecks {
+			ch <- prometheus.MustNewConstMetric(c.pieHealthChecks, prometheus.GaugeValue, float64(count),
+				pie.libraryName, pie.libraryId, status)
+		}
+		emitPieSlices(ch, c.pieVideoCodecs, pie.libraryName, pie.libraryId, pie.PieStats.Video.Codecs)
+		emitPieSlices(ch, c.pieVideoContainers, pie.libraryName, pie.libraryId, pie.PieStats.Video.Containers)
+		emitPieSlices(ch, c.pieVideoResolutions, pie.libraryName, pie.libraryId, pie.PieStats.Video.Resolutions)
+		emitPieSlices(ch, c.pieAudioCodecs, pie.libraryName, pie.libraryId, pie.PieStats.Audio.Codecs)
+		emitPieSlices(ch, c.pieAudioContainers, pie.libraryName, pie.libraryId, pie.PieStats.Audio.Containers)
+	}
+}
+
+// emitParsedFloat parses raw as a float64 and, on success, emits a node-scoped gauge.
+// On parse failure it debug-logs and silently skips the metric (intentional: Tdarr may
+// send empty/non-numeric resource strings for nodes that haven't reported yet).
+func emitParsedFloat(ch chan<- prometheus.Metric, desc *prometheus.Desc, raw string, nodeId, nodeName string) {
+	if v, floatErr := strconv.ParseFloat(raw, 64); floatErr == nil {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, nodeId, nodeName)
+	} else {
+		log.Debug().Str("nodeId", nodeId).Str("nodeName", nodeName).
+			Str("raw", raw).Err(floatErr).Msg("Failed to parse node resource stat; skipping metric")
+	}
+}
+
+// emitNodeMetrics emits all per-node and per-worker series for the given node map.
+// Pure: reads nodeData, writes to ch. Resource-stat parse failures are silently skipped
+// (see emitParsedFloat); ETA parse failures skip only the eta_seconds gauge.
+func (c *TdarrCollector) emitNodeMetrics(ch chan<- prometheus.Metric, nodeData map[string]TdarrNode) {
 	for _, node := range nodeData {
 		m := c.nodeCollector.metrics
 
@@ -621,31 +658,11 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 			float64(node.ResourceStats.Process.Uptime), node.Id, node.Name)
 
 		// convert resource stats to float from string; skip on parse failure
-		log.Debug().Str("nodeId", node.Id).Str("nodeName", node.Name).
-			Str("heapUsedMb", node.ResourceStats.Process.HeapUsedMb).Msg("Node heap used mb")
-		if v, floatErr := strconv.ParseFloat(node.ResourceStats.Process.HeapUsedMb, 64); floatErr == nil {
-			ch <- prometheus.MustNewConstMetric(m.nodeHeapUsedMb, prometheus.GaugeValue, v, node.Id, node.Name)
-		}
-		log.Debug().Str("nodeId", node.Id).Str("nodeName", node.Name).
-			Str("heapTotalMb", node.ResourceStats.Process.HeapTotalMb).Msg("Node heap total mb")
-		if v, floatErr := strconv.ParseFloat(node.ResourceStats.Process.HeapTotalMb, 64); floatErr == nil {
-			ch <- prometheus.MustNewConstMetric(m.nodeHeapTotalMb, prometheus.GaugeValue, v, node.Id, node.Name)
-		}
-		log.Debug().Str("nodeId", node.Id).Str("nodeName", node.Name).
-			Str("cpuPercent", node.ResourceStats.Os.CpuPercent).Msg("Node cpu percent")
-		if v, floatErr := strconv.ParseFloat(node.ResourceStats.Os.CpuPercent, 64); floatErr == nil {
-			ch <- prometheus.MustNewConstMetric(m.nodeHostCpuPercent, prometheus.GaugeValue, v, node.Id, node.Name)
-		}
-		log.Debug().Str("nodeId", node.Id).Str("nodeName", node.Name).
-			Str("memUsedGb", node.ResourceStats.Os.MemUsedGb).Msg("Node mem used gb")
-		if v, floatErr := strconv.ParseFloat(node.ResourceStats.Os.MemUsedGb, 64); floatErr == nil {
-			ch <- prometheus.MustNewConstMetric(m.nodeHostMemUsedGb, prometheus.GaugeValue, v, node.Id, node.Name)
-		}
-		log.Debug().Str("nodeId", node.Id).Str("nodeName", node.Name).
-			Str("memTotalGb", node.ResourceStats.Os.MemTotalGb).Msg("Node mem total gb")
-		if v, floatErr := strconv.ParseFloat(node.ResourceStats.Os.MemTotalGb, 64); floatErr == nil {
-			ch <- prometheus.MustNewConstMetric(m.nodeHostMemTotalGb, prometheus.GaugeValue, v, node.Id, node.Name)
-		}
+		emitParsedFloat(ch, m.nodeHeapUsedMb, node.ResourceStats.Process.HeapUsedMb, node.Id, node.Name)
+		emitParsedFloat(ch, m.nodeHeapTotalMb, node.ResourceStats.Process.HeapTotalMb, node.Id, node.Name)
+		emitParsedFloat(ch, m.nodeHostCpuPercent, node.ResourceStats.Os.CpuPercent, node.Id, node.Name)
+		emitParsedFloat(ch, m.nodeHostMemUsedGb, node.ResourceStats.Os.MemUsedGb, node.Id, node.Name)
+		emitParsedFloat(ch, m.nodeHostMemTotalGb, node.ResourceStats.Os.MemTotalGb, node.Id, node.Name)
 
 		// node state gauges
 		pausedVal := 0.0
@@ -733,7 +750,6 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 			}
 		}
 	}
-	return nil
 }
 
 func getGeneralReqPayload(payloadRequestType string) TdarrMetricRequest {

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -38,8 +38,13 @@ type unknownStatusKey struct {
 }
 
 type TdarrCollector struct {
-	config                config.Config
-	api                   tdarrAPI // shared HTTP client, built once in the constructor
+	// Only the config values read at collect time are stored, not the whole
+	// config.Config bag — the URL/SSL/timeout/api-key and instance label are
+	// consumed once in the constructor (client + descs) and never needed again.
+	statsPath      string
+	pieStatsPath   string
+	maxConcurrency int
+	api            tdarrAPI // shared HTTP client, built once in the constructor
 	statsCache            *TdarrLibStatsCache
 	partialFailure        atomic.Bool // set by getLibStats workers on per-library fetch error
 	unknownStatusMu       sync.Mutex
@@ -138,7 +143,9 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 	instance := prometheus.Labels{"tdarr_instance": runConfig.InstanceName}
 
 	c := &TdarrCollector{
-		config:              runConfig,
+		statsPath:           runConfig.TdarrStatsPath,
+		pieStatsPath:        runConfig.TdarrPieStatsPath,
+		maxConcurrency:      runConfig.HttpMaxConcurrency,
 		api:                 api,
 		statsCache:          NewTdarrLibStatsCache(),
 		unknownStatusCounts: make(map[unknownStatusKey]float64),
@@ -349,7 +356,7 @@ func (c *TdarrCollector) getLibStats(wg *sync.WaitGroup, inChan <-chan TdarrPieD
 	for piePayload := range inChan {
 		pieMetric := &TdarrPieStats{}
 		log.Debug().Interface("payload", piePayload).Msg("Requesting Lib stats pie data from Tdarr")
-		err := c.httpReqHelper(c.config.TdarrPieStatsPath, piePayload, pieMetric)
+		err := c.httpReqHelper(c.pieStatsPath, piePayload, pieMetric)
 		if err != nil {
 			log.Error().Interface("payload", piePayload).Err(err).Msg("Failed to get Lib stats pie data")
 			// Signal partial failure so Collect() can set tdarr_up=0.
@@ -391,7 +398,7 @@ func (c *TdarrCollector) fetchPies(allLibs []TdarrLibraryInfo) []*TdarrPieStats 
 	inChan := make(chan TdarrPieDataRequest, len(allLibs))
 	outChan := make(chan *TdarrPieStats, len(allLibs))
 	// start workers
-	for i := 0; i < c.config.HttpMaxConcurrency; i++ {
+	for i := 0; i < c.maxConcurrency; i++ {
 		dataWg.Add(1)
 		go c.getLibStats(dataWg, inChan, outChan)
 	}
@@ -479,7 +486,7 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 	// get server metrics
 	metricReqBody := getGeneralReqPayload("")
 	metric := &TdarrMetric{}
-	err := c.httpReqHelper(c.config.TdarrStatsPath, metricReqBody, &metric)
+	err := c.httpReqHelper(c.statsPath, metricReqBody, &metric)
 	if err != nil {
 		return err
 	}
@@ -507,7 +514,7 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 	}
 
 	// supports only api versions: v2.24.01+
-	log.Debug().Str("path", c.config.TdarrPieStatsPath).Msg("Fetching library pie stats")
+	log.Debug().Str("path", c.pieStatsPath).Msg("Fetching library pie stats")
 	// already have total file count from general stats (`metric.TotalFileCount`)
 	// check cache for all libraries data
 	// this won't block other reads when checking
@@ -529,7 +536,7 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 	} else { // fetch new data and update cache
 		getLibsPayload := getGeneralReqPayload("library")
 		allLibs := []TdarrLibraryInfo{}
-		err := c.httpReqHelper(c.config.TdarrStatsPath, getLibsPayload, &allLibs)
+		err := c.httpReqHelper(c.statsPath, getLibsPayload, &allLibs)
 		if err != nil {
 			return fmt.Errorf("get library details: %w", err)
 		}

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -302,7 +302,7 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 		),
 		pieAudioContainers: newGauge(
 			"library_audio_containers",
-			"Tdarr video containers for library by type",
+			"Tdarr audio containers for library by type",
 			[]string{"library_name", "library_id", "container_type"}, instance,
 		),
 		pieAudioResolutions: newGauge(

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -65,6 +65,7 @@ type TdarrCollector struct {
 	pieVideoResolutions   *prometheus.Desc
 	pieAudioCodecs        *prometheus.Desc
 	pieAudioContainers    *prometheus.Desc
+	pieAudioResolutions   *prometheus.Desc
 	unknownStatusTotal    *prometheus.Desc    // counter for status values not in known enum
 	nodeCollector         *TdarrNodeCollector // node data
 	upMetric              *prometheus.Desc
@@ -246,6 +247,11 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 			"Tdarr video containers for library by type",
 			[]string{"library_name", "library_id", "container_type"}, instance,
 		),
+		pieAudioResolutions: newDesc(
+			"library_audio_resolutions",
+			"Tdarr audio resolutions for library by type",
+			[]string{"library_name", "library_id", "resolution"}, instance,
+		),
 		unknownStatusTotal: newDesc(
 			"unknown_status_total",
 			"Count of pie status values not in the known enum, by job_kind (transcode|healthcheck) and status label. "+
@@ -287,6 +293,7 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 		c.pieVideoResolutions,
 		c.pieAudioCodecs,
 		c.pieAudioContainers,
+		c.pieAudioResolutions,
 		c.unknownStatusTotal,
 		c.upMetric,
 	}
@@ -602,6 +609,7 @@ func (c *TdarrCollector) emitPieMetrics(ch chan<- prometheus.Metric, pieData []*
 		emitPieSlices(ch, c.pieVideoResolutions, pie.libraryName, pie.libraryId, pie.PieStats.Video.Resolutions)
 		emitPieSlices(ch, c.pieAudioCodecs, pie.libraryName, pie.libraryId, pie.PieStats.Audio.Codecs)
 		emitPieSlices(ch, c.pieAudioContainers, pie.libraryName, pie.libraryId, pie.PieStats.Audio.Containers)
+		emitPieSlices(ch, c.pieAudioResolutions, pie.libraryName, pie.libraryId, pie.PieStats.Audio.Resolutions)
 	}
 }
 

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -17,6 +17,14 @@ var (
 	METRIC_PREFIX = "tdarr"
 )
 
+// tdarrAPI is the HTTP-client seam used by the collectors. *client.RequestClient
+// satisfies it directly; tests inject an in-memory fake instead of a real client
+// plus httptest server.
+type tdarrAPI interface {
+	DoRequest(path string, target interface{}, queryParams ...client.QueryParams) error
+	DoPostRequest(path string, target interface{}, payload []byte) error
+}
+
 // unknownStatusKey identifies a unique (kind, status) pair for the unknown-status counter.
 type unknownStatusKey struct {
 	kind   string
@@ -25,6 +33,7 @@ type unknownStatusKey struct {
 
 type TdarrCollector struct {
 	config                config.Config
+	api                   tdarrAPI // shared HTTP client, built once in the constructor
 	statsCache            *TdarrLibStatsCache
 	partialFailure        atomic.Bool // set by getLibStats workers on per-library fetch error
 	unknownStatusMu       sync.Mutex
@@ -96,9 +105,28 @@ func (c *TdarrLibStatsCache) SetLibStats(stats []*TdarrPieStats) {
 }
 
 // collector
-func NewTdarrCollector(runConfig config.Config) *TdarrCollector {
+//
+// NewTdarrCollector builds the shared HTTP client once from runConfig and wires it
+// into both the top-level collector and the embedded node collector. The client is
+// surfaced as a tdarrAPI; the error from client.NewRequestClient is propagated so the
+// composition root (main) can fail fast on a bad URL.
+func NewTdarrCollector(runConfig config.Config) (*TdarrCollector, error) {
+	api, err := client.NewRequestClient(runConfig.UrlParsed, runConfig.VerifySsl, runConfig.HttpTimeoutSeconds, runConfig.ApiKey)
+	if err != nil {
+		log.Error().
+			Err(err).Msg("Failed to create http request client for Tdarr, ensure proper URL is provided")
+		return nil, err
+	}
+	return newTdarrCollectorWithAPI(runConfig, api), nil
+}
+
+// newTdarrCollectorWithAPI is the test-injection seam: it builds a fully wired
+// TdarrCollector around an already-constructed tdarrAPI. The same api is shared with
+// the node collector since both hit the same base URL.
+func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrCollector {
 	return &TdarrCollector{
 		config:              runConfig,
+		api:                 api,
 		statsCache:          NewTdarrLibStatsCache(),
 		unknownStatusCounts: make(map[unknownStatusKey]float64),
 		totalFilesMetric: prometheus.NewDesc(
@@ -242,7 +270,7 @@ func NewTdarrCollector(runConfig config.Config) *TdarrCollector {
 			nil,
 			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
 		),
-		nodeCollector: NewTdarrNodeCollector(runConfig),
+		nodeCollector: NewTdarrNodeCollector(runConfig, api),
 	}
 }
 
@@ -297,12 +325,6 @@ func (c *TdarrCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *TdarrCollector) httpReqHelper(path string, reqPayload interface{}, target interface{}) error {
-	httpClient, err := client.NewRequestClient(c.config.UrlParsed, c.config.VerifySsl, c.config.HttpTimeoutSeconds, c.config.ApiKey)
-	if err != nil {
-		log.Error().
-			Err(err).Msg("Failed to create http request client for Tdarr, ensure proper URL is provided")
-		return err
-	}
 	log.Debug().Interface("payload", reqPayload).Msg("Requesting statistics data from Tdarr")
 	// Marshal it into JSON prior to requesting
 	payload, err := json.Marshal(reqPayload)
@@ -312,7 +334,7 @@ func (c *TdarrCollector) httpReqHelper(path string, reqPayload interface{}, targ
 		return err
 	}
 	// make request
-	httpErr := httpClient.DoPostRequest(path, target, payload)
+	httpErr := c.api.DoPostRequest(path, target, payload)
 	if httpErr != nil {
 		log.Error().Str("urlPath", path).Interface("payload", reqPayload).Err(httpErr).Msg("Failed to get data for Tdarr exporter")
 		return httpErr

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -16,11 +16,33 @@ import (
 
 const METRIC_PREFIX = "tdarr"
 
-// newDesc builds a *prometheus.Desc with the METRIC_PREFIX-prefixed fqName and the
+// buildDesc builds a *prometheus.Desc with the METRIC_PREFIX-prefixed fqName and the
 // shared const instance label. It collapses the repeated NewDesc/BuildFQName boilerplate
 // in both the collector and node-metrics constructors to a single call per metric.
-func newDesc(name, help string, varLabels []string, instance prometheus.Labels) *prometheus.Desc {
+func buildDesc(name, help string, varLabels []string, instance prometheus.Labels) *prometheus.Desc {
 	return prometheus.NewDesc(prometheus.BuildFQName(METRIC_PREFIX, "", name), help, varLabels, instance)
+}
+
+// typedDesc bundles a *prometheus.Desc with its value type so emit sites don't have
+// to repeat prometheus.GaugeValue/CounterValue on every MustNewConstMetric call. The
+// value type lives next to the desc in exactly one place (the constructor).
+type typedDesc struct {
+	desc      *prometheus.Desc
+	valueType prometheus.ValueType
+}
+
+// mustNewConstMetric emits a const metric for this desc using its bundled value type.
+func (d typedDesc) mustNewConstMetric(value float64, labelValues ...string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(d.desc, d.valueType, value, labelValues...)
+}
+
+// newGauge / newCounter build a typedDesc carrying the matching Prometheus value type.
+func newGauge(name, help string, varLabels []string, instance prometheus.Labels) typedDesc {
+	return typedDesc{desc: buildDesc(name, help, varLabels, instance), valueType: prometheus.GaugeValue}
+}
+
+func newCounter(name, help string, varLabels []string, instance prometheus.Labels) typedDesc {
+	return typedDesc{desc: buildDesc(name, help, varLabels, instance), valueType: prometheus.CounterValue}
 }
 
 // tdarrAPI is the HTTP-client seam used by the collectors. *client.RequestClient
@@ -41,43 +63,43 @@ type TdarrCollector struct {
 	// Only the config values read at collect time are stored, not the whole
 	// config.Config bag — the URL/SSL/timeout/api-key and instance label are
 	// consumed once in the constructor (client + descs) and never needed again.
-	statsPath      string
-	pieStatsPath   string
-	maxConcurrency int
-	api            tdarrAPI // shared HTTP client, built once in the constructor
+	statsPath             string
+	pieStatsPath          string
+	maxConcurrency        int
+	api                   tdarrAPI // shared HTTP client, built once in the constructor
 	statsCache            *TdarrLibStatsCache
 	partialFailure        atomic.Bool // set by getLibStats workers on per-library fetch error
 	unknownStatusMu       sync.Mutex
 	unknownStatusCounts   map[unknownStatusKey]float64 // monotonic counter for enum drift detection
-	totalFilesMetric      *prometheus.Desc
-	totalTranscodeCount   *prometheus.Desc
-	totalHealthCheckCount *prometheus.Desc
-	sizeDiff              *prometheus.Desc
-	tdarrScore            *prometheus.Desc
-	healthCheckScore      *prometheus.Desc
-	avgNumStreams         *prometheus.Desc
-	streamStatsDuration   *prometheus.Desc
-	streamStatsBitRate    *prometheus.Desc
-	streamStatsNumFrames  *prometheus.Desc
-	pieNumFiles           *prometheus.Desc
-	pieNumTranscodes      *prometheus.Desc
-	pieNumHealthChecks    *prometheus.Desc
-	pieSizeDiff           *prometheus.Desc
-	pieTranscodes         *prometheus.Desc
-	pieHealthChecks       *prometheus.Desc
-	pieVideoCodecs        *prometheus.Desc
-	pieVideoContainers    *prometheus.Desc
-	pieVideoResolutions   *prometheus.Desc
-	pieAudioCodecs        *prometheus.Desc
-	pieAudioContainers    *prometheus.Desc
-	pieAudioResolutions   *prometheus.Desc
-	unknownStatusTotal    *prometheus.Desc    // counter for status values not in known enum
+	totalFilesMetric      typedDesc
+	totalTranscodeCount   typedDesc
+	totalHealthCheckCount typedDesc
+	sizeDiff              typedDesc
+	tdarrScore            typedDesc
+	healthCheckScore      typedDesc
+	avgNumStreams         typedDesc
+	streamStatsDuration   typedDesc
+	streamStatsBitRate    typedDesc
+	streamStatsNumFrames  typedDesc
+	pieNumFiles           typedDesc
+	pieNumTranscodes      typedDesc
+	pieNumHealthChecks    typedDesc
+	pieSizeDiff           typedDesc
+	pieTranscodes         typedDesc
+	pieHealthChecks       typedDesc
+	pieVideoCodecs        typedDesc
+	pieVideoContainers    typedDesc
+	pieVideoResolutions   typedDesc
+	pieAudioCodecs        typedDesc
+	pieAudioContainers    typedDesc
+	pieAudioResolutions   typedDesc
+	unknownStatusTotal    typedDesc           // counter for status values not in known enum
 	nodeCollector         *TdarrNodeCollector // node data
-	upMetric              *prometheus.Desc
+	upMetric              typedDesc
 	// descsList is the collector's own descs in Describe order, assembled once in the
 	// constructor. Describe ranges over this plus the node collector's descs(), so a
 	// metric is registered for Describe in exactly one place (no field-by-field hand-list).
-	descsList []*prometheus.Desc
+	descsList []typedDesc
 }
 
 // Cache to store library stats and reduce excessive API calls
@@ -149,124 +171,124 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 		api:                 api,
 		statsCache:          NewTdarrLibStatsCache(),
 		unknownStatusCounts: make(map[unknownStatusKey]float64),
-		totalFilesMetric: newDesc(
+		totalFilesMetric: newGauge(
 			"files_total",
 			"Tdarr total file count - includes files in ignore lists within each library",
 			nil, instance,
 		),
-		totalTranscodeCount: newDesc(
+		totalTranscodeCount: newGauge(
 			"transcodes_total",
 			"Tdarr total transcode count for all libraries",
 			nil, instance,
 		),
-		totalHealthCheckCount: newDesc(
+		totalHealthCheckCount: newGauge(
 			"health_checks_total",
 			"Tdarr total health check count for all libraries",
 			nil, instance,
 		),
-		sizeDiff: newDesc(
+		sizeDiff: newGauge(
 			"size_diff_gb",
 			"Tdarr size difference (+/-) in GB",
 			nil, instance,
 		),
-		tdarrScore: newDesc(
+		tdarrScore: newGauge(
 			"score_pct",
 			"Tdarr score percentage - how much of your libraries has been handled by tdarr",
 			nil, instance,
 		),
-		healthCheckScore: newDesc(
+		healthCheckScore: newGauge(
 			"health_check_score_pct",
 			"Tdarr health check score percentage - how much of your libraries has been health checked by tdarr",
 			nil, instance,
 		),
-		avgNumStreams: newDesc(
+		avgNumStreams: newGauge(
 			"avg_num_streams",
 			"Tdarr average number of streams in video",
 			nil, instance,
 		),
-		streamStatsDuration: newDesc(
+		streamStatsDuration: newGauge(
 			"stream_stats_duration",
 			"Tdarr stream stats duration",
 			[]string{"stat_type"}, instance,
 		),
-		streamStatsBitRate: newDesc(
+		streamStatsBitRate: newGauge(
 			"stream_stats_bit_rate",
 			"Tdarr stream stats bit rate",
 			[]string{"stat_type"}, instance,
 		),
-		streamStatsNumFrames: newDesc(
+		streamStatsNumFrames: newGauge(
 			"stream_stats_num_frames",
 			"Tdarr stream stats number of frames",
 			[]string{"stat_type"}, instance,
 		),
-		pieNumFiles: newDesc(
+		pieNumFiles: newGauge(
 			"library_files_total",
 			"Tdarr total files in library",
 			[]string{"library_name", "library_id"}, instance,
 		),
-		pieNumTranscodes: newDesc(
+		pieNumTranscodes: newGauge(
 			"library_transcodes_total",
 			"Tdarr total transcodes for library by status",
 			[]string{"library_name", "library_id"}, instance,
 		),
-		pieNumHealthChecks: newDesc(
+		pieNumHealthChecks: newGauge(
 			"library_health_checks_total",
 			"Tdarr total health checks for library by status",
 			[]string{"library_name", "library_id"}, instance,
 		),
-		pieSizeDiff: newDesc(
+		pieSizeDiff: newGauge(
 			"library_size_diff_gb",
 			"Tdarr size difference (+/-) in GB for library",
 			[]string{"library_name", "library_id"}, instance,
 		),
-		pieTranscodes: newDesc(
+		pieTranscodes: newGauge(
 			"library_transcodes",
 			"Tdarr transcodes for library by status",
 			[]string{"library_name", "library_id", "status"}, instance,
 		),
-		pieHealthChecks: newDesc(
+		pieHealthChecks: newGauge(
 			"library_health_checks",
 			"Tdarr health checks for library by status",
 			[]string{"library_name", "library_id", "status"}, instance,
 		),
-		pieVideoCodecs: newDesc(
+		pieVideoCodecs: newGauge(
 			"library_video_codecs",
 			"Tdarr video codecs for library by type",
 			[]string{"library_name", "library_id", "codec"}, instance,
 		),
-		pieVideoContainers: newDesc(
+		pieVideoContainers: newGauge(
 			"library_video_containers",
 			"Tdarr video containers for library by type",
 			[]string{"library_name", "library_id", "container_type"}, instance,
 		),
-		pieVideoResolutions: newDesc(
+		pieVideoResolutions: newGauge(
 			"library_video_resolutions",
 			"Tdarr video resolutions for library by type",
 			[]string{"library_name", "library_id", "resolution"}, instance,
 		),
-		pieAudioCodecs: newDesc(
+		pieAudioCodecs: newGauge(
 			"library_audio_codecs",
 			"Tdarr audio codecs for library by type",
 			[]string{"library_name", "library_id", "codec"}, instance,
 		),
-		pieAudioContainers: newDesc(
+		pieAudioContainers: newGauge(
 			"library_audio_containers",
 			"Tdarr video containers for library by type",
 			[]string{"library_name", "library_id", "container_type"}, instance,
 		),
-		pieAudioResolutions: newDesc(
+		pieAudioResolutions: newGauge(
 			"library_audio_resolutions",
 			"Tdarr audio resolutions for library by type",
 			[]string{"library_name", "library_id", "resolution"}, instance,
 		),
-		unknownStatusTotal: newDesc(
+		unknownStatusTotal: newCounter(
 			"unknown_status_total",
 			"Count of pie status values not in the known enum, by job_kind (transcode|healthcheck) and status label. "+
 				"A non-zero value indicates Tdarr emitted a status that the exporter does not pre-emit zeros for. "+
 				"Use increase(tdarr_unknown_status_total[24h]) > 0 to alert on API drift.",
 			[]string{"job_kind", "status"}, instance,
 		),
-		upMetric: newDesc(
+		upMetric: newGauge(
 			"up",
 			"1 if the last collection cycle succeeded, 0 otherwise (Tdarr API error, response parse error, or partial pie-stats fetch). "+
 				"Distinct from prometheus built-in 'up' which indicates exporter process reachability.",
@@ -278,7 +300,7 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 	// Assemble the collector's own descs once, in Describe order. Describe ranges over
 	// this list plus the node collector's descs() — adding a metric means appending here
 	// in exactly one place. The order matches the historical hand-written Describe list.
-	c.descsList = []*prometheus.Desc{
+	c.descsList = []typedDesc{
 		c.totalFilesMetric,
 		c.totalTranscodeCount,
 		c.totalHealthCheckCount,
@@ -318,10 +340,10 @@ func (c *TdarrCollector) Describe(ch chan<- *prometheus.Desc) {
 	// slice: appending to c.descsList could alias/overwrite its backing array if it
 	// ever had spare capacity. Two loops are allocation-free and alias-free.
 	for _, d := range c.descsList {
-		ch <- d
+		ch <- d.desc
 	}
 	for _, d := range c.nodeCollector.metrics.descs() {
-		ch <- d
+		ch <- d.desc
 	}
 }
 
@@ -453,7 +475,7 @@ func (c *TdarrCollector) Collect(ch chan<- prometheus.Metric) {
 	if err != nil || partial {
 		v = 0.0
 	}
-	ch <- prometheus.MustNewConstMetric(c.upMetric, prometheus.GaugeValue, v)
+	ch <- c.upMetric.mustNewConstMetric(v)
 }
 
 // totalsFromMetric builds the cache-totals snapshot from a general-stats metric.
@@ -557,7 +579,7 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 	// A non-zero value means Tdarr returned a status label the exporter did not pre-init zeros for.
 	c.unknownStatusMu.Lock()
 	for key, count := range c.unknownStatusCounts {
-		ch <- prometheus.MustNewConstMetric(c.unknownStatusTotal, prometheus.CounterValue, count,
+		ch <- c.unknownStatusTotal.mustNewConstMetric(count,
 			key.kind, key.status)
 	}
 	c.unknownStatusMu.Unlock()
@@ -575,29 +597,29 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 // emitGeneralMetrics emits the top-level server gauges and stream-stats series for a
 // general-stats metric. Pure: it only reads the metric/scores and writes to ch.
 func (c *TdarrCollector) emitGeneralMetrics(ch chan<- prometheus.Metric, metric *TdarrMetric, score, healthScore float64) {
-	ch <- prometheus.MustNewConstMetric(c.totalFilesMetric, prometheus.GaugeValue, float64(metric.TotalFileCount))
-	ch <- prometheus.MustNewConstMetric(c.totalTranscodeCount, prometheus.GaugeValue, float64(metric.TotalTranscodeCount))
-	ch <- prometheus.MustNewConstMetric(c.totalHealthCheckCount, prometheus.GaugeValue, float64(metric.TotalHealthCheckCount))
-	ch <- prometheus.MustNewConstMetric(c.sizeDiff, prometheus.GaugeValue, metric.SizeDiff)
-	ch <- prometheus.MustNewConstMetric(c.tdarrScore, prometheus.GaugeValue, score)
-	ch <- prometheus.MustNewConstMetric(c.healthCheckScore, prometheus.GaugeValue, healthScore)
-	ch <- prometheus.MustNewConstMetric(c.avgNumStreams, prometheus.GaugeValue, metric.AvgNumStreams)
-	ch <- prometheus.MustNewConstMetric(c.streamStatsDuration, prometheus.GaugeValue, float64(metric.StreamStats.Duration.Average), "average")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsDuration, prometheus.GaugeValue, float64(metric.StreamStats.Duration.Highest), "highest")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsDuration, prometheus.GaugeValue, float64(metric.StreamStats.Duration.Total), "total")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsBitRate, prometheus.GaugeValue, float64(metric.StreamStats.BitRate.Average), "average")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsBitRate, prometheus.GaugeValue, float64(metric.StreamStats.BitRate.Highest), "highest")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsBitRate, prometheus.GaugeValue, float64(metric.StreamStats.BitRate.Total), "total")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsNumFrames, prometheus.GaugeValue, float64(metric.StreamStats.NumFrames.Average), "average")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsNumFrames, prometheus.GaugeValue, float64(metric.StreamStats.NumFrames.Highest), "highest")
-	ch <- prometheus.MustNewConstMetric(c.streamStatsNumFrames, prometheus.GaugeValue, float64(metric.StreamStats.NumFrames.Total), "total")
+	ch <- c.totalFilesMetric.mustNewConstMetric(float64(metric.TotalFileCount))
+	ch <- c.totalTranscodeCount.mustNewConstMetric(float64(metric.TotalTranscodeCount))
+	ch <- c.totalHealthCheckCount.mustNewConstMetric(float64(metric.TotalHealthCheckCount))
+	ch <- c.sizeDiff.mustNewConstMetric(metric.SizeDiff)
+	ch <- c.tdarrScore.mustNewConstMetric(score)
+	ch <- c.healthCheckScore.mustNewConstMetric(healthScore)
+	ch <- c.avgNumStreams.mustNewConstMetric(metric.AvgNumStreams)
+	ch <- c.streamStatsDuration.mustNewConstMetric(float64(metric.StreamStats.Duration.Average), "average")
+	ch <- c.streamStatsDuration.mustNewConstMetric(float64(metric.StreamStats.Duration.Highest), "highest")
+	ch <- c.streamStatsDuration.mustNewConstMetric(float64(metric.StreamStats.Duration.Total), "total")
+	ch <- c.streamStatsBitRate.mustNewConstMetric(float64(metric.StreamStats.BitRate.Average), "average")
+	ch <- c.streamStatsBitRate.mustNewConstMetric(float64(metric.StreamStats.BitRate.Highest), "highest")
+	ch <- c.streamStatsBitRate.mustNewConstMetric(float64(metric.StreamStats.BitRate.Total), "total")
+	ch <- c.streamStatsNumFrames.mustNewConstMetric(float64(metric.StreamStats.NumFrames.Average), "average")
+	ch <- c.streamStatsNumFrames.mustNewConstMetric(float64(metric.StreamStats.NumFrames.Highest), "highest")
+	ch <- c.streamStatsNumFrames.mustNewConstMetric(float64(metric.StreamStats.NumFrames.Total), "total")
 }
 
 // emitPieSlices emits one gauge per slice in a pie-slice list (codecs/containers/resolutions),
 // lowercasing the slice name as the final label. Shared by the five video/audio loops.
-func emitPieSlices(ch chan<- prometheus.Metric, desc *prometheus.Desc, libName, libId string, slices []TdarrPieSlice) {
+func emitPieSlices(ch chan<- prometheus.Metric, desc typedDesc, libName, libId string, slices []TdarrPieSlice) {
 	for _, pieSlice := range slices {
-		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(pieSlice.Value),
+		ch <- desc.mustNewConstMetric(float64(pieSlice.Value),
 			libName, libId, strings.ToLower(pieSlice.Name))
 	}
 }
@@ -606,18 +628,18 @@ func emitPieSlices(ch chan<- prometheus.Metric, desc *prometheus.Desc, libName, 
 // video/audio codec/container/resolution slices). Pure: reads pieData, writes to ch.
 func (c *TdarrCollector) emitPieMetrics(ch chan<- prometheus.Metric, pieData []*TdarrPieStats) {
 	for _, pie := range pieData {
-		ch <- prometheus.MustNewConstMetric(c.pieNumFiles, prometheus.GaugeValue, float64(pie.PieStats.TotalFiles), pie.libraryName, pie.libraryId)
-		ch <- prometheus.MustNewConstMetric(c.pieNumTranscodes, prometheus.GaugeValue, float64(pie.PieStats.TotalTranscodeCount), pie.libraryName, pie.libraryId)
-		ch <- prometheus.MustNewConstMetric(c.pieNumHealthChecks, prometheus.GaugeValue, float64(pie.PieStats.TotalHealthCheckCount), pie.libraryName, pie.libraryId)
-		ch <- prometheus.MustNewConstMetric(c.pieSizeDiff, prometheus.GaugeValue, pie.PieStats.SizeDiff, pie.libraryName, pie.libraryId)
+		ch <- c.pieNumFiles.mustNewConstMetric(float64(pie.PieStats.TotalFiles), pie.libraryName, pie.libraryId)
+		ch <- c.pieNumTranscodes.mustNewConstMetric(float64(pie.PieStats.TotalTranscodeCount), pie.libraryName, pie.libraryId)
+		ch <- c.pieNumHealthChecks.mustNewConstMetric(float64(pie.PieStats.TotalHealthCheckCount), pie.libraryName, pie.libraryId)
+		ch <- c.pieSizeDiff.mustNewConstMetric(pie.PieStats.SizeDiff, pie.libraryName, pie.libraryId)
 		// Emit transcode statuses from the normalized map (pre-cleaned labels, full enum coverage).
 		for status, count := range pie.NormalizedTranscodes {
-			ch <- prometheus.MustNewConstMetric(c.pieTranscodes, prometheus.GaugeValue, float64(count),
+			ch <- c.pieTranscodes.mustNewConstMetric(float64(count),
 				pie.libraryName, pie.libraryId, status)
 		}
 		// Emit health check statuses from the normalized map (pre-cleaned labels, full enum coverage).
 		for status, count := range pie.NormalizedHealthChecks {
-			ch <- prometheus.MustNewConstMetric(c.pieHealthChecks, prometheus.GaugeValue, float64(count),
+			ch <- c.pieHealthChecks.mustNewConstMetric(float64(count),
 				pie.libraryName, pie.libraryId, status)
 		}
 		emitPieSlices(ch, c.pieVideoCodecs, pie.libraryName, pie.libraryId, pie.PieStats.Video.Codecs)
@@ -632,9 +654,9 @@ func (c *TdarrCollector) emitPieMetrics(ch chan<- prometheus.Metric, pieData []*
 // emitParsedFloat parses raw as a float64 and, on success, emits a node-scoped gauge.
 // On parse failure it debug-logs and silently skips the metric (intentional: Tdarr may
 // send empty/non-numeric resource strings for nodes that haven't reported yet).
-func emitParsedFloat(ch chan<- prometheus.Metric, desc *prometheus.Desc, raw string, nodeId, nodeName string) {
+func emitParsedFloat(ch chan<- prometheus.Metric, desc typedDesc, raw string, nodeId, nodeName string) {
 	if v, floatErr := strconv.ParseFloat(raw, 64); floatErr == nil {
-		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, nodeId, nodeName)
+		ch <- desc.mustNewConstMetric(v, nodeId, nodeName)
 	} else {
 		log.Debug().Str("nodeId", nodeId).Str("nodeName", nodeName).
 			Str("raw", raw).Err(floatErr).Msg("Failed to parse node resource stat; skipping metric")
@@ -649,14 +671,14 @@ func (c *TdarrCollector) emitNodeMetrics(ch chan<- prometheus.Metric, nodeData m
 		m := c.nodeCollector.metrics
 
 		// node identity info
-		ch <- prometheus.MustNewConstMetric(m.nodeInfo, prometheus.GaugeValue, 1,
+		ch <- m.nodeInfo.mustNewConstMetric(1,
 			node.Id, node.Name, node.GpuSelect,
 			strconv.Itoa(node.Config.Pid), strconv.Itoa(node.Priority),
 			strconv.FormatBool(node.AllowGpuDoCpu),
 		)
 
 		// node uptime
-		ch <- prometheus.MustNewConstMetric(m.nodeUptime, prometheus.GaugeValue,
+		ch <- m.nodeUptime.mustNewConstMetric(
 			float64(node.ResourceStats.Process.Uptime), node.Id, node.Name)
 
 		// convert resource stats to float from string; skip on parse failure
@@ -671,13 +693,13 @@ func (c *TdarrCollector) emitNodeMetrics(ch chan<- prometheus.Metric, nodeData m
 		if node.Paused {
 			pausedVal = 1.0
 		}
-		ch <- prometheus.MustNewConstMetric(m.nodePaused, prometheus.GaugeValue, pausedVal, node.Id, node.Name)
-		ch <- prometheus.MustNewConstMetric(m.nodeMaxGpuWorkers, prometheus.GaugeValue, float64(node.MaxGpuWorkers), node.Id, node.Name)
+		ch <- m.nodePaused.mustNewConstMetric(pausedVal, node.Id, node.Name)
+		ch <- m.nodeMaxGpuWorkers.mustNewConstMetric(float64(node.MaxGpuWorkers), node.Id, node.Name)
 		schedVal := 0.0
 		if node.ScheduleEnabled {
 			schedVal = 1.0
 		}
-		ch <- prometheus.MustNewConstMetric(m.nodeScheduleEnabled, prometheus.GaugeValue, schedVal, node.Id, node.Name)
+		ch <- m.nodeScheduleEnabled.mustNewConstMetric(schedVal, node.Id, node.Name)
 
 		// per-type gauges — always emit all four types so zero-value series appear
 		emitPerType(ch, m.nodeWorkerLimit, node.Id, node.Name, node.WorkerLimits)
@@ -688,14 +710,14 @@ func (c *TdarrCollector) emitNodeMetrics(ch chan<- prometheus.Metric, nodeData m
 		// (raw API string preserved as worker_type, "unknown" as compute_type).
 		workerCounts := countWorkersByType(node.Workers)
 		for _, d := range knownWorkerTypeDims {
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerCount, prometheus.GaugeValue,
+			ch <- m.nodeWorkerCount.mustNewConstMetric(
 				float64(workerCounts.known[d]), node.Id, node.Name, d.workerType, d.computeType)
 		}
 		for rawType, count := range workerCounts.unknown {
 			if count == 0 {
 				continue
 			}
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerCount, prometheus.GaugeValue,
+			ch <- m.nodeWorkerCount.mustNewConstMetric(
 				float64(count), node.Id, node.Name, rawType, computeTypeUnknown)
 		}
 
@@ -714,7 +736,7 @@ func (c *TdarrCollector) emitNodeMetrics(ch chan<- prometheus.Metric, nodeData m
 			// unified worker info metric (all workers, flow or classic).
 			// Split Tdarr's compound workerType string into worker_type + compute_type labels.
 			wType, cType := parseWorkerType(worker.WorkerType)
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerInfo, prometheus.GaugeValue, 1,
+			ch <- m.nodeWorkerInfo.mustNewConstMetric(1,
 				node.Id, node.Name, worker.Id, wType, cType,
 				strconv.FormatBool(worker.FlowWorker),
 				worker.Status, worker.File,
@@ -723,28 +745,28 @@ func (c *TdarrCollector) emitNodeMetrics(ch chan<- prometheus.Metric, nodeData m
 			)
 
 			// per-worker numeric gauges
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerPercentage, prometheus.GaugeValue,
+			ch <- m.nodeWorkerPercentage.mustNewConstMetric(
 				worker.Percentage, node.Id, node.Name, worker.Id)
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerFps, prometheus.GaugeValue,
+			ch <- m.nodeWorkerFps.mustNewConstMetric(
 				float64(worker.Fps), node.Id, node.Name, worker.Id)
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerOriginalFileSizeGb, prometheus.GaugeValue,
+			ch <- m.nodeWorkerOriginalFileSizeGb.mustNewConstMetric(
 				worker.OriginalfileSizeGb, node.Id, node.Name, worker.Id)
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerOutputFileSizeGb, prometheus.GaugeValue,
+			ch <- m.nodeWorkerOutputFileSizeGb.mustNewConstMetric(
 				worker.OutputFileSizeGb, node.Id, node.Name, worker.Id)
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerEstFileSizeGb, prometheus.GaugeValue,
+			ch <- m.nodeWorkerEstFileSizeGb.mustNewConstMetric(
 				worker.EstSizeGb, node.Id, node.Name, worker.Id)
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerJobStartTimestamp, prometheus.GaugeValue,
+			ch <- m.nodeWorkerJobStartTimestamp.mustNewConstMetric(
 				float64(worker.Job.StartTime), node.Id, node.Name, worker.Id)
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerStartTimestamp, prometheus.GaugeValue,
+			ch <- m.nodeWorkerStartTimestamp.mustNewConstMetric(
 				float64(worker.StartTime), node.Id, node.Name, worker.Id)
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerStatusTimestamp, prometheus.GaugeValue,
+			ch <- m.nodeWorkerStatusTimestamp.mustNewConstMetric(
 				float64(worker.StatusTs), node.Id, node.Name, worker.Id)
-			ch <- prometheus.MustNewConstMetric(m.nodeWorkerPid, prometheus.GaugeValue,
+			ch <- m.nodeWorkerPid.mustNewConstMetric(
 				float64(worker.Process.Pid), node.Id, node.Name, worker.Id)
 
 			// ETA: parse "H:MM:SS" string into seconds; skip on parse failure
 			if etaSecs, ok := parseEtaSeconds(worker.Eta); ok {
-				ch <- prometheus.MustNewConstMetric(m.nodeWorkerEtaSeconds, prometheus.GaugeValue,
+				ch <- m.nodeWorkerEtaSeconds.mustNewConstMetric(
 					float64(etaSecs), node.Id, node.Name, worker.Id)
 			} else {
 				log.Debug().Str("nodeId", node.Id).Str("workerId", worker.Id).

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -17,6 +17,13 @@ var (
 	METRIC_PREFIX = "tdarr"
 )
 
+// newDesc builds a *prometheus.Desc with the METRIC_PREFIX-prefixed fqName and the
+// shared const instance label. It collapses the repeated NewDesc/BuildFQName boilerplate
+// in both the collector and node-metrics constructors to a single call per metric.
+func newDesc(name, help string, varLabels []string, instance prometheus.Labels) *prometheus.Desc {
+	return prometheus.NewDesc(prometheus.BuildFQName(METRIC_PREFIX, "", name), help, varLabels, instance)
+}
+
 // tdarrAPI is the HTTP-client seam used by the collectors. *client.RequestClient
 // satisfies it directly; tests inject an in-memory fake instead of a real client
 // plus httptest server.
@@ -62,6 +69,10 @@ type TdarrCollector struct {
 	unknownStatusTotal    *prometheus.Desc    // counter for status values not in known enum
 	nodeCollector         *TdarrNodeCollector // node data
 	upMetric              *prometheus.Desc
+	// descsList is the collector's own descs in Describe order, assembled once in the
+	// constructor. Describe ranges over this plus the node collector's descs(), so a
+	// metric is registered for Describe in exactly one place (no field-by-field hand-list).
+	descsList []*prometheus.Desc
 }
 
 // Cache to store library stats and reduce excessive API calls
@@ -124,204 +135,175 @@ func NewTdarrCollector(runConfig config.Config) (*TdarrCollector, error) {
 // TdarrCollector around an already-constructed tdarrAPI. The same api is shared with
 // the node collector since both hit the same base URL.
 func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrCollector {
-	return &TdarrCollector{
+	instance := prometheus.Labels{"tdarr_instance": runConfig.InstanceName}
+
+	c := &TdarrCollector{
 		config:              runConfig,
 		api:                 api,
 		statsCache:          NewTdarrLibStatsCache(),
 		unknownStatusCounts: make(map[unknownStatusKey]float64),
-		totalFilesMetric: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "files_total"),
+		totalFilesMetric: newDesc(
+			"files_total",
 			"Tdarr total file count - includes files in ignore lists within each library",
-			nil,
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			nil, instance,
 		),
-		totalTranscodeCount: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "transcodes_total"),
+		totalTranscodeCount: newDesc(
+			"transcodes_total",
 			"Tdarr total transcode count for all libraries",
-			nil,
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			nil, instance,
 		),
-		totalHealthCheckCount: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "health_checks_total"),
+		totalHealthCheckCount: newDesc(
+			"health_checks_total",
 			"Tdarr total health check count for all libraries",
-			nil,
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			nil, instance,
 		),
-		sizeDiff: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "size_diff_gb"),
+		sizeDiff: newDesc(
+			"size_diff_gb",
 			"Tdarr size difference (+/-) in GB",
-			nil,
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			nil, instance,
 		),
-		tdarrScore: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "score_pct"),
+		tdarrScore: newDesc(
+			"score_pct",
 			"Tdarr score percentage - how much of your libraries has been handled by tdarr",
-			nil,
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			nil, instance,
 		),
-		healthCheckScore: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "health_check_score_pct"),
+		healthCheckScore: newDesc(
+			"health_check_score_pct",
 			"Tdarr health check score percentage - how much of your libraries has been health checked by tdarr",
-			nil,
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			nil, instance,
 		),
-		avgNumStreams: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "avg_num_streams"),
+		avgNumStreams: newDesc(
+			"avg_num_streams",
 			"Tdarr average number of streams in video",
-			nil,
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			nil, instance,
 		),
-		streamStatsDuration: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "stream_stats_duration"),
+		streamStatsDuration: newDesc(
+			"stream_stats_duration",
 			"Tdarr stream stats duration",
-			[]string{"stat_type"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"stat_type"}, instance,
 		),
-		streamStatsBitRate: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "stream_stats_bit_rate"),
+		streamStatsBitRate: newDesc(
+			"stream_stats_bit_rate",
 			"Tdarr stream stats bit rate",
-			[]string{"stat_type"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"stat_type"}, instance,
 		),
-		streamStatsNumFrames: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "stream_stats_num_frames"),
+		streamStatsNumFrames: newDesc(
+			"stream_stats_num_frames",
 			"Tdarr stream stats number of frames",
-			[]string{"stat_type"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"stat_type"}, instance,
 		),
-		pieNumFiles: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_files_total"),
+		pieNumFiles: newDesc(
+			"library_files_total",
 			"Tdarr total files in library",
-			[]string{"library_name", "library_id"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id"}, instance,
 		),
-		pieNumTranscodes: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_transcodes_total"),
+		pieNumTranscodes: newDesc(
+			"library_transcodes_total",
 			"Tdarr total transcodes for library by status",
-			[]string{"library_name", "library_id"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id"}, instance,
 		),
-		pieNumHealthChecks: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_health_checks_total"),
+		pieNumHealthChecks: newDesc(
+			"library_health_checks_total",
 			"Tdarr total health checks for library by status",
-			[]string{"library_name", "library_id"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id"}, instance,
 		),
-		pieSizeDiff: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_size_diff_gb"),
+		pieSizeDiff: newDesc(
+			"library_size_diff_gb",
 			"Tdarr size difference (+/-) in GB for library",
-			[]string{"library_name", "library_id"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id"}, instance,
 		),
-		pieTranscodes: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_transcodes"),
+		pieTranscodes: newDesc(
+			"library_transcodes",
 			"Tdarr transcodes for library by status",
-			[]string{"library_name", "library_id", "status"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id", "status"}, instance,
 		),
-		pieHealthChecks: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_health_checks"),
+		pieHealthChecks: newDesc(
+			"library_health_checks",
 			"Tdarr health checks for library by status",
-			[]string{"library_name", "library_id", "status"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id", "status"}, instance,
 		),
-		pieVideoCodecs: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_video_codecs"),
+		pieVideoCodecs: newDesc(
+			"library_video_codecs",
 			"Tdarr video codecs for library by type",
-			[]string{"library_name", "library_id", "codec"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id", "codec"}, instance,
 		),
-		pieVideoContainers: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_video_containers"),
+		pieVideoContainers: newDesc(
+			"library_video_containers",
 			"Tdarr video containers for library by type",
-			[]string{"library_name", "library_id", "container_type"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id", "container_type"}, instance,
 		),
-		pieVideoResolutions: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_video_resolutions"),
+		pieVideoResolutions: newDesc(
+			"library_video_resolutions",
 			"Tdarr video resolutions for library by type",
-			[]string{"library_name", "library_id", "resolution"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id", "resolution"}, instance,
 		),
-		pieAudioCodecs: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_audio_codecs"),
+		pieAudioCodecs: newDesc(
+			"library_audio_codecs",
 			"Tdarr audio codecs for library by type",
-			[]string{"library_name", "library_id", "codec"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id", "codec"}, instance,
 		),
-		pieAudioContainers: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "library_audio_containers"),
+		pieAudioContainers: newDesc(
+			"library_audio_containers",
 			"Tdarr video containers for library by type",
-			[]string{"library_name", "library_id", "container_type"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"library_name", "library_id", "container_type"}, instance,
 		),
-		unknownStatusTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "unknown_status_total"),
+		unknownStatusTotal: newDesc(
+			"unknown_status_total",
 			"Count of pie status values not in the known enum, by job_kind (transcode|healthcheck) and status label. "+
 				"A non-zero value indicates Tdarr emitted a status that the exporter does not pre-emit zeros for. "+
 				"Use increase(tdarr_unknown_status_total[24h]) > 0 to alert on API drift.",
-			[]string{"job_kind", "status"},
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			[]string{"job_kind", "status"}, instance,
 		),
-		upMetric: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "up"),
+		upMetric: newDesc(
+			"up",
 			"1 if the last collection cycle succeeded, 0 otherwise (Tdarr API error, response parse error, or partial pie-stats fetch). "+
 				"Distinct from prometheus built-in 'up' which indicates exporter process reachability.",
-			nil,
-			prometheus.Labels{"tdarr_instance": runConfig.InstanceName},
+			nil, instance,
 		),
 		nodeCollector: NewTdarrNodeCollector(runConfig, api),
 	}
+
+	// Assemble the collector's own descs once, in Describe order. Describe ranges over
+	// this list plus the node collector's descs() — adding a metric means appending here
+	// in exactly one place. The order matches the historical hand-written Describe list.
+	c.descsList = []*prometheus.Desc{
+		c.totalFilesMetric,
+		c.totalTranscodeCount,
+		c.totalHealthCheckCount,
+		c.sizeDiff,
+		c.tdarrScore,
+		c.healthCheckScore,
+		c.pieNumFiles,
+		c.pieNumTranscodes,
+		c.pieNumHealthChecks,
+		c.pieSizeDiff,
+		c.pieTranscodes,
+		c.pieHealthChecks,
+		c.avgNumStreams,
+		c.streamStatsDuration,
+		c.streamStatsBitRate,
+		c.streamStatsNumFrames,
+		c.pieVideoCodecs,
+		c.pieVideoContainers,
+		c.pieVideoResolutions,
+		c.pieAudioCodecs,
+		c.pieAudioContainers,
+		c.unknownStatusTotal,
+		c.upMetric,
+	}
+
+	return c
 }
 
+// Describe emits every registered desc by ranging over a single ordered slice: the
+// collector's own descs (assembled in the constructor) followed by the node collector's
+// descs(). There is no field-by-field hand-list and no reach-in to nodeCollector.metrics.*,
+// so a metric is described in exactly one place. TestDescribe_EmitsAllDescs guards the
+// count, since Prometheus does not flag a desc that silently drops out of Describe.
 func (c *TdarrCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.totalFilesMetric
-	ch <- c.totalTranscodeCount
-	ch <- c.totalHealthCheckCount
-	ch <- c.sizeDiff
-	ch <- c.tdarrScore
-	ch <- c.healthCheckScore
-	ch <- c.pieNumFiles
-	ch <- c.pieNumTranscodes
-	ch <- c.pieNumHealthChecks
-	ch <- c.pieSizeDiff
-	ch <- c.pieTranscodes
-	ch <- c.pieHealthChecks
-	ch <- c.avgNumStreams
-	ch <- c.streamStatsDuration
-	ch <- c.streamStatsBitRate
-	ch <- c.streamStatsNumFrames
-	ch <- c.pieVideoCodecs
-	ch <- c.pieVideoContainers
-	ch <- c.pieVideoResolutions
-	ch <- c.pieAudioCodecs
-	ch <- c.pieAudioContainers
-	ch <- c.unknownStatusTotal
-	ch <- c.upMetric
-	ch <- c.nodeCollector.metrics.nodeInfo
-	ch <- c.nodeCollector.metrics.nodeUptime
-	ch <- c.nodeCollector.metrics.nodeHeapUsedMb
-	ch <- c.nodeCollector.metrics.nodeHeapTotalMb
-	ch <- c.nodeCollector.metrics.nodeHostCpuPercent
-	ch <- c.nodeCollector.metrics.nodeHostMemUsedGb
-	ch <- c.nodeCollector.metrics.nodeHostMemTotalGb
-	ch <- c.nodeCollector.metrics.nodePaused
-	ch <- c.nodeCollector.metrics.nodeMaxGpuWorkers
-	ch <- c.nodeCollector.metrics.nodeScheduleEnabled
-	ch <- c.nodeCollector.metrics.nodeWorkerCount
-	ch <- c.nodeCollector.metrics.nodeWorkerLimit
-	ch <- c.nodeCollector.metrics.nodeQueueLength
-	ch <- c.nodeCollector.metrics.nodeWorkerInfo
-	ch <- c.nodeCollector.metrics.nodeWorkerPercentage
-	ch <- c.nodeCollector.metrics.nodeWorkerFps
-	ch <- c.nodeCollector.metrics.nodeWorkerOriginalFileSizeGb
-	ch <- c.nodeCollector.metrics.nodeWorkerOutputFileSizeGb
-	ch <- c.nodeCollector.metrics.nodeWorkerEstFileSizeGb
-	ch <- c.nodeCollector.metrics.nodeWorkerJobStartTimestamp
-	ch <- c.nodeCollector.metrics.nodeWorkerStartTimestamp
-	ch <- c.nodeCollector.metrics.nodeWorkerStatusTimestamp
-	ch <- c.nodeCollector.metrics.nodeWorkerEtaSeconds
-	ch <- c.nodeCollector.metrics.nodeWorkerPid
+	for _, d := range append(c.descsList, c.nodeCollector.metrics.descs()...) {
+		ch <- d
+	}
 }
 
 func (c *TdarrCollector) httpReqHelper(path string, reqPayload interface{}, target interface{}) error {

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -297,7 +297,7 @@ func (c *TdarrCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *TdarrCollector) httpReqHelper(path string, reqPayload interface{}, target interface{}) error {
-	httpClient, err := client.NewRequestClient(c.config.UrlParsed, c.config.VerifySsl, c.config.ApiKey)
+	httpClient, err := client.NewRequestClient(c.config.UrlParsed, c.config.VerifySsl, c.config.HttpTimeoutSeconds, c.config.ApiKey)
 	if err != nil {
 		log.Error().
 			Err(err).Msg("Failed to create http request client for Tdarr, ensure proper URL is provided")
@@ -425,7 +425,7 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 	// (e.g. files queued but not yet transcoded), catching invalidation cases the three top-level
 	// counts miss. Older Tdarr versions that omit tableXCount fields decode to 0; 0==0 means
 	// no spurious refetches — behavior degrades gracefully to original 3-totals logic.
-	if c.statsCache.libraryStats == nil ||
+	if c.statsCache.GetLibStats() == nil ||
 		cacheTotals.totalFileCount != metric.TotalFileCount ||
 		cacheTotals.totalTranscodeCount != metric.TotalTranscodeCount ||
 		cacheTotals.totalHealthCheckCount != metric.TotalHealthCheckCount ||

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -13,6 +13,7 @@ import (
 	"github.com/homeylab/tdarr-exporter/internal/client"
 	"github.com/homeylab/tdarr-exporter/internal/config"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -85,7 +86,10 @@ type TdarrCollector struct {
 	// baseCtx is the parent context for every scrape's HTTP requests. main wires in
 	// a context cancelled on shutdown so in-flight scrapes abort promptly; tests and
 	// the WithAPI constructor default it to context.Background().
-	baseCtx               context.Context
+	baseCtx context.Context
+	// logger defaults to the package-global log.Logger and is shared with the node
+	// collector at construction. Injected so tests can silence or capture logs.
+	logger                zerolog.Logger
 	statsCache            *TdarrLibStatsCache
 	partialFailure        atomic.Bool // set by getLibStats workers on per-library fetch error
 	unknownStatusMu       sync.Mutex
@@ -193,6 +197,7 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 		maxConcurrency:      runConfig.HttpMaxConcurrency,
 		api:                 api,
 		baseCtx:             context.Background(),
+		logger:              log.Logger,
 		statsCache:          NewTdarrLibStatsCache(),
 		unknownStatusCounts: make(map[unknownStatusKey]float64),
 		totalFilesMetric: newGauge(
@@ -318,7 +323,7 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 				"Distinct from prometheus built-in 'up' which indicates exporter process reachability.",
 			nil, instance,
 		),
-		nodeCollector: NewTdarrNodeCollector(runConfig, api),
+		nodeCollector: NewTdarrNodeCollector(runConfig, api, log.Logger),
 	}
 
 	// Assemble the collector's own descs once, in Describe order. Describe ranges over
@@ -372,7 +377,7 @@ func (c *TdarrCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *TdarrCollector) httpReqHelper(ctx context.Context, path string, reqPayload any, target any) error {
-	log.Debug().Interface("payload", reqPayload).Msg("Requesting statistics data from Tdarr")
+	c.logger.Debug().Interface("payload", reqPayload).Msg("Requesting statistics data from Tdarr")
 	// Marshal it into JSON prior to requesting
 	payload, err := json.Marshal(reqPayload)
 	if err != nil {
@@ -383,7 +388,7 @@ func (c *TdarrCollector) httpReqHelper(ctx context.Context, path string, reqPayl
 	if httpErr != nil {
 		return fmt.Errorf("request %s: %w: %w", path, ErrUpstream, httpErr)
 	}
-	log.Debug().Str("urlPath", path).Interface("payload", reqPayload).Interface("response", target).Msg("Stats API Response")
+	c.logger.Debug().Str("urlPath", path).Interface("payload", reqPayload).Interface("response", target).Msg("Stats API Response")
 	return nil
 }
 
@@ -401,10 +406,10 @@ func (c *TdarrCollector) getLibStats(ctx context.Context, wg *sync.WaitGroup, in
 	defer wg.Done()
 	for piePayload := range inChan {
 		pieMetric := &TdarrPieStats{}
-		log.Debug().Interface("payload", piePayload).Msg("Requesting Lib stats pie data from Tdarr")
+		c.logger.Debug().Interface("payload", piePayload).Msg("Requesting Lib stats pie data from Tdarr")
 		err := c.httpReqHelper(ctx, c.pieStatsPath, piePayload, pieMetric)
 		if err != nil {
-			log.Error().Interface("payload", piePayload).Err(err).Msg("Failed to get Lib stats pie data")
+			c.logger.Error().Interface("payload", piePayload).Err(err).Msg("Failed to get Lib stats pie data")
 			// Signal partial failure so Collect() can set tdarr_up=0.
 			// Previously-cached normalized data for this library is preserved (acceptable:
 			// last-known zero-padded series keep emitting while tdarr_up signals the issue).
@@ -419,7 +424,7 @@ func (c *TdarrCollector) getLibStats(ctx context.Context, wg *sync.WaitGroup, in
 		// response always populates _id and name for real libraries, so this
 		// branch should never fire — log loudly if it does.
 		if pieMetric.libraryId == "" || pieMetric.libraryName == "" {
-			log.Warn().
+			c.logger.Warn().
 				Str("libraryId", pieMetric.libraryId).
 				Str("libraryName", pieMetric.libraryName).
 				Msg("Tdarr returned library with empty id or name; dropping series")
@@ -496,7 +501,7 @@ func (c *TdarrCollector) Collect(ch chan<- prometheus.Metric) {
 	defer cancel()
 	err := c.collect(ctx, ch)
 	if err != nil {
-		log.Error().Err(err).Msg("Collection cycle failed")
+		c.logger.Error().Err(err).Msg("Collection cycle failed")
 	}
 	// Always reset partialFailure flag — must NOT short-circuit via OR or the flag leaks across scrapes.
 	partial := c.partialFailure.Swap(false)
@@ -542,7 +547,7 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 		return err
 	}
 
-	log.Debug().Int("totalFiles", metric.TotalFileCount).
+	c.logger.Debug().Int("totalFiles", metric.TotalFileCount).
 		Int("totalTranscodes", metric.TotalTranscodeCount).
 		Int("totalHealthChecks", metric.TotalHealthCheckCount).
 		Msg("General stats totals")
@@ -565,7 +570,7 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 	}
 
 	// supports only api versions: v2.24.01+
-	log.Debug().Str("path", c.pieStatsPath).Msg("Fetching library pie stats")
+	c.logger.Debug().Str("path", c.pieStatsPath).Msg("Fetching library pie stats")
 	// already have total file count from general stats (`metric.TotalFileCount`)
 	// check cache for all libraries data
 	// this won't block other reads when checking
@@ -578,11 +583,11 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 	// omit those fields; they decode to 0, so 0==0 never triggers a spurious refetch.
 	shouldCollect := shouldRefetch(cacheTotals, c.statsCache.GetLibStats() == nil, metric)
 	if shouldCollect {
-		log.Debug().Msg("Stats totals mismatch - re-fetching library pie stats")
+		c.logger.Debug().Msg("Stats totals mismatch - re-fetching library pie stats")
 	}
 	// if counts are the same use cache
 	if !shouldCollect {
-		log.Debug().Msg("Using cached library stats - api totals matches cached values")
+		c.logger.Debug().Msg("Using cached library stats - api totals matches cached values")
 		pieData = c.statsCache.GetLibStats()
 	} else { // fetch new data and update cache
 		getLibsPayload := getGeneralReqPayload("library")
@@ -593,7 +598,7 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 		}
 
 		pieData = c.fetchPies(ctx, allLibs)
-		log.Debug().Msg("All library stats gathered - setting cache")
+		c.logger.Debug().Msg("All library stats gathered - setting cache")
 		c.statsCache.SetLibStats(pieData)
 
 		// set totals here after all data is collected
@@ -683,11 +688,11 @@ func (c *TdarrCollector) emitPieMetrics(ch chan<- prometheus.Metric, pieData []*
 // emitParsedFloat parses raw as a float64 and, on success, emits a node-scoped gauge.
 // On parse failure it debug-logs and silently skips the metric (intentional: Tdarr may
 // send empty/non-numeric resource strings for nodes that haven't reported yet).
-func emitParsedFloat(ch chan<- prometheus.Metric, desc typedDesc, raw string, nodeId, nodeName string) {
+func (c *TdarrCollector) emitParsedFloat(ch chan<- prometheus.Metric, desc typedDesc, raw string, nodeId, nodeName string) {
 	if v, floatErr := strconv.ParseFloat(raw, 64); floatErr == nil {
 		ch <- desc.mustNewConstMetric(v, nodeId, nodeName)
 	} else {
-		log.Debug().Str("nodeId", nodeId).Str("nodeName", nodeName).
+		c.logger.Debug().Str("nodeId", nodeId).Str("nodeName", nodeName).
 			Str("raw", raw).Err(floatErr).Msg("Failed to parse node resource stat; skipping metric")
 	}
 }
@@ -711,11 +716,11 @@ func (c *TdarrCollector) emitNodeMetrics(ch chan<- prometheus.Metric, nodeData m
 			float64(node.ResourceStats.Process.Uptime), node.Id, node.Name)
 
 		// convert resource stats to float from string; skip on parse failure
-		emitParsedFloat(ch, m.nodeHeapUsedMb, node.ResourceStats.Process.HeapUsedMb, node.Id, node.Name)
-		emitParsedFloat(ch, m.nodeHeapTotalMb, node.ResourceStats.Process.HeapTotalMb, node.Id, node.Name)
-		emitParsedFloat(ch, m.nodeHostCpuPercent, node.ResourceStats.Os.CpuPercent, node.Id, node.Name)
-		emitParsedFloat(ch, m.nodeHostMemUsedGb, node.ResourceStats.Os.MemUsedGb, node.Id, node.Name)
-		emitParsedFloat(ch, m.nodeHostMemTotalGb, node.ResourceStats.Os.MemTotalGb, node.Id, node.Name)
+		c.emitParsedFloat(ch, m.nodeHeapUsedMb, node.ResourceStats.Process.HeapUsedMb, node.Id, node.Name)
+		c.emitParsedFloat(ch, m.nodeHeapTotalMb, node.ResourceStats.Process.HeapTotalMb, node.Id, node.Name)
+		c.emitParsedFloat(ch, m.nodeHostCpuPercent, node.ResourceStats.Os.CpuPercent, node.Id, node.Name)
+		c.emitParsedFloat(ch, m.nodeHostMemUsedGb, node.ResourceStats.Os.MemUsedGb, node.Id, node.Name)
+		c.emitParsedFloat(ch, m.nodeHostMemTotalGb, node.ResourceStats.Os.MemTotalGb, node.Id, node.Name)
 
 		// node state gauges
 		pausedVal := 0.0
@@ -746,13 +751,15 @@ func (c *TdarrCollector) emitNodeMetrics(ch chan<- prometheus.Metric, nodeData m
 			if count == 0 {
 				continue
 			}
+			c.logger.Warn().Str("workerType", rawType).Int("count", count).
+				Msg("Unknown worker type encountered; bucketing under 'unknown'")
 			ch <- m.nodeWorkerCount.mustNewConstMetric(
 				float64(count), node.Id, node.Name, rawType, computeTypeUnknown)
 		}
 
 		// per-worker metrics
 		for _, worker := range node.Workers {
-			log.Debug().Interface("worker", worker).Msg("Worker data")
+			c.logger.Debug().Interface("worker", worker).Msg("Worker data")
 
 			// plugin labels: empty strings for flow workers (no plugin step concept)
 			pluginId := worker.LastPluginDetails.Id
@@ -798,7 +805,7 @@ func (c *TdarrCollector) emitNodeMetrics(ch chan<- prometheus.Metric, nodeData m
 				ch <- m.nodeWorkerEtaSeconds.mustNewConstMetric(
 					float64(etaSecs), node.Id, node.Name, worker.Id)
 			} else {
-				log.Debug().Str("nodeId", node.Id).Str("workerId", worker.Id).
+				c.logger.Debug().Str("nodeId", node.Id).Str("workerId", worker.Id).
 					Str("eta", worker.Eta).Msg("Failed to parse worker ETA; skipping metric")
 			}
 		}

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -307,7 +307,13 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 // so a metric is described in exactly one place. TestDescribe_EmitsAllDescs guards the
 // count, since Prometheus does not flag a desc that silently drops out of Describe.
 func (c *TdarrCollector) Describe(ch chan<- *prometheus.Desc) {
-	for _, d := range append(c.descsList, c.nodeCollector.metrics.descs()...) {
+	// Range over the two sources separately rather than append()-ing them into one
+	// slice: appending to c.descsList could alias/overwrite its backing array if it
+	// ever had spare capacity. Two loops are allocation-free and alias-free.
+	for _, d := range c.descsList {
+		ch <- d
+	}
+	for _, d := range c.nodeCollector.metrics.descs() {
 		ch <- d
 	}
 }
@@ -406,10 +412,11 @@ func (c *TdarrCollector) fetchPies(allLibs []TdarrLibraryInfo) []*TdarrPieStats 
 	// close channel to signal workers to stop
 	close(inChan)
 
-	// wait for workers to finish
-	dataWg.Wait()
-
-	// collect results
+	// Drain results concurrently with the workers. Starting the drain before
+	// dataWg.Wait() means correctness no longer depends on outChan being buffered
+	// to len(allLibs): even with a smaller (or unbuffered) outChan, workers never
+	// block on send because the drain is always consuming. pieData is written only
+	// by this goroutine and read only after resultWg.Wait(), so there is no race.
 	resultWg := &sync.WaitGroup{}
 	resultWg.Add(1)
 	go func() {
@@ -419,7 +426,8 @@ func (c *TdarrCollector) fetchPies(allLibs []TdarrLibraryInfo) []*TdarrPieStats 
 		}
 	}()
 
-	// close channel no longer needed
+	// wait for workers to finish producing, then close outChan to stop the drain
+	dataWg.Wait()
 	close(outChan)
 
 	// wait for results to be collected
@@ -505,10 +513,11 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 	// this won't block other reads when checking
 	cacheTotals := c.statsCache.GetTotals()
 	// Refetch if the cache is empty (first run) or any of the 10 totals changed.
-	// table0Count–table6Count cover every per-bucket state transition (e.g. files queued
-	// but not yet transcoded), catching invalidation cases the three top-level counts miss.
-	// Older Tdarr versions that omit tableXCount fields decode to 0; 0==0 means no spurious
-	// refetches — behavior degrades gracefully to original 3-totals logic.
+	// Beyond the three top-level counts, the seven per-bucket queue fields
+	// (holdQueue/transcodeQueue/… on TdarrMetric) catch state transitions the totals miss
+	// (e.g. files queued but not yet transcoded). Their Tdarr JSON source (table0Count–table6Count)
+	// and bucket meanings are documented on TdarrMetric in tdarr_models.go. Older Tdarr versions
+	// omit those fields; they decode to 0, so 0==0 never triggers a spurious refetch.
 	shouldCollect := shouldRefetch(cacheTotals, c.statsCache.GetLibStats() == nil, metric)
 	if shouldCollect {
 		log.Debug().Msg("Stats totals mismatch - re-fetching library pie stats")

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -13,9 +13,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var (
-	METRIC_PREFIX = "tdarr"
-)
+const METRIC_PREFIX = "tdarr"
 
 // newDesc builds a *prometheus.Desc with the METRIC_PREFIX-prefixed fqName and the
 // shared const instance label. It collapses the repeated NewDesc/BuildFQName boilerplate
@@ -28,8 +26,8 @@ func newDesc(name, help string, varLabels []string, instance prometheus.Labels) 
 // satisfies it directly; tests inject an in-memory fake instead of a real client
 // plus httptest server.
 type tdarrAPI interface {
-	DoRequest(path string, target interface{}, queryParams ...client.QueryParams) error
-	DoPostRequest(path string, target interface{}, payload []byte) error
+	DoRequest(path string, target any, queryParams ...client.QueryParams) error
+	DoPostRequest(path string, target any, payload []byte) error
 }
 
 // unknownStatusKey identifies a unique (kind, status) pair for the unknown-status counter.
@@ -306,7 +304,7 @@ func (c *TdarrCollector) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
-func (c *TdarrCollector) httpReqHelper(path string, reqPayload interface{}, target interface{}) error {
+func (c *TdarrCollector) httpReqHelper(path string, reqPayload any, target any) error {
 	log.Debug().Interface("payload", reqPayload).Msg("Requesting statistics data from Tdarr")
 	// Marshal it into JSON prior to requesting
 	payload, err := json.Marshal(reqPayload)
@@ -741,7 +739,7 @@ func getGeneralReqPayload(payloadRequestType string) TdarrMetricRequest {
 				Collection: "LibrarySettingsJSONDB",
 				Mode:       "getAll",
 				DocId:      "",
-				Obj:        map[string]interface{}{},
+				Obj:        map[string]any{},
 			},
 		}
 	} else {
@@ -750,7 +748,7 @@ func getGeneralReqPayload(payloadRequestType string) TdarrMetricRequest {
 				Collection: "StatisticsJSONDB",
 				Mode:       "getById",
 				DocId:      "statistics",
-				Obj:        map[string]interface{}{},
+				Obj:        map[string]any{},
 			},
 		}
 	}

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -115,7 +115,6 @@ type TdarrCollector struct {
 	pieVideoResolutions   typedDesc
 	pieAudioCodecs        typedDesc
 	pieAudioContainers    typedDesc
-	pieAudioResolutions   typedDesc
 	unknownStatusTotal    typedDesc           // counter for status values not in known enum
 	nodeCollector         *TdarrNodeCollector // node data
 	upMetric              typedDesc
@@ -305,11 +304,6 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 			"Tdarr audio containers for library by type",
 			[]string{"library_name", "library_id", "container_type"}, instance,
 		),
-		pieAudioResolutions: newGauge(
-			"library_audio_resolutions",
-			"Tdarr audio resolutions for library by type",
-			[]string{"library_name", "library_id", "resolution"}, instance,
-		),
 		unknownStatusTotal: newCounter(
 			"unknown_status_total",
 			"Count of pie status values not in the known enum, by job_kind (transcode|healthcheck) and status label. "+
@@ -351,7 +345,6 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 		c.pieVideoResolutions,
 		c.pieAudioCodecs,
 		c.pieAudioContainers,
-		c.pieAudioResolutions,
 		c.unknownStatusTotal,
 		c.upMetric,
 	}
@@ -681,7 +674,6 @@ func (c *TdarrCollector) emitPieMetrics(ch chan<- prometheus.Metric, pieData []*
 		emitPieSlices(ch, c.pieVideoResolutions, pie.libraryName, pie.libraryId, pie.PieStats.Video.Resolutions)
 		emitPieSlices(ch, c.pieAudioCodecs, pie.libraryName, pie.libraryId, pie.PieStats.Audio.Codecs)
 		emitPieSlices(ch, c.pieAudioContainers, pie.libraryName, pie.libraryId, pie.PieStats.Audio.Containers)
-		emitPieSlices(ch, c.pieAudioResolutions, pie.libraryName, pie.libraryId, pie.PieStats.Audio.Resolutions)
 	}
 }
 

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -63,8 +64,8 @@ func newCounter(name, help string, varLabels []string, instance prometheus.Label
 // satisfies it directly; tests inject an in-memory fake instead of a real client
 // plus httptest server.
 type tdarrAPI interface {
-	DoRequest(path string, target any, queryParams ...client.QueryParams) error
-	DoPostRequest(path string, target any, payload []byte) error
+	DoRequest(ctx context.Context, path string, target any, queryParams ...client.QueryParams) error
+	DoPostRequest(ctx context.Context, path string, target any, payload []byte) error
 }
 
 // unknownStatusKey identifies a unique (kind, status) pair for the unknown-status counter.
@@ -77,10 +78,14 @@ type TdarrCollector struct {
 	// Only the config values read at collect time are stored, not the whole
 	// config.Config bag — the URL/SSL/timeout/api-key and instance label are
 	// consumed once in the constructor (client + descs) and never needed again.
-	statsPath             string
-	pieStatsPath          string
-	maxConcurrency        int
-	api                   tdarrAPI // shared HTTP client, built once in the constructor
+	statsPath      string
+	pieStatsPath   string
+	maxConcurrency int
+	api            tdarrAPI // shared HTTP client, built once in the constructor
+	// baseCtx is the parent context for every scrape's HTTP requests. main wires in
+	// a context cancelled on shutdown so in-flight scrapes abort promptly; tests and
+	// the WithAPI constructor default it to context.Background().
+	baseCtx               context.Context
 	statsCache            *TdarrLibStatsCache
 	partialFailure        atomic.Bool // set by getLibStats workers on per-library fetch error
 	unknownStatusMu       sync.Mutex
@@ -162,14 +167,18 @@ func (c *TdarrLibStatsCache) SetLibStats(stats []*TdarrPieStats) {
 // into both the top-level collector and the embedded node collector. The client is
 // surfaced as a tdarrAPI; the error from client.NewRequestClient is propagated so the
 // composition root (main) can fail fast on a bad URL.
-func NewTdarrCollector(runConfig config.Config) (*TdarrCollector, error) {
+func NewTdarrCollector(ctx context.Context, runConfig config.Config) (*TdarrCollector, error) {
 	api, err := client.NewRequestClient(runConfig.UrlParsed, runConfig.VerifySsl, runConfig.HttpTimeoutSeconds, runConfig.ApiKey)
 	if err != nil {
 		log.Error().
 			Err(err).Msg("Failed to create http request client for Tdarr, ensure proper URL is provided")
 		return nil, err
 	}
-	return newTdarrCollectorWithAPI(runConfig, api), nil
+	c := newTdarrCollectorWithAPI(runConfig, api)
+	// Wire the shutdown-cancellable context from the composition root so a scrape
+	// in flight when the process is terminating aborts instead of running to completion.
+	c.baseCtx = ctx
+	return c, nil
 }
 
 // newTdarrCollectorWithAPI is the test-injection seam: it builds a fully wired
@@ -183,6 +192,7 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 		pieStatsPath:        runConfig.TdarrPieStatsPath,
 		maxConcurrency:      runConfig.HttpMaxConcurrency,
 		api:                 api,
+		baseCtx:             context.Background(),
 		statsCache:          NewTdarrLibStatsCache(),
 		unknownStatusCounts: make(map[unknownStatusKey]float64),
 		totalFilesMetric: newGauge(
@@ -361,7 +371,7 @@ func (c *TdarrCollector) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
-func (c *TdarrCollector) httpReqHelper(path string, reqPayload any, target any) error {
+func (c *TdarrCollector) httpReqHelper(ctx context.Context, path string, reqPayload any, target any) error {
 	log.Debug().Interface("payload", reqPayload).Msg("Requesting statistics data from Tdarr")
 	// Marshal it into JSON prior to requesting
 	payload, err := json.Marshal(reqPayload)
@@ -369,7 +379,7 @@ func (c *TdarrCollector) httpReqHelper(path string, reqPayload any, target any) 
 		return fmt.Errorf("marshal payload: %w: %w", ErrParse, err)
 	}
 	// make request
-	httpErr := c.api.DoPostRequest(path, target, payload)
+	httpErr := c.api.DoPostRequest(ctx, path, target, payload)
 	if httpErr != nil {
 		return fmt.Errorf("request %s: %w: %w", path, ErrUpstream, httpErr)
 	}
@@ -387,12 +397,12 @@ func (c *TdarrCollector) bumpUnknownStatus(kind, status string) {
 }
 
 // support concurrency
-func (c *TdarrCollector) getLibStats(wg *sync.WaitGroup, inChan <-chan TdarrPieDataRequest, outChan chan<- *TdarrPieStats) {
+func (c *TdarrCollector) getLibStats(ctx context.Context, wg *sync.WaitGroup, inChan <-chan TdarrPieDataRequest, outChan chan<- *TdarrPieStats) {
 	defer wg.Done()
 	for piePayload := range inChan {
 		pieMetric := &TdarrPieStats{}
 		log.Debug().Interface("payload", piePayload).Msg("Requesting Lib stats pie data from Tdarr")
-		err := c.httpReqHelper(c.pieStatsPath, piePayload, pieMetric)
+		err := c.httpReqHelper(ctx, c.pieStatsPath, piePayload, pieMetric)
 		if err != nil {
 			log.Error().Interface("payload", piePayload).Err(err).Msg("Failed to get Lib stats pie data")
 			// Signal partial failure so Collect() can set tdarr_up=0.
@@ -427,7 +437,7 @@ func (c *TdarrCollector) getLibStats(wg *sync.WaitGroup, inChan <-chan TdarrPieD
 // fans the results back in. Per-library fetch failures are handled inside getLibStats
 // (it sets partialFailure and skips that library), so this returns only the gathered
 // pie stats — the same set collect() previously assembled inline before caching.
-func (c *TdarrCollector) fetchPies(allLibs []TdarrLibraryInfo) []*TdarrPieStats {
+func (c *TdarrCollector) fetchPies(ctx context.Context, allLibs []TdarrLibraryInfo) []*TdarrPieStats {
 	var pieData []*TdarrPieStats
 
 	dataWg := &sync.WaitGroup{}
@@ -436,7 +446,7 @@ func (c *TdarrCollector) fetchPies(allLibs []TdarrLibraryInfo) []*TdarrPieStats 
 	// start workers
 	for i := 0; i < c.maxConcurrency; i++ {
 		dataWg.Add(1)
-		go c.getLibStats(dataWg, inChan, outChan)
+		go c.getLibStats(ctx, dataWg, inChan, outChan)
 	}
 
 	// send data to workers
@@ -479,7 +489,12 @@ func (c *TdarrCollector) fetchPies(allLibs []TdarrLibraryInfo) []*TdarrPieStats 
 }
 
 func (c *TdarrCollector) Collect(ch chan<- prometheus.Metric) {
-	err := c.collect(ch)
+	// Derive a per-scrape context from baseCtx (cancelled on shutdown). The defer
+	// releases the context tree when the scrape returns; if baseCtx is cancelled
+	// mid-scrape, the in-flight HTTP requests abort.
+	ctx, cancel := context.WithCancel(c.baseCtx)
+	defer cancel()
+	err := c.collect(ctx, ch)
 	if err != nil {
 		log.Error().Err(err).Msg("Collection cycle failed")
 	}
@@ -518,11 +533,11 @@ func shouldRefetch(cached tdarrCacheTotals, libStatsNil bool, metric *TdarrMetri
 	return libStatsNil || cached != totalsFromMetric(metric)
 }
 
-func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
+func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) error {
 	// get server metrics
 	metricReqBody := getGeneralReqPayload("")
 	metric := &TdarrMetric{}
-	err := c.httpReqHelper(c.statsPath, metricReqBody, &metric)
+	err := c.httpReqHelper(ctx, c.statsPath, metricReqBody, &metric)
 	if err != nil {
 		return err
 	}
@@ -572,12 +587,12 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 	} else { // fetch new data and update cache
 		getLibsPayload := getGeneralReqPayload("library")
 		allLibs := []TdarrLibraryInfo{}
-		err := c.httpReqHelper(c.statsPath, getLibsPayload, &allLibs)
+		err := c.httpReqHelper(ctx, c.statsPath, getLibsPayload, &allLibs)
 		if err != nil {
 			return fmt.Errorf("get library details: %w", err)
 		}
 
-		pieData = c.fetchPies(allLibs)
+		pieData = c.fetchPies(ctx, allLibs)
 		log.Debug().Msg("All library stats gathered - setting cache")
 		c.statsCache.SetLibStats(pieData)
 
@@ -599,7 +614,7 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 	c.unknownStatusMu.Unlock()
 
 	// get all node metrics
-	nodeData, err := c.nodeCollector.GetNodeData()
+	nodeData, err := c.nodeCollector.GetNodeData(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -309,15 +310,12 @@ func (c *TdarrCollector) httpReqHelper(path string, reqPayload any, target any) 
 	// Marshal it into JSON prior to requesting
 	payload, err := json.Marshal(reqPayload)
 	if err != nil {
-		log.Error().Err(err).Interface("payload", reqPayload).
-			Msg("Failed to marshal payload for statistics request")
-		return err
+		return fmt.Errorf("marshal payload: %w", err)
 	}
 	// make request
 	httpErr := c.api.DoPostRequest(path, target, payload)
 	if httpErr != nil {
-		log.Error().Str("urlPath", path).Interface("payload", reqPayload).Err(httpErr).Msg("Failed to get data for Tdarr exporter")
-		return httpErr
+		return fmt.Errorf("request %s failed: %w", path, httpErr)
 	}
 	log.Debug().Str("urlPath", path).Interface("payload", reqPayload).Interface("response", target).Msg("Stats API Response")
 	return nil
@@ -424,6 +422,9 @@ func (c *TdarrCollector) fetchPies(allLibs []TdarrLibraryInfo) []*TdarrPieStats 
 
 func (c *TdarrCollector) Collect(ch chan<- prometheus.Metric) {
 	err := c.collect(ch)
+	if err != nil {
+		log.Error().Err(err).Msg("Collection cycle failed")
+	}
 	// Always reset partialFailure flag — must NOT short-circuit via OR or the flag leaks across scrapes.
 	partial := c.partialFailure.Swap(false)
 	v := 1.0
@@ -483,13 +484,11 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 
 	score, floatConvertErr = strconv.ParseFloat(metric.TdarrScore, 64)
 	if floatConvertErr != nil {
-		log.Error().Str("tdarrScoreStr", metric.TdarrScore).Err(floatConvertErr).Msg("Failed to convert a tdarr score to float")
-		return floatConvertErr
+		return fmt.Errorf("parse tdarr score %q: %w", metric.TdarrScore, floatConvertErr)
 	}
 	healthScore, floatConvertErr = strconv.ParseFloat(metric.HealthCheckScore, 64)
 	if floatConvertErr != nil {
-		log.Error().Str("healthCodeStr", metric.HealthCheckScore).Err(floatConvertErr).Msg("Failed to convert a health score to float")
-		return floatConvertErr
+		return fmt.Errorf("parse health score %q: %w", metric.HealthCheckScore, floatConvertErr)
 	}
 
 	// supports only api versions: v2.24.01+
@@ -516,8 +515,7 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 		allLibs := []TdarrLibraryInfo{}
 		err := c.httpReqHelper(c.config.TdarrStatsPath, getLibsPayload, &allLibs)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to get library details")
-			return err
+			return fmt.Errorf("get library details: %w", err)
 		}
 
 		pieData = c.fetchPies(allLibs)

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -15,6 +16,19 @@ import (
 )
 
 const METRIC_PREFIX = "tdarr"
+
+// Sentinel categories for collection failures so callers and tests can branch
+// on the cause with errors.Is instead of matching error strings. Boundary errors
+// wrap one of these alongside the underlying cause (via multi-%w), so the original
+// error chain (e.g. a transport or JSON error) stays inspectable.
+var (
+	// ErrUpstream marks a failure talking to the Tdarr API: request construction,
+	// transport, a non-2xx status, or an unreadable/undecodable response body.
+	ErrUpstream = errors.New("tdarr upstream request failed")
+	// ErrParse marks a failure interpreting an otherwise-successful response:
+	// payload marshalling or a numeric field that could not be converted.
+	ErrParse = errors.New("tdarr response parse failed")
+)
 
 // buildDesc builds a *prometheus.Desc with the METRIC_PREFIX-prefixed fqName and the
 // shared const instance label. It collapses the repeated NewDesc/BuildFQName boilerplate
@@ -352,12 +366,12 @@ func (c *TdarrCollector) httpReqHelper(path string, reqPayload any, target any) 
 	// Marshal it into JSON prior to requesting
 	payload, err := json.Marshal(reqPayload)
 	if err != nil {
-		return fmt.Errorf("marshal payload: %w", err)
+		return fmt.Errorf("marshal payload: %w: %w", ErrParse, err)
 	}
 	// make request
 	httpErr := c.api.DoPostRequest(path, target, payload)
 	if httpErr != nil {
-		return fmt.Errorf("request %s failed: %w", path, httpErr)
+		return fmt.Errorf("request %s: %w: %w", path, ErrUpstream, httpErr)
 	}
 	log.Debug().Str("urlPath", path).Interface("payload", reqPayload).Interface("response", target).Msg("Stats API Response")
 	return nil
@@ -528,11 +542,11 @@ func (c *TdarrCollector) collect(ch chan<- prometheus.Metric) error {
 
 	score, floatConvertErr = strconv.ParseFloat(metric.TdarrScore, 64)
 	if floatConvertErr != nil {
-		return fmt.Errorf("parse tdarr score %q: %w", metric.TdarrScore, floatConvertErr)
+		return fmt.Errorf("parse tdarr score %q: %w: %w", metric.TdarrScore, ErrParse, floatConvertErr)
 	}
 	healthScore, floatConvertErr = strconv.ParseFloat(metric.HealthCheckScore, 64)
 	if floatConvertErr != nil {
-		return fmt.Errorf("parse health score %q: %w", metric.HealthCheckScore, floatConvertErr)
+		return fmt.Errorf("parse health score %q: %w: %w", metric.HealthCheckScore, ErrParse, floatConvertErr)
 	}
 
 	// supports only api versions: v2.24.01+

--- a/internal/collector/tdarr_emit_test.go
+++ b/internal/collector/tdarr_emit_test.go
@@ -292,9 +292,8 @@ func TestEmitPieMetrics(t *testing.T) {
 				Resolutions: []TdarrPieSlice{{Name: "1080P", Value: 2}},
 			},
 			Audio: TdarrPieVideoSlice{
-				Codecs:      []TdarrPieSlice{{Name: "AAC", Value: 8}, {Name: "FLAC", Value: 1}},
-				Containers:  []TdarrPieSlice{{Name: "M4A", Value: 6}},
-				Resolutions: []TdarrPieSlice{{Name: "1080P", Value: 9}},
+				Codecs:     []TdarrPieSlice{{Name: "AAC", Value: 8}, {Name: "FLAC", Value: 1}},
+				Containers: []TdarrPieSlice{{Name: "M4A", Value: 6}},
 			},
 		},
 		NormalizedTranscodes:   map[string]int{"success": 5, "queued": 0},
@@ -344,10 +343,6 @@ func TestEmitPieMetrics(t *testing.T) {
 	if got := findOne(t, samples, "tdarr_library_audio_containers",
 		map[string]string{"library_id": "lib-audio-01", "container_type": "m4a"}).value; got != 6 {
 		t.Errorf("audio_containers{m4a} = %v, want 6", got)
-	}
-	if got := findOne(t, samples, "tdarr_library_audio_resolutions",
-		map[string]string{"library_id": "lib-audio-01", "resolution": "1080p"}).value; got != 9 {
-		t.Errorf("audio_resolutions{1080p} = %v, want 9", got)
 	}
 
 	// const instance label is propagated

--- a/internal/collector/tdarr_emit_test.go
+++ b/internal/collector/tdarr_emit_test.go
@@ -1,0 +1,572 @@
+package collector
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// sample is a flattened view of one emitted prometheus.Metric: the descriptor's
+// fqName, its label set (name->value, including the const tdarr_instance label), and
+// the numeric value. It lets table tests assert the full emitted series set without
+// depending on emission order.
+type sample struct {
+	fqName string
+	labels map[string]string
+	value  float64
+}
+
+// drain converts the metrics sent to ch (the channel must already be closed) into
+// flattened samples. fqName is parsed out of the Desc string since *prometheus.Desc
+// exposes no public fqName accessor.
+func drain(t *testing.T, ch <-chan prometheus.Metric) []sample {
+	t.Helper()
+	var out []sample
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		labels := map[string]string{}
+		for _, lp := range pb.GetLabel() {
+			labels[lp.GetName()] = lp.GetValue()
+		}
+		var val float64
+		switch {
+		case pb.GetGauge() != nil:
+			val = pb.GetGauge().GetValue()
+		case pb.GetCounter() != nil:
+			val = pb.GetCounter().GetValue()
+		default:
+			t.Fatalf("unexpected metric type for %s", m.Desc().String())
+		}
+		out = append(out, sample{
+			fqName: fqNameFromDesc(m.Desc().String()),
+			labels: labels,
+			value:  val,
+		})
+	}
+	return out
+}
+
+// fqNameFromDesc extracts the fqName from a Desc.String() rendering, which looks like:
+//
+//	Desc{fqName: "tdarr_files_total", help: "...", ...}
+func fqNameFromDesc(desc string) string {
+	const marker = `fqName: "`
+	i := len(marker)
+	start := indexOf(desc, marker)
+	if start < 0 {
+		return desc
+	}
+	rest := desc[start+i:]
+	end := indexOf(rest, `"`)
+	if end < 0 {
+		return desc
+	}
+	return rest[:end]
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// collectSamples runs emit fn against a buffered channel, closes it, and drains.
+func collectSamples(t *testing.T, emit func(ch chan<- prometheus.Metric)) []sample {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 512)
+	emit(ch)
+	close(ch)
+	return drain(t, ch)
+}
+
+// countByName returns how many samples carry the given fqName.
+func countByName(samples []sample, fqName string) int {
+	n := 0
+	for _, s := range samples {
+		if s.fqName == fqName {
+			n++
+		}
+	}
+	return n
+}
+
+// findOne returns the single sample matching fqName and the given label subset.
+// Fails if zero or more than one match (forces tests to pin an exact series).
+func findOne(t *testing.T, samples []sample, fqName string, wantLabels map[string]string) sample {
+	t.Helper()
+	var matches []sample
+	for _, s := range samples {
+		if s.fqName != fqName {
+			continue
+		}
+		ok := true
+		for k, v := range wantLabels {
+			if s.labels[k] != v {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			matches = append(matches, s)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("findOne(%s, %v): want exactly 1 match, got %d", fqName, wantLabels, len(matches))
+	}
+	return matches[0]
+}
+
+// hasName returns true if any sample carries fqName.
+func hasName(samples []sample, fqName string) bool {
+	return countByName(samples, fqName) > 0
+}
+
+// --- shouldRefetch / totalsFromMetric ----------------------------------------
+
+func TestShouldRefetch(t *testing.T) {
+	t.Parallel()
+
+	// base metric whose totals exactly match the cached struct below.
+	base := &TdarrMetric{
+		TotalFileCount:        100,
+		TotalTranscodeCount:   40,
+		TotalHealthCheckCount: 30,
+		HoldQueue:             1,
+		TranscodeQueue:        2,
+		TranscodeSuccess:      3,
+		TranscodeFailed:       4,
+		HealthCheckQueue:      5,
+		HealthCheckSuccess:    6,
+		HealthCheckFailed:     7,
+	}
+	matchingCache := totalsFromMetric(base)
+
+	// mutate returns a copy of base with one field changed, to prove every field
+	// participates in the refetch decision.
+	mutate := func(f func(m *TdarrMetric)) *TdarrMetric {
+		cp := *base
+		f(&cp)
+		return &cp
+	}
+
+	tests := []struct {
+		name        string
+		cached      tdarrCacheTotals
+		libStatsNil bool
+		metric      *TdarrMetric
+		want        bool
+	}{
+		{
+			name:        "empty cache (libStatsNil) forces refetch even when totals match",
+			cached:      matchingCache,
+			libStatsNil: true,
+			metric:      base,
+			want:        true,
+		},
+		{
+			name:        "totals match and cache populated -> no refetch",
+			cached:      matchingCache,
+			libStatsNil: false,
+			metric:      base,
+			want:        false,
+		},
+		{
+			name:        "zero cache vs zero metric -> no refetch (graceful degradation)",
+			cached:      tdarrCacheTotals{},
+			libStatsNil: false,
+			metric:      &TdarrMetric{},
+			want:        false,
+		},
+		{
+			name:        "totalFileCount changed -> refetch",
+			cached:      matchingCache,
+			libStatsNil: false,
+			metric:      mutate(func(m *TdarrMetric) { m.TotalFileCount = 101 }),
+			want:        true,
+		},
+		{
+			name:        "totalTranscodeCount changed -> refetch",
+			cached:      matchingCache,
+			libStatsNil: false,
+			metric:      mutate(func(m *TdarrMetric) { m.TotalTranscodeCount = 41 }),
+			want:        true,
+		},
+		{
+			name:        "totalHealthCheckCount changed -> refetch",
+			cached:      matchingCache,
+			libStatsNil: false,
+			metric:      mutate(func(m *TdarrMetric) { m.TotalHealthCheckCount = 31 }),
+			want:        true,
+		},
+		{
+			name:        "table0Count (holdQueue) changed -> refetch",
+			cached:      matchingCache,
+			libStatsNil: false,
+			metric:      mutate(func(m *TdarrMetric) { m.HoldQueue = 99 }),
+			want:        true,
+		},
+		{
+			name:        "table1Count (transcodeQueue) changed -> refetch",
+			cached:      matchingCache,
+			libStatsNil: false,
+			metric:      mutate(func(m *TdarrMetric) { m.TranscodeQueue = 99 }),
+			want:        true,
+		},
+		{
+			name:        "table6Count (healthCheckFailed) changed -> refetch",
+			cached:      matchingCache,
+			libStatsNil: false,
+			metric:      mutate(func(m *TdarrMetric) { m.HealthCheckFailed = 99 }),
+			want:        true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldRefetch(tc.cached, tc.libStatsNil, tc.metric); got != tc.want {
+				t.Errorf("shouldRefetch = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTotalsFromMetric(t *testing.T) {
+	t.Parallel()
+	metric := &TdarrMetric{
+		TotalFileCount:        11,
+		TotalTranscodeCount:   22,
+		TotalHealthCheckCount: 33,
+		HoldQueue:             44,
+		TranscodeQueue:        55,
+		TranscodeSuccess:      66,
+		TranscodeFailed:       77,
+		HealthCheckQueue:      88,
+		HealthCheckSuccess:    99,
+		HealthCheckFailed:     110,
+	}
+	want := tdarrCacheTotals{
+		totalFileCount:        11,
+		totalTranscodeCount:   22,
+		totalHealthCheckCount: 33,
+		holdQueue:             44,
+		transcodeQueue:        55,
+		transcodeSuccess:      66,
+		transcodeFailed:       77,
+		healthCheckQueue:      88,
+		healthCheckSuccess:    99,
+		healthCheckFailed:     110,
+	}
+	if got := totalsFromMetric(metric); got != want {
+		t.Errorf("totalsFromMetric mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// --- emitPieSlices / emitPieMetrics ------------------------------------------
+
+func TestEmitPieMetrics(t *testing.T) {
+	t.Parallel()
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, newSuccessFakeAPI(cfg))
+
+	pie := &TdarrPieStats{
+		libraryName: "Music",
+		libraryId:   "lib-audio-01",
+		PieStats: TdarrPieStat{
+			TotalFiles:            12,
+			TotalTranscodeCount:   5,
+			TotalHealthCheckCount: 3,
+			SizeDiff:              -1.5,
+			Video: TdarrPieVideoSlice{
+				Codecs:      []TdarrPieSlice{{Name: "H264", Value: 7}},
+				Containers:  []TdarrPieSlice{{Name: "MKV", Value: 4}},
+				Resolutions: []TdarrPieSlice{{Name: "1080P", Value: 2}},
+			},
+			Audio: TdarrPieVideoSlice{
+				Codecs:     []TdarrPieSlice{{Name: "AAC", Value: 8}, {Name: "FLAC", Value: 1}},
+				Containers: []TdarrPieSlice{{Name: "M4A", Value: 6}},
+			},
+		},
+		NormalizedTranscodes:   map[string]int{"success": 5, "queued": 0},
+		NormalizedHealthChecks: map[string]int{"success": 3},
+	}
+
+	samples := collectSamples(t, func(ch chan<- prometheus.Metric) {
+		c.emitPieMetrics(ch, []*TdarrPieStats{pie})
+	})
+
+	// totals
+	if got := findOne(t, samples, "tdarr_library_files_total",
+		map[string]string{"library_name": "Music", "library_id": "lib-audio-01"}).value; got != 12 {
+		t.Errorf("files_total = %v, want 12", got)
+	}
+	if got := findOne(t, samples, "tdarr_library_size_diff_gb",
+		map[string]string{"library_id": "lib-audio-01"}).value; got != -1.5 {
+		t.Errorf("size_diff = %v, want -1.5", got)
+	}
+
+	// normalized status maps emit one series per key
+	if n := countByName(samples, "tdarr_library_transcodes"); n != 2 {
+		t.Errorf("library_transcodes series count = %d, want 2", n)
+	}
+	if got := findOne(t, samples, "tdarr_library_transcodes",
+		map[string]string{"library_id": "lib-audio-01", "status": "success"}).value; got != 5 {
+		t.Errorf("transcodes{success} = %v, want 5", got)
+	}
+	if got := findOne(t, samples, "tdarr_library_health_checks",
+		map[string]string{"library_id": "lib-audio-01", "status": "success"}).value; got != 3 {
+		t.Errorf("health_checks{success} = %v, want 3", got)
+	}
+
+	// slice labels are lowercased
+	if got := findOne(t, samples, "tdarr_library_video_codecs",
+		map[string]string{"library_id": "lib-audio-01", "codec": "h264"}).value; got != 7 {
+		t.Errorf("video_codecs{h264} = %v, want 7", got)
+	}
+	if got := findOne(t, samples, "tdarr_library_video_resolutions",
+		map[string]string{"library_id": "lib-audio-01", "resolution": "1080p"}).value; got != 2 {
+		t.Errorf("video_resolutions{1080p} = %v, want 2", got)
+	}
+	if got := findOne(t, samples, "tdarr_library_audio_codecs",
+		map[string]string{"library_id": "lib-audio-01", "codec": "flac"}).value; got != 1 {
+		t.Errorf("audio_codecs{flac} = %v, want 1", got)
+	}
+	if got := findOne(t, samples, "tdarr_library_audio_containers",
+		map[string]string{"library_id": "lib-audio-01", "container_type": "m4a"}).value; got != 6 {
+		t.Errorf("audio_containers{m4a} = %v, want 6", got)
+	}
+
+	// const instance label is propagated
+	s := findOne(t, samples, "tdarr_library_files_total",
+		map[string]string{"library_id": "lib-audio-01"})
+	if s.labels["tdarr_instance"] != "test-instance" {
+		t.Errorf("tdarr_instance label = %q, want test-instance", s.labels["tdarr_instance"])
+	}
+}
+
+func TestEmitPieSlices_LowercasesNames(t *testing.T) {
+	t.Parallel()
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, newSuccessFakeAPI(cfg))
+
+	slices := []TdarrPieSlice{{Name: "HEVC", Value: 3}, {Name: "Av1", Value: 9}}
+	samples := collectSamples(t, func(ch chan<- prometheus.Metric) {
+		emitPieSlices(ch, c.pieVideoCodecs, "Shows", "lib-video-01", slices)
+	})
+
+	if len(samples) != 2 {
+		t.Fatalf("want 2 samples, got %d", len(samples))
+	}
+	var gotNames []string
+	for _, s := range samples {
+		gotNames = append(gotNames, s.labels["codec"])
+		if s.labels["library_name"] != "Shows" || s.labels["library_id"] != "lib-video-01" {
+			t.Errorf("unexpected library labels: %v", s.labels)
+		}
+	}
+	sort.Strings(gotNames)
+	if gotNames[0] != "av1" || gotNames[1] != "hevc" {
+		t.Errorf("codec labels = %v, want lowercased [av1 hevc]", gotNames)
+	}
+	if got := findOne(t, samples, "tdarr_library_video_codecs",
+		map[string]string{"codec": "hevc"}).value; got != 3 {
+		t.Errorf("value for hevc = %v, want 3", got)
+	}
+}
+
+// --- emitNodeMetrics ----------------------------------------------------------
+
+func TestEmitNodeMetrics(t *testing.T) {
+	t.Parallel()
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, newSuccessFakeAPI(cfg))
+
+	busy := TdarrNode{
+		Id:   "node-busy",
+		Name: "BusyNode",
+		ResourceStats: TdarrResourceStats{
+			Process: struct {
+				Uptime      int64  `json:"uptime"`
+				HeapUsedMb  string `json:"heapUsedMB"`
+				HeapTotalMb string `json:"heapTotalMB"`
+			}{Uptime: 3600, HeapUsedMb: "128.5", HeapTotalMb: "256.0"},
+			Os: struct {
+				CpuPercent string `json:"cpuPerc"`
+				MemUsedGb  string `json:"memUsedGB"`
+				MemTotalGb string `json:"memTotalGB"`
+			}{CpuPercent: "42.0", MemUsedGb: "8.0", MemTotalGb: "16.0"},
+		},
+		Workers: map[string]TdarrNodeWorkers{
+			"w1": {
+				Id:                 "w1",
+				WorkerType:         "transcodecpu",
+				Percentage:         55.5,
+				Fps:                24,
+				OriginalfileSizeGb: 2.0,
+				OutputFileSizeGb:   1.0,
+				EstSizeGb:          1.2,
+				Status:             "processing",
+				File:               "movie.mkv",
+				Eta:                "0:30:00",
+			},
+		},
+	}
+
+	idle := TdarrNode{
+		Id:   "node-idle",
+		Name: "IdleNode",
+		ResourceStats: TdarrResourceStats{
+			Process: struct {
+				Uptime      int64  `json:"uptime"`
+				HeapUsedMb  string `json:"heapUsedMB"`
+				HeapTotalMb string `json:"heapTotalMB"`
+			}{Uptime: 10, HeapUsedMb: "not-a-number", HeapTotalMb: "64.0"},
+			Os: struct {
+				CpuPercent string `json:"cpuPerc"`
+				MemUsedGb  string `json:"memUsedGB"`
+				MemTotalGb string `json:"memTotalGB"`
+			}{CpuPercent: "1.0", MemUsedGb: "1.0", MemTotalGb: "8.0"},
+		},
+		Workers: map[string]TdarrNodeWorkers{},
+	}
+
+	nodeData := map[string]TdarrNode{"node-busy": busy, "node-idle": idle}
+	samples := collectSamples(t, func(ch chan<- prometheus.Metric) {
+		c.emitNodeMetrics(ch, nodeData)
+	})
+
+	busyL := map[string]string{"node_id": "node-busy"}
+	idleL := map[string]string{"node_id": "node-idle"}
+
+	// node identity emitted once per node
+	if n := countByName(samples, "tdarr_node_info"); n != 2 {
+		t.Errorf("node_info count = %d, want 2", n)
+	}
+
+	// resource stats: busy node parses all; idle node's heap-used is unparseable -> absent.
+	if got := findOne(t, samples, "tdarr_node_heap_used_mb", busyL).value; got != 128.5 {
+		t.Errorf("busy heap_used = %v, want 128.5", got)
+	}
+	// idle node heap-used must be skipped (unparseable), but heap-total (parseable) present.
+	for _, s := range samples {
+		if s.fqName == "tdarr_node_heap_used_mb" && s.labels["node_id"] == "node-idle" {
+			t.Errorf("idle node heap_used_mb should be skipped (unparseable), but was emitted: %v", s.value)
+		}
+	}
+	if got := findOne(t, samples, "tdarr_node_heap_total_mb", idleL).value; got != 64.0 {
+		t.Errorf("idle heap_total = %v, want 64.0", got)
+	}
+	if got := findOne(t, samples, "tdarr_node_host_cpu_percent", busyL).value; got != 42.0 {
+		t.Errorf("busy cpu_percent = %v, want 42.0", got)
+	}
+
+	// per-type worker_count: four known dims always emitted per node (zeros included).
+	if got := findOne(t, samples, "tdarr_node_worker_count",
+		map[string]string{"node_id": "node-busy", "worker_type": "transcode", "compute_type": "cpu"}).value; got != 1 {
+		t.Errorf("busy worker_count{transcode,cpu} = %v, want 1", got)
+	}
+	if got := findOne(t, samples, "tdarr_node_worker_count",
+		map[string]string{"node_id": "node-busy", "worker_type": "healthcheck", "compute_type": "gpu"}).value; got != 0 {
+		t.Errorf("busy worker_count{healthcheck,gpu} = %v, want 0", got)
+	}
+	if n := countByName(samples, "tdarr_node_worker_count"); n != 8 {
+		// 4 known dims * 2 nodes, no unknown buckets.
+		t.Errorf("worker_count series total = %d, want 8", n)
+	}
+
+	// per-worker gauges only for the busy node's worker.
+	if got := findOne(t, samples, "tdarr_node_worker_percentage",
+		map[string]string{"node_id": "node-busy", "worker_id": "w1"}).value; got != 55.5 {
+		t.Errorf("worker percentage = %v, want 55.5", got)
+	}
+	if got := findOne(t, samples, "tdarr_node_worker_fps",
+		map[string]string{"worker_id": "w1"}).value; got != 24 {
+		t.Errorf("worker fps = %v, want 24", got)
+	}
+	// ETA "0:30:00" -> 1800 seconds.
+	if got := findOne(t, samples, "tdarr_node_worker_eta_seconds",
+		map[string]string{"worker_id": "w1"}).value; got != 1800 {
+		t.Errorf("worker eta_seconds = %v, want 1800", got)
+	}
+	// idle node has no workers -> no per-worker series.
+	for _, fq := range []string{"tdarr_node_worker_percentage", "tdarr_node_worker_info"} {
+		for _, s := range samples {
+			if s.fqName == fq && s.labels["node_id"] == "node-idle" {
+				t.Errorf("idle node should emit no %s, but got one", fq)
+			}
+		}
+	}
+
+	// node_info / worker_info label correctness for the busy worker.
+	wi := findOne(t, samples, "tdarr_node_worker_info",
+		map[string]string{"node_id": "node-busy", "worker_id": "w1"})
+	if wi.labels["worker_type"] != "transcode" || wi.labels["compute_type"] != "cpu" {
+		t.Errorf("worker_info type labels = %v, want transcode/cpu", wi.labels)
+	}
+	if wi.labels["worker_status"] != "processing" || wi.labels["worker_file"] != "movie.mkv" {
+		t.Errorf("worker_info status/file labels = %v", wi.labels)
+	}
+
+	// sanity: every node emits worker_limit and queue_length for the four known dims.
+	if !hasName(samples, "tdarr_node_worker_limit") || !hasName(samples, "tdarr_node_queue_length") {
+		t.Error("expected per-type worker_limit and queue_length series")
+	}
+}
+
+// --- emitGeneralMetrics -------------------------------------------------------
+
+func TestEmitGeneralMetrics(t *testing.T) {
+	t.Parallel()
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, newSuccessFakeAPI(cfg))
+
+	metric := &TdarrMetric{
+		TotalFileCount:        100,
+		TotalTranscodeCount:   40,
+		TotalHealthCheckCount: 30,
+		SizeDiff:              12.5,
+		AvgNumStreams:         2.0,
+		StreamStats: TdarrStreamStats{
+			Duration:  TdarrStreamStatsObj{Average: 1, Highest: 2, Total: 3},
+			BitRate:   TdarrStreamStatsObj{Average: 4, Highest: 5, Total: 6},
+			NumFrames: TdarrStreamStatsObj{Average: 7, Highest: 8, Total: 9},
+		},
+	}
+	samples := collectSamples(t, func(ch chan<- prometheus.Metric) {
+		c.emitGeneralMetrics(ch, metric, 88.0, 77.0)
+	})
+
+	if got := findOne(t, samples, "tdarr_files_total", map[string]string{}).value; got != 100 {
+		t.Errorf("files_total = %v, want 100", got)
+	}
+	if got := findOne(t, samples, "tdarr_score_pct", map[string]string{}).value; got != 88.0 {
+		t.Errorf("score_pct = %v, want 88.0", got)
+	}
+	if got := findOne(t, samples, "tdarr_health_check_score_pct", map[string]string{}).value; got != 77.0 {
+		t.Errorf("health_check_score_pct = %v, want 77.0", got)
+	}
+	if got := findOne(t, samples, "tdarr_size_diff_gb", map[string]string{}).value; got != 12.5 {
+		t.Errorf("size_diff_gb = %v, want 12.5", got)
+	}
+	// stream stats: 3 stat_type series each for duration/bit_rate/num_frames.
+	if n := countByName(samples, "tdarr_stream_stats_duration"); n != 3 {
+		t.Errorf("stream_stats_duration series = %d, want 3", n)
+	}
+	if got := findOne(t, samples, "tdarr_stream_stats_bit_rate",
+		map[string]string{"stat_type": "total"}).value; got != 6 {
+		t.Errorf("bit_rate{total} = %v, want 6", got)
+	}
+	if got := findOne(t, samples, "tdarr_stream_stats_num_frames",
+		map[string]string{"stat_type": "average"}).value; got != 7 {
+		t.Errorf("num_frames{average} = %v, want 7", got)
+	}
+}

--- a/internal/collector/tdarr_emit_test.go
+++ b/internal/collector/tdarr_emit_test.go
@@ -292,8 +292,9 @@ func TestEmitPieMetrics(t *testing.T) {
 				Resolutions: []TdarrPieSlice{{Name: "1080P", Value: 2}},
 			},
 			Audio: TdarrPieVideoSlice{
-				Codecs:     []TdarrPieSlice{{Name: "AAC", Value: 8}, {Name: "FLAC", Value: 1}},
-				Containers: []TdarrPieSlice{{Name: "M4A", Value: 6}},
+				Codecs:      []TdarrPieSlice{{Name: "AAC", Value: 8}, {Name: "FLAC", Value: 1}},
+				Containers:  []TdarrPieSlice{{Name: "M4A", Value: 6}},
+				Resolutions: []TdarrPieSlice{{Name: "1080P", Value: 9}},
 			},
 		},
 		NormalizedTranscodes:   map[string]int{"success": 5, "queued": 0},
@@ -343,6 +344,10 @@ func TestEmitPieMetrics(t *testing.T) {
 	if got := findOne(t, samples, "tdarr_library_audio_containers",
 		map[string]string{"library_id": "lib-audio-01", "container_type": "m4a"}).value; got != 6 {
 		t.Errorf("audio_containers{m4a} = %v, want 6", got)
+	}
+	if got := findOne(t, samples, "tdarr_library_audio_resolutions",
+		map[string]string{"library_id": "lib-audio-01", "resolution": "1080p"}).value; got != 9 {
+		t.Errorf("audio_resolutions{1080p} = %v, want 9", got)
 	}
 
 	// const instance label is propagated

--- a/internal/collector/tdarr_enums_test.go
+++ b/internal/collector/tdarr_enums_test.go
@@ -1,0 +1,346 @@
+package collector
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// cleanTranscodeLabel
+// ---------------------------------------------------------------------------
+
+func TestCleanTranscodeLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "Not required lowercased",
+			input: "Not required",
+			want:  "not required",
+		},
+		{
+			name:  "Transcode error strips prefix",
+			input: "Transcode error",
+			want:  "error",
+		},
+		{
+			name:  "Queued lowercased",
+			input: "Queued",
+			want:  "queued",
+		},
+		{
+			name:  "Success lowercased",
+			input: "Success",
+			want:  "success",
+		},
+		{
+			name:  "already lowercase transcode prefix stripped",
+			input: "transcodecpu",
+			want:  "cpu",
+		},
+		{
+			name:  "empty string returns empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "whitespace-only after trim",
+			input: "transcode ",
+			// "transcode " -> lower -> "transcode " -> TrimPrefix("transcode") -> " " -> TrimSpace -> ""
+			want: "",
+		},
+		{
+			name:  "no transcode prefix, just lowercase",
+			input: "Cancelled",
+			want:  "cancelled",
+		},
+		{
+			name:  "Hold lowercased",
+			input: "Hold",
+			want:  "hold",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := cleanTranscodeLabel(tc.input)
+			if got != tc.want {
+				t.Errorf("cleanTranscodeLabel(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cleanHealthCheckLabel
+// ---------------------------------------------------------------------------
+
+func TestCleanHealthCheckLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "Queued lowercased",
+			input: "Queued",
+			want:  "queued",
+		},
+		{
+			name:  "Error lowercased",
+			input: "Error",
+			want:  "error",
+		},
+		{
+			name:  "Success lowercased",
+			input: "Success",
+			want:  "success",
+		},
+		{
+			name:  "Cancelled lowercased",
+			input: "Cancelled",
+			want:  "cancelled",
+		},
+		{
+			name:  "already lowercase unchanged",
+			input: "queued",
+			want:  "queued",
+		},
+		{
+			name:  "mixed case",
+			input: "QUEUED",
+			want:  "queued",
+		},
+		{
+			name:  "empty string returns empty",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := cleanHealthCheckLabel(tc.input)
+			if got != tc.want {
+				t.Errorf("cleanHealthCheckLabel(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// normalizeStatusSlice
+// ---------------------------------------------------------------------------
+
+func TestNormalizeStatusSlice(t *testing.T) {
+	t.Parallel()
+
+	// knownForTest is a small known set used by most sub-tests to avoid coupling to
+	// the production knownTranscodeStatuses / knownHealthCheckStatuses sets.
+	knownForTest := map[string]struct{}{
+		"queued":  {},
+		"error":   {},
+		"success": {},
+	}
+	identityCleaner := func(s string) string { return s }
+
+	t.Run("empty raw slice populates all known statuses as zero", func(t *testing.T) {
+		t.Parallel()
+		result := normalizeStatusSlice(nil, knownForTest, identityCleaner, "transcode", "lib1", nil)
+
+		if len(result) != len(knownForTest) {
+			t.Fatalf("want %d entries, got %d: %v", len(knownForTest), len(result), result)
+		}
+		for k := range knownForTest {
+			val, ok := result[k]
+			if !ok {
+				t.Errorf("key %q missing from result", k)
+				continue
+			}
+			if val != 0 {
+				t.Errorf("result[%q] = %d, want 0", k, val)
+			}
+		}
+	})
+
+	t.Run("known statuses are stored with their API values", func(t *testing.T) {
+		t.Parallel()
+		raw := []TdarrPieSlice{
+			{Name: "queued", Value: 10},
+			{Name: "success", Value: 5},
+			// "error" absent → stays 0
+		}
+		result := normalizeStatusSlice(raw, knownForTest, identityCleaner, "transcode", "lib1", nil)
+
+		if result["queued"] != 10 {
+			t.Errorf("result[queued] = %d, want 10", result["queued"])
+		}
+		if result["success"] != 5 {
+			t.Errorf("result[success] = %d, want 5", result["success"])
+		}
+		if result["error"] != 0 {
+			t.Errorf("result[error] = %d, want 0 (absent in raw)", result["error"])
+		}
+	})
+
+	t.Run("cleaner function is applied before known-set lookup", func(t *testing.T) {
+		t.Parallel()
+		raw := []TdarrPieSlice{
+			{Name: "Transcode error", Value: 7},
+		}
+		// Use cleanTranscodeLabel: "Transcode error" -> "error".
+		knownWithError := map[string]struct{}{
+			"queued": {},
+			"error":  {},
+		}
+		result := normalizeStatusSlice(raw, knownWithError, cleanTranscodeLabel, "transcode", "lib1", nil)
+		if result["error"] != 7 {
+			t.Errorf("result[error] = %d, want 7 after label cleaning", result["error"])
+		}
+	})
+
+	t.Run("unknown status: stored with real value and unknownCounter called", func(t *testing.T) {
+		t.Parallel()
+		raw := []TdarrPieSlice{
+			{Name: "futurestatus", Value: 3},
+		}
+		var counterCalls []struct{ kind, status string }
+		counter := func(kind, status string) {
+			counterCalls = append(counterCalls, struct{ kind, status string }{kind, status})
+		}
+		result := normalizeStatusSlice(raw, knownForTest, identityCleaner, "transcode", "lib99", counter)
+
+		// Observable effect 1: the unknown status is present in result with its real value.
+		if result["futurestatus"] != 3 {
+			t.Errorf("result[futurestatus] = %d, want 3 (unknown status should not be discarded)", result["futurestatus"])
+		}
+		// Observable effect 2: unknownCounter was invoked exactly once with the right args.
+		if len(counterCalls) != 1 {
+			t.Fatalf("unknownCounter calls: want 1, got %d", len(counterCalls))
+		}
+		if counterCalls[0].kind != "transcode" {
+			t.Errorf("unknownCounter kind = %q, want %q", counterCalls[0].kind, "transcode")
+		}
+		if counterCalls[0].status != "futurestatus" {
+			t.Errorf("unknownCounter status = %q, want %q", counterCalls[0].status, "futurestatus")
+		}
+	})
+
+	t.Run("unknown status: known statuses are still zero-padded", func(t *testing.T) {
+		t.Parallel()
+		raw := []TdarrPieSlice{
+			{Name: "alientype", Value: 99},
+		}
+		result := normalizeStatusSlice(raw, knownForTest, identityCleaner, "transcode", "lib1", nil)
+
+		for k := range knownForTest {
+			if result[k] != 0 {
+				t.Errorf("result[%q] = %d, want 0 (known status absent from raw should be 0)", k, result[k])
+			}
+		}
+	})
+
+	t.Run("unknown status: nil unknownCounter does not panic", func(t *testing.T) {
+		t.Parallel()
+		raw := []TdarrPieSlice{
+			{Name: "mysterystatus", Value: 1},
+		}
+		// Must not panic even when unknownCounter is nil.
+		result := normalizeStatusSlice(raw, knownForTest, identityCleaner, "transcode", "lib1", nil)
+		if result["mysterystatus"] != 1 {
+			t.Errorf("result[mysterystatus] = %d, want 1", result["mysterystatus"])
+		}
+	})
+
+	t.Run("multiple unknown statuses each invoke counter and are distinct in result", func(t *testing.T) {
+		t.Parallel()
+		raw := []TdarrPieSlice{
+			{Name: "alpha", Value: 2},
+			{Name: "beta", Value: 5},
+		}
+		callCount := 0
+		counter := func(kind, status string) { callCount++ }
+		result := normalizeStatusSlice(raw, knownForTest, identityCleaner, "healthcheck", "lib2", counter)
+
+		if callCount != 2 {
+			t.Errorf("unknownCounter calls: want 2, got %d", callCount)
+		}
+		if result["alpha"] != 2 {
+			t.Errorf("result[alpha] = %d, want 2", result["alpha"])
+		}
+		if result["beta"] != 5 {
+			t.Errorf("result[beta] = %d, want 5", result["beta"])
+		}
+	})
+
+	t.Run("production transcode known set with real cleaner normalizes correctly", func(t *testing.T) {
+		t.Parallel()
+		raw := []TdarrPieSlice{
+			{Name: "Not required", Value: 100},
+			{Name: "Transcode error", Value: 4},
+			{Name: "Queued", Value: 8},
+			{Name: "Success", Value: 20},
+			{Name: "Ignored", Value: 0},
+			{Name: "Cancelled", Value: 1},
+			{Name: "Hold", Value: 2},
+		}
+		var unknownCalls int
+		counter := func(kind, status string) { unknownCalls++ }
+		result := normalizeStatusSlice(raw, knownTranscodeStatuses, cleanTranscodeLabel, "transcode", "lib1", counter)
+
+		// All entries are known; counter must not be called.
+		if unknownCalls != 0 {
+			t.Errorf("unknownCounter calls: want 0 (all known), got %d", unknownCalls)
+		}
+		want := map[string]int{
+			"not required": 100,
+			"error":        4,
+			"queued":       8,
+			"success":      20,
+			"ignored":      0,
+			"cancelled":    1,
+			"hold":         2,
+		}
+		for k, wantVal := range want {
+			if result[k] != wantVal {
+				t.Errorf("result[%q] = %d, want %d", k, result[k], wantVal)
+			}
+		}
+	})
+
+	t.Run("production healthcheck known set with real cleaner normalizes correctly", func(t *testing.T) {
+		t.Parallel()
+		raw := []TdarrPieSlice{
+			{Name: "Queued", Value: 3},
+			{Name: "Error", Value: 1},
+			{Name: "Success", Value: 50},
+			// "Cancelled" absent → 0
+		}
+		var unknownCalls int
+		counter := func(kind, status string) { unknownCalls++ }
+		result := normalizeStatusSlice(raw, knownHealthCheckStatuses, cleanHealthCheckLabel, "healthcheck", "lib2", counter)
+
+		if unknownCalls != 0 {
+			t.Errorf("unknownCounter calls: want 0 (all known), got %d", unknownCalls)
+		}
+		if result["queued"] != 3 {
+			t.Errorf("result[queued] = %d, want 3", result["queued"])
+		}
+		if result["error"] != 1 {
+			t.Errorf("result[error] = %d, want 1", result["error"])
+		}
+		if result["success"] != 50 {
+			t.Errorf("result[success] = %d, want 50", result["success"])
+		}
+		if result["cancelled"] != 0 {
+			t.Errorf("result[cancelled] = %d, want 0 (absent in raw)", result["cancelled"])
+		}
+	})
+}

--- a/internal/collector/tdarr_golden_test.go
+++ b/internal/collector/tdarr_golden_test.go
@@ -1,0 +1,199 @@
+package collector
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/homeylab/tdarr-exporter/internal/config"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// collectorMetricNames is the exhaustive list of metric families emitted by
+// TdarrCollector.Collect.  Metrics that come from internal/handlers/metrics.go
+// (tdarr_scrape_duration_seconds, tdarr_scrape_requests_total) are intentionally
+// excluded so they cannot influence the comparison.
+var collectorMetricNames = []string{
+	"tdarr_avg_num_streams",
+	"tdarr_files_total",
+	"tdarr_health_check_score_pct",
+	"tdarr_health_checks_total",
+	"tdarr_library_audio_codecs",
+	"tdarr_library_audio_containers",
+	"tdarr_library_files_total",
+	"tdarr_library_health_checks",
+	"tdarr_library_health_checks_total",
+	"tdarr_library_size_diff_gb",
+	"tdarr_library_transcodes",
+	"tdarr_library_transcodes_total",
+	"tdarr_library_video_codecs",
+	"tdarr_library_video_containers",
+	"tdarr_library_video_resolutions",
+	"tdarr_node_heap_total_mb",
+	"tdarr_node_heap_used_mb",
+	"tdarr_node_host_cpu_percent",
+	"tdarr_node_host_mem_total_gb",
+	"tdarr_node_host_mem_used_gb",
+	"tdarr_node_info",
+	"tdarr_node_max_gpu_workers",
+	"tdarr_node_paused",
+	"tdarr_node_queue_length",
+	"tdarr_node_schedule_enabled",
+	"tdarr_node_uptime_seconds",
+	"tdarr_node_worker_count",
+	"tdarr_node_worker_est_file_size_gb",
+	"tdarr_node_worker_eta_seconds",
+	"tdarr_node_worker_fps",
+	"tdarr_node_worker_info",
+	"tdarr_node_worker_job_start_timestamp_seconds",
+	"tdarr_node_worker_limit",
+	"tdarr_node_worker_original_file_size_gb",
+	"tdarr_node_worker_output_file_size_gb",
+	"tdarr_node_worker_percentage",
+	"tdarr_node_worker_pid",
+	"tdarr_node_worker_start_timestamp_seconds",
+	"tdarr_node_worker_status_timestamp_seconds",
+	"tdarr_score_pct",
+	"tdarr_size_diff_gb",
+	"tdarr_stream_stats_bit_rate",
+	"tdarr_stream_stats_duration",
+	"tdarr_stream_stats_num_frames",
+	"tdarr_transcodes_total",
+	"tdarr_unknown_status_total",
+	"tdarr_up",
+}
+
+// readFixture reads a file from testdata/ relative to the test file location.
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+// newGoldenTestServer builds a fake Tdarr API server backed by testdata fixtures.
+// Routing:
+//   - POST /api/v2/cruddb  collection=StatisticsJSONDB  → general_stats.json
+//   - POST /api/v2/cruddb  collection=LibrarySettingsJSONDB → library_list.json
+//   - POST /api/v2/stats/get-pies  libraryId=lib-video-01 → pie_stats_lib_video_01.json
+//   - POST /api/v2/stats/get-pies  libraryId=lib-audio-01 → pie_stats_lib_audio_01.json
+//   - GET  /api/v2/get-nodes → nodes.json
+func newGoldenTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	generalStats := readFixture(t, "general_stats.json")
+	libraryList := readFixture(t, "library_list.json")
+	pieVideo := readFixture(t, "pie_stats_lib_video_01.json")
+	pieAudio := readFixture(t, "pie_stats_lib_audio_01.json")
+	nodesData := readFixture(t, "nodes.json")
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v2/cruddb", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body error", http.StatusBadRequest)
+			return
+		}
+		var req TdarrMetricRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, "unmarshal error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Data.Collection {
+		case "LibrarySettingsJSONDB":
+			_, _ = w.Write(libraryList)
+		default: // StatisticsJSONDB
+			_, _ = w.Write(generalStats)
+		}
+	})
+
+	mux.HandleFunc("/api/v2/stats/get-pies", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body error", http.StatusBadRequest)
+			return
+		}
+		var req TdarrPieDataRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, "unmarshal error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Data.LibraryId {
+		case "lib-audio-01":
+			_, _ = w.Write(pieAudio)
+		default: // lib-video-01
+			_, _ = w.Write(pieVideo)
+		}
+	})
+
+	mux.HandleFunc("/api/v2/get-nodes", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(nodesData)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newGoldenTestConfig returns a config.Config pointing at serverURL with deterministic settings.
+// HttpMaxConcurrency=1 ensures per-library pie requests are processed sequentially,
+// making pieData slice ordering fully deterministic.
+func newGoldenTestConfig(t *testing.T, serverURL string) config.Config {
+	t.Helper()
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	return config.Config{
+		UrlParsed:          u,
+		InstanceName:       "tdarr.localdomain",
+		ApiKey:             "",
+		VerifySsl:          false,
+		HttpTimeoutSeconds: 5,
+		TdarrStatsPath:     "/api/v2/cruddb",
+		TdarrPieStatsPath:  "/api/v2/stats/get-pies",
+		TdarrNodePath:      "/api/v2/get-nodes",
+		HttpMaxConcurrency: 1,
+	}
+}
+
+// TestCollect_Golden_FullFixture is a characterization test that pins the exact
+// Prometheus output of TdarrCollector.Collect against testdata/expected_output.txt.
+//
+// Fixture paths exercised:
+//   - general stats + stream stats (all fields)
+//   - two libraries: "Shows" (video-only) and "Music" (with audio codecs + audio containers)
+//   - all known transcode statuses (not required, success, error, queued, hold, ignored, cancelled)
+//   - unknown transcode status "pending" → exercises tdarr_unknown_status_total
+//   - all known health check statuses (success, error, queued, cancelled)
+//   - video codecs, containers, resolutions (lowercased from mixed-case fixture values)
+//   - audio codecs (aac, flac, opus) and audio containers (mkv, m4a) for "Music" library
+//   - idle node "IdleNode" with no workers (zero-value worker count/limit/queue series emitted)
+//   - busy node "BusyNode" with one active transcode CPU worker exercising all per-worker gauges:
+//     percentage, fps, original/output/est file sizes, job_start/start/status timestamps, pid, eta_seconds
+//   - tdarr_up = 1 on success path
+func TestCollect_Golden_FullFixture(t *testing.T) {
+	srv := newGoldenTestServer(t)
+	cfg := newGoldenTestConfig(t, srv.URL)
+	collector := NewTdarrCollector(cfg)
+
+	expectedFile, err := os.Open("testdata/expected_output.txt")
+	if err != nil {
+		t.Fatalf("open expected output: %v", err)
+	}
+	defer expectedFile.Close()
+
+	if err := testutil.CollectAndCompare(collector, expectedFile, collectorMetricNames...); err != nil {
+		t.Errorf("metric output mismatch:\n%v", err)
+	}
+}

--- a/internal/collector/tdarr_golden_test.go
+++ b/internal/collector/tdarr_golden_test.go
@@ -138,7 +138,7 @@ func TestCollect_Golden_FullFixture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open expected output: %v", err)
 	}
-	defer expectedFile.Close()
+	defer func() { _ = expectedFile.Close() }()
 
 	if err := testutil.CollectAndCompare(collector, expectedFile, collectorMetricNames...); err != nil {
 		t.Errorf("metric output mismatch:\n%v", err)

--- a/internal/collector/tdarr_golden_test.go
+++ b/internal/collector/tdarr_golden_test.go
@@ -1,10 +1,6 @@
 package collector
 
 import (
-	"encoding/json"
-	"io"
-	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
@@ -77,80 +73,13 @@ func readFixture(t *testing.T, name string) []byte {
 	return data
 }
 
-// newGoldenTestServer builds a fake Tdarr API server backed by testdata fixtures.
-// Routing:
-//   - POST /api/v2/cruddb  collection=StatisticsJSONDB  → general_stats.json
-//   - POST /api/v2/cruddb  collection=LibrarySettingsJSONDB → library_list.json
-//   - POST /api/v2/stats/get-pies  libraryId=lib-video-01 → pie_stats_lib_video_01.json
-//   - POST /api/v2/stats/get-pies  libraryId=lib-audio-01 → pie_stats_lib_audio_01.json
-//   - GET  /api/v2/get-nodes → nodes.json
-func newGoldenTestServer(t *testing.T) *httptest.Server {
-	t.Helper()
-
-	generalStats := readFixture(t, "general_stats.json")
-	libraryList := readFixture(t, "library_list.json")
-	pieVideo := readFixture(t, "pie_stats_lib_video_01.json")
-	pieAudio := readFixture(t, "pie_stats_lib_audio_01.json")
-	nodesData := readFixture(t, "nodes.json")
-
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/api/v2/cruddb", func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "read body error", http.StatusBadRequest)
-			return
-		}
-		var req TdarrMetricRequest
-		if err := json.Unmarshal(body, &req); err != nil {
-			http.Error(w, "unmarshal error", http.StatusBadRequest)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		switch req.Data.Collection {
-		case "LibrarySettingsJSONDB":
-			_, _ = w.Write(libraryList)
-		default: // StatisticsJSONDB
-			_, _ = w.Write(generalStats)
-		}
-	})
-
-	mux.HandleFunc("/api/v2/stats/get-pies", func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "read body error", http.StatusBadRequest)
-			return
-		}
-		var req TdarrPieDataRequest
-		if err := json.Unmarshal(body, &req); err != nil {
-			http.Error(w, "unmarshal error", http.StatusBadRequest)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		switch req.Data.LibraryId {
-		case "lib-audio-01":
-			_, _ = w.Write(pieAudio)
-		default: // lib-video-01
-			_, _ = w.Write(pieVideo)
-		}
-	})
-
-	mux.HandleFunc("/api/v2/get-nodes", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(nodesData)
-	})
-
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return srv
-}
-
-// newGoldenTestConfig returns a config.Config pointing at serverURL with deterministic settings.
+// newGoldenTestConfig returns a config.Config with deterministic settings.
 // HttpMaxConcurrency=1 ensures per-library pie requests are processed sequentially,
-// making pieData slice ordering fully deterministic.
-func newGoldenTestConfig(t *testing.T, serverURL string) config.Config {
+// making pieData slice ordering fully deterministic. UrlParsed is set so the config
+// is well-formed even though the injected fake never makes a network call.
+func newGoldenTestConfig(t *testing.T) config.Config {
 	t.Helper()
-	u, err := url.Parse(serverURL)
+	u, err := url.Parse("http://tdarr.test")
 	if err != nil {
 		t.Fatalf("parse url: %v", err)
 	}
@@ -165,6 +94,24 @@ func newGoldenTestConfig(t *testing.T, serverURL string) config.Config {
 		TdarrNodePath:      "/api/v2/get-nodes",
 		HttpMaxConcurrency: 1,
 	}
+}
+
+// newGoldenFakeAPI builds a fakeTdarrAPI backed by the testdata fixtures, mirroring
+// the routing the real Tdarr API performs:
+//   - POST /api/v2/cruddb  collection=StatisticsJSONDB      → general_stats.json
+//   - POST /api/v2/cruddb  collection=LibrarySettingsJSONDB → library_list.json
+//   - POST /api/v2/stats/get-pies  libraryId=lib-video-01   → pie_stats_lib_video_01.json
+//   - POST /api/v2/stats/get-pies  libraryId=lib-audio-01   → pie_stats_lib_audio_01.json
+//   - GET  /api/v2/get-nodes                                → nodes.json
+func newGoldenFakeAPI(t *testing.T, cfg config.Config) *fakeTdarrAPI {
+	t.Helper()
+	api := newFakeTdarrAPI()
+	api.setResponse(fakeKey{path: cfg.TdarrStatsPath, disc: "StatisticsJSONDB"}, readFixture(t, "general_stats.json"))
+	api.setResponse(fakeKey{path: cfg.TdarrStatsPath, disc: "LibrarySettingsJSONDB"}, readFixture(t, "library_list.json"))
+	api.setResponse(fakeKey{path: cfg.TdarrPieStatsPath, disc: "lib-video-01"}, readFixture(t, "pie_stats_lib_video_01.json"))
+	api.setResponse(fakeKey{path: cfg.TdarrPieStatsPath, disc: "lib-audio-01"}, readFixture(t, "pie_stats_lib_audio_01.json"))
+	api.setResponse(fakeKey{path: cfg.TdarrNodePath}, readFixture(t, "nodes.json"))
+	return api
 }
 
 // TestCollect_Golden_FullFixture is a characterization test that pins the exact
@@ -183,9 +130,9 @@ func newGoldenTestConfig(t *testing.T, serverURL string) config.Config {
 //     percentage, fps, original/output/est file sizes, job_start/start/status timestamps, pid, eta_seconds
 //   - tdarr_up = 1 on success path
 func TestCollect_Golden_FullFixture(t *testing.T) {
-	srv := newGoldenTestServer(t)
-	cfg := newGoldenTestConfig(t, srv.URL)
-	collector := NewTdarrCollector(cfg)
+	cfg := newGoldenTestConfig(t)
+	api := newGoldenFakeAPI(t, cfg)
+	collector := newTdarrCollectorWithAPI(cfg, api)
 
 	expectedFile, err := os.Open("testdata/expected_output.txt")
 	if err != nil {

--- a/internal/collector/tdarr_models.go
+++ b/internal/collector/tdarr_models.go
@@ -5,10 +5,10 @@ type TdarrMetricRequest struct {
 }
 
 type TdarrDataRequest struct {
-	Collection string                 `json:"collection"`
-	Mode       string                 `json:"mode"`
-	DocId      string                 `json:"docID"`
-	Obj        map[string]interface{} `json:"obj"`
+	Collection string         `json:"collection"`
+	Mode       string         `json:"mode"`
+	DocId      string         `json:"docID"`
+	Obj        map[string]any `json:"obj"`
 }
 
 type TdarrPieDataRequest struct {

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -103,87 +103,75 @@ func NewTdarrNodeMetrics(runConfig config.Config) *TdarrNodeMetrics {
 	instance := prometheus.Labels{"tdarr_instance": runConfig.InstanceName}
 
 	return &TdarrNodeMetrics{
-		nodeInfo: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_info"),
+		nodeInfo: newDesc(
+			"node_info",
 			"Tdarr node identity information",
 			[]string{"node_id", "node_name", "gpu_select", "node_pid", "node_priority",
 				"gpu_can_do_cpu"},
 			instance,
 		),
-		nodeUptime: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_uptime_seconds"),
+		nodeUptime: newDesc(
+			"node_uptime_seconds",
 			"Tdarr node uptime in seconds",
-			nodeLabelPair,
-			instance,
+			nodeLabelPair, instance,
 		),
-		nodeHeapUsedMb: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_heap_used_mb"),
+		nodeHeapUsedMb: newDesc(
+			"node_heap_used_mb",
 			"Tdarr node heap used in MB",
-			nodeLabelPair,
-			instance,
+			nodeLabelPair, instance,
 		),
-		nodeHeapTotalMb: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_heap_total_mb"),
+		nodeHeapTotalMb: newDesc(
+			"node_heap_total_mb",
 			"Tdarr node heap total in MB",
-			nodeLabelPair,
-			instance,
+			nodeLabelPair, instance,
 		),
-		nodeHostCpuPercent: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_host_cpu_percent"),
+		nodeHostCpuPercent: newDesc(
+			"node_host_cpu_percent",
 			"Tdarr node cpu percent used",
-			nodeLabelPair,
-			instance,
+			nodeLabelPair, instance,
 		),
-		nodeHostMemUsedGb: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_host_mem_used_gb"),
+		nodeHostMemUsedGb: newDesc(
+			"node_host_mem_used_gb",
 			"Memory used in GB for host that Tdarr node is running on",
-			nodeLabelPair,
-			instance,
+			nodeLabelPair, instance,
 		),
-		nodeHostMemTotalGb: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_host_mem_total_gb"),
+		nodeHostMemTotalGb: newDesc(
+			"node_host_mem_total_gb",
 			"Total memory in GB for host that Tdarr node is running on",
-			nodeLabelPair,
-			instance,
+			nodeLabelPair, instance,
 		),
-		nodePaused: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_paused"),
+		nodePaused: newDesc(
+			"node_paused",
 			"1 if the Tdarr node is paused, 0 otherwise",
-			nodeLabelPair,
-			instance,
+			nodeLabelPair, instance,
 		),
-		nodeMaxGpuWorkers: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_max_gpu_workers"),
+		nodeMaxGpuWorkers: newDesc(
+			"node_max_gpu_workers",
 			"Maximum number of GPU workers configured for the Tdarr node",
-			nodeLabelPair,
-			instance,
+			nodeLabelPair, instance,
 		),
-		nodeScheduleEnabled: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_schedule_enabled"),
+		nodeScheduleEnabled: newDesc(
+			"node_schedule_enabled",
 			"1 if scheduled operation is enabled on the Tdarr node, 0 otherwise",
-			nodeLabelPair,
-			instance,
+			nodeLabelPair, instance,
 		),
-		nodeWorkerCount: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_count"),
+		nodeWorkerCount: newDesc(
+			"node_worker_count",
 			"Number of active workers on the Tdarr node by worker_type and compute_type",
-			nodeTypeLabelPair,
-			instance,
+			nodeTypeLabelPair, instance,
 		),
-		nodeWorkerLimit: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_limit"),
+		nodeWorkerLimit: newDesc(
+			"node_worker_limit",
 			"Configured worker limit on the Tdarr node by worker_type and compute_type",
-			nodeTypeLabelPair,
-			instance,
+			nodeTypeLabelPair, instance,
 		),
-		nodeQueueLength: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_queue_length"),
+		nodeQueueLength: newDesc(
+			"node_queue_length",
 			"Current queue length on the Tdarr node by worker_type and compute_type",
-			nodeTypeLabelPair,
-			instance,
+			nodeTypeLabelPair, instance,
 		),
-		nodeWorkerInfo: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_info"),
+		nodeWorkerInfo: newDesc(
+			"node_worker_info",
 			"Tdarr node worker identity and categorical state (always 1)",
 			[]string{"node_id", "node_name", "worker_id", "worker_type", "compute_type", "flow_worker",
 				"worker_status", "worker_file",
@@ -191,66 +179,88 @@ func NewTdarrNodeMetrics(runConfig config.Config) *TdarrNodeMetrics {
 				"worker_connected", "worker_idle"},
 			instance,
 		),
-		nodeWorkerPercentage: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_percentage"),
+		nodeWorkerPercentage: newDesc(
+			"node_worker_percentage",
 			"Tdarr node worker transcode/healthcheck progress percentage",
-			workerLabelPair,
-			instance,
+			workerLabelPair, instance,
 		),
-		nodeWorkerFps: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_fps"),
+		nodeWorkerFps: newDesc(
+			"node_worker_fps",
 			"Tdarr node worker frames per second",
-			workerLabelPair,
-			instance,
+			workerLabelPair, instance,
 		),
-		nodeWorkerOriginalFileSizeGb: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_original_file_size_gb"),
+		nodeWorkerOriginalFileSizeGb: newDesc(
+			"node_worker_original_file_size_gb",
 			"Tdarr node worker original file size in GB",
-			workerLabelPair,
-			instance,
+			workerLabelPair, instance,
 		),
-		nodeWorkerOutputFileSizeGb: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_output_file_size_gb"),
+		nodeWorkerOutputFileSizeGb: newDesc(
+			"node_worker_output_file_size_gb",
 			"Tdarr node worker current output file size in GB",
-			workerLabelPair,
-			instance,
+			workerLabelPair, instance,
 		),
-		nodeWorkerEstFileSizeGb: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_est_file_size_gb"),
+		nodeWorkerEstFileSizeGb: newDesc(
+			"node_worker_est_file_size_gb",
 			"Tdarr node worker estimated output file size in GB",
-			workerLabelPair,
-			instance,
+			workerLabelPair, instance,
 		),
-		nodeWorkerJobStartTimestamp: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_job_start_timestamp_seconds"),
+		nodeWorkerJobStartTimestamp: newDesc(
+			"node_worker_job_start_timestamp_seconds",
 			"Tdarr node worker job start time as Unix timestamp in seconds",
-			workerLabelPair,
-			instance,
+			workerLabelPair, instance,
 		),
-		nodeWorkerStartTimestamp: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_start_timestamp_seconds"),
+		nodeWorkerStartTimestamp: newDesc(
+			"node_worker_start_timestamp_seconds",
 			"Tdarr node worker current plugin step start time as Unix timestamp in seconds",
-			workerLabelPair,
-			instance,
+			workerLabelPair, instance,
 		),
-		nodeWorkerStatusTimestamp: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_status_timestamp_seconds"),
+		nodeWorkerStatusTimestamp: newDesc(
+			"node_worker_status_timestamp_seconds",
 			"Tdarr node worker last status update time as Unix timestamp in seconds",
-			workerLabelPair,
-			instance,
+			workerLabelPair, instance,
 		),
-		nodeWorkerEtaSeconds: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_eta_seconds"),
+		nodeWorkerEtaSeconds: newDesc(
+			"node_worker_eta_seconds",
 			"Tdarr node worker estimated time remaining in seconds",
-			workerLabelPair,
-			instance,
+			workerLabelPair, instance,
 		),
-		nodeWorkerPid: prometheus.NewDesc(
-			prometheus.BuildFQName(METRIC_PREFIX, "", "node_worker_pid"),
+		nodeWorkerPid: newDesc(
+			"node_worker_pid",
 			"Tdarr node worker process ID",
-			workerLabelPair,
-			instance,
+			workerLabelPair, instance,
 		),
+	}
+}
+
+// descs returns the node metrics' descs in Describe order. The TdarrCollector's Describe
+// appends this to its own descs so it never reaches into TdarrNodeMetrics field-by-field —
+// the node metric set is owned and ordered here, in one place.
+func (m *TdarrNodeMetrics) descs() []*prometheus.Desc {
+	return []*prometheus.Desc{
+		m.nodeInfo,
+		m.nodeUptime,
+		m.nodeHeapUsedMb,
+		m.nodeHeapTotalMb,
+		m.nodeHostCpuPercent,
+		m.nodeHostMemUsedGb,
+		m.nodeHostMemTotalGb,
+		m.nodePaused,
+		m.nodeMaxGpuWorkers,
+		m.nodeScheduleEnabled,
+		m.nodeWorkerCount,
+		m.nodeWorkerLimit,
+		m.nodeQueueLength,
+		m.nodeWorkerInfo,
+		m.nodeWorkerPercentage,
+		m.nodeWorkerFps,
+		m.nodeWorkerOriginalFileSizeGb,
+		m.nodeWorkerOutputFileSizeGb,
+		m.nodeWorkerEstFileSizeGb,
+		m.nodeWorkerJobStartTimestamp,
+		m.nodeWorkerStartTimestamp,
+		m.nodeWorkerStatusTimestamp,
+		m.nodeWorkerEtaSeconds,
+		m.nodeWorkerPid,
 	}
 }
 

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -3,7 +3,6 @@ package collector
 import (
 	"fmt"
 
-	"github.com/homeylab/tdarr-exporter/internal/client"
 	"github.com/homeylab/tdarr-exporter/internal/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
@@ -93,6 +92,7 @@ type TdarrNodeMetrics struct {
 
 type TdarrNodeCollector struct {
 	config  config.Config
+	api     tdarrAPI // shared with the parent TdarrCollector (same base URL)
 	metrics *TdarrNodeMetrics
 }
 
@@ -254,23 +254,20 @@ func NewTdarrNodeMetrics(runConfig config.Config) *TdarrNodeMetrics {
 	}
 }
 
-func NewTdarrNodeCollector(runConfig config.Config) *TdarrNodeCollector {
+// NewTdarrNodeCollector wires the shared tdarrAPI (built by the parent collector)
+// into the node collector so node requests reuse the same HTTP client.
+func NewTdarrNodeCollector(runConfig config.Config, api tdarrAPI) *TdarrNodeCollector {
 	return &TdarrNodeCollector{
 		config:  runConfig,
+		api:     api,
 		metrics: NewTdarrNodeMetrics(runConfig),
 	}
 }
 
 func (n *TdarrNodeCollector) GetNodeData() (map[string]TdarrNode, error) {
-	httpClient, err := client.NewRequestClient(n.config.UrlParsed, n.config.VerifySsl, n.config.HttpTimeoutSeconds, n.config.ApiKey)
-	if err != nil {
-		log.Error().
-			Err(err).Msg("Failed to create http request client for Tdarr, ensure proper URL is provided")
-		return nil, err
-	}
 	// get node data
 	nodeData := map[string]TdarrNode{}
-	nodeHttpErr := httpClient.DoRequest(n.config.TdarrNodePath, &nodeData)
+	nodeHttpErr := n.api.DoRequest(n.config.TdarrNodePath, &nodeData)
 	if nodeHttpErr != nil {
 		log.Error().Err(nodeHttpErr).Msg("Failed to get node data for Tdarr exporter")
 		return nil, nodeHttpErr

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -56,38 +56,38 @@ func parseWorkerType(api string) (workerType, computeType string) {
 
 type TdarrNodeMetrics struct {
 	// identity / info
-	nodeInfo *prometheus.Desc
+	nodeInfo typedDesc
 	// resource stats
-	nodeUptime         *prometheus.Desc
-	nodeHeapUsedMb     *prometheus.Desc
-	nodeHeapTotalMb    *prometheus.Desc
-	nodeHostCpuPercent *prometheus.Desc
-	nodeHostMemUsedGb  *prometheus.Desc
-	nodeHostMemTotalGb *prometheus.Desc
+	nodeUptime         typedDesc
+	nodeHeapUsedMb     typedDesc
+	nodeHeapTotalMb    typedDesc
+	nodeHostCpuPercent typedDesc
+	nodeHostMemUsedGb  typedDesc
+	nodeHostMemTotalGb typedDesc
 	// node state gauges
-	nodePaused          *prometheus.Desc
-	nodeMaxGpuWorkers   *prometheus.Desc
-	nodeScheduleEnabled *prometheus.Desc
+	nodePaused          typedDesc
+	nodeMaxGpuWorkers   typedDesc
+	nodeScheduleEnabled typedDesc
 	// per-type node gauges; split across two labels:
 	//   worker_type  ∈ {transcode, healthcheck}
 	//   compute_type ∈ {cpu, gpu}
 	// Unknown API values from Tdarr emit the raw string as worker_type with compute_type="unknown".
-	nodeWorkerCount *prometheus.Desc
-	nodeWorkerLimit *prometheus.Desc
-	nodeQueueLength *prometheus.Desc
+	nodeWorkerCount typedDesc
+	nodeWorkerLimit typedDesc
+	nodeQueueLength typedDesc
 	// worker identity / info
-	nodeWorkerInfo *prometheus.Desc
+	nodeWorkerInfo typedDesc
 	// per-worker numeric gauges
-	nodeWorkerPercentage         *prometheus.Desc
-	nodeWorkerFps                *prometheus.Desc
-	nodeWorkerOriginalFileSizeGb *prometheus.Desc
-	nodeWorkerOutputFileSizeGb   *prometheus.Desc
-	nodeWorkerEstFileSizeGb      *prometheus.Desc
-	nodeWorkerJobStartTimestamp  *prometheus.Desc
-	nodeWorkerStartTimestamp     *prometheus.Desc
-	nodeWorkerStatusTimestamp    *prometheus.Desc
-	nodeWorkerEtaSeconds         *prometheus.Desc
-	nodeWorkerPid                *prometheus.Desc
+	nodeWorkerPercentage         typedDesc
+	nodeWorkerFps                typedDesc
+	nodeWorkerOriginalFileSizeGb typedDesc
+	nodeWorkerOutputFileSizeGb   typedDesc
+	nodeWorkerEstFileSizeGb      typedDesc
+	nodeWorkerJobStartTimestamp  typedDesc
+	nodeWorkerStartTimestamp     typedDesc
+	nodeWorkerStatusTimestamp    typedDesc
+	nodeWorkerEtaSeconds         typedDesc
+	nodeWorkerPid                typedDesc
 }
 
 type TdarrNodeCollector struct {
@@ -105,74 +105,74 @@ func NewTdarrNodeMetrics(runConfig config.Config) *TdarrNodeMetrics {
 	instance := prometheus.Labels{"tdarr_instance": runConfig.InstanceName}
 
 	return &TdarrNodeMetrics{
-		nodeInfo: newDesc(
+		nodeInfo: newGauge(
 			"node_info",
 			"Tdarr node identity information",
 			[]string{"node_id", "node_name", "gpu_select", "node_pid", "node_priority",
 				"gpu_can_do_cpu"},
 			instance,
 		),
-		nodeUptime: newDesc(
+		nodeUptime: newGauge(
 			"node_uptime_seconds",
 			"Tdarr node uptime in seconds",
 			nodeLabelPair, instance,
 		),
-		nodeHeapUsedMb: newDesc(
+		nodeHeapUsedMb: newGauge(
 			"node_heap_used_mb",
 			"Tdarr node heap used in MB",
 			nodeLabelPair, instance,
 		),
-		nodeHeapTotalMb: newDesc(
+		nodeHeapTotalMb: newGauge(
 			"node_heap_total_mb",
 			"Tdarr node heap total in MB",
 			nodeLabelPair, instance,
 		),
-		nodeHostCpuPercent: newDesc(
+		nodeHostCpuPercent: newGauge(
 			"node_host_cpu_percent",
 			"Tdarr node cpu percent used",
 			nodeLabelPair, instance,
 		),
-		nodeHostMemUsedGb: newDesc(
+		nodeHostMemUsedGb: newGauge(
 			"node_host_mem_used_gb",
 			"Memory used in GB for host that Tdarr node is running on",
 			nodeLabelPair, instance,
 		),
-		nodeHostMemTotalGb: newDesc(
+		nodeHostMemTotalGb: newGauge(
 			"node_host_mem_total_gb",
 			"Total memory in GB for host that Tdarr node is running on",
 			nodeLabelPair, instance,
 		),
-		nodePaused: newDesc(
+		nodePaused: newGauge(
 			"node_paused",
 			"1 if the Tdarr node is paused, 0 otherwise",
 			nodeLabelPair, instance,
 		),
-		nodeMaxGpuWorkers: newDesc(
+		nodeMaxGpuWorkers: newGauge(
 			"node_max_gpu_workers",
 			"Maximum number of GPU workers configured for the Tdarr node",
 			nodeLabelPair, instance,
 		),
-		nodeScheduleEnabled: newDesc(
+		nodeScheduleEnabled: newGauge(
 			"node_schedule_enabled",
 			"1 if scheduled operation is enabled on the Tdarr node, 0 otherwise",
 			nodeLabelPair, instance,
 		),
-		nodeWorkerCount: newDesc(
+		nodeWorkerCount: newGauge(
 			"node_worker_count",
 			"Number of active workers on the Tdarr node by worker_type and compute_type",
 			nodeTypeLabelPair, instance,
 		),
-		nodeWorkerLimit: newDesc(
+		nodeWorkerLimit: newGauge(
 			"node_worker_limit",
 			"Configured worker limit on the Tdarr node by worker_type and compute_type",
 			nodeTypeLabelPair, instance,
 		),
-		nodeQueueLength: newDesc(
+		nodeQueueLength: newGauge(
 			"node_queue_length",
 			"Current queue length on the Tdarr node by worker_type and compute_type",
 			nodeTypeLabelPair, instance,
 		),
-		nodeWorkerInfo: newDesc(
+		nodeWorkerInfo: newGauge(
 			"node_worker_info",
 			"Tdarr node worker identity and categorical state (always 1)",
 			[]string{"node_id", "node_name", "worker_id", "worker_type", "compute_type", "flow_worker",
@@ -181,52 +181,52 @@ func NewTdarrNodeMetrics(runConfig config.Config) *TdarrNodeMetrics {
 				"worker_connected", "worker_idle"},
 			instance,
 		),
-		nodeWorkerPercentage: newDesc(
+		nodeWorkerPercentage: newGauge(
 			"node_worker_percentage",
 			"Tdarr node worker transcode/healthcheck progress percentage",
 			workerLabelPair, instance,
 		),
-		nodeWorkerFps: newDesc(
+		nodeWorkerFps: newGauge(
 			"node_worker_fps",
 			"Tdarr node worker frames per second",
 			workerLabelPair, instance,
 		),
-		nodeWorkerOriginalFileSizeGb: newDesc(
+		nodeWorkerOriginalFileSizeGb: newGauge(
 			"node_worker_original_file_size_gb",
 			"Tdarr node worker original file size in GB",
 			workerLabelPair, instance,
 		),
-		nodeWorkerOutputFileSizeGb: newDesc(
+		nodeWorkerOutputFileSizeGb: newGauge(
 			"node_worker_output_file_size_gb",
 			"Tdarr node worker current output file size in GB",
 			workerLabelPair, instance,
 		),
-		nodeWorkerEstFileSizeGb: newDesc(
+		nodeWorkerEstFileSizeGb: newGauge(
 			"node_worker_est_file_size_gb",
 			"Tdarr node worker estimated output file size in GB",
 			workerLabelPair, instance,
 		),
-		nodeWorkerJobStartTimestamp: newDesc(
+		nodeWorkerJobStartTimestamp: newGauge(
 			"node_worker_job_start_timestamp_seconds",
 			"Tdarr node worker job start time as Unix timestamp in seconds",
 			workerLabelPair, instance,
 		),
-		nodeWorkerStartTimestamp: newDesc(
+		nodeWorkerStartTimestamp: newGauge(
 			"node_worker_start_timestamp_seconds",
 			"Tdarr node worker current plugin step start time as Unix timestamp in seconds",
 			workerLabelPair, instance,
 		),
-		nodeWorkerStatusTimestamp: newDesc(
+		nodeWorkerStatusTimestamp: newGauge(
 			"node_worker_status_timestamp_seconds",
 			"Tdarr node worker last status update time as Unix timestamp in seconds",
 			workerLabelPair, instance,
 		),
-		nodeWorkerEtaSeconds: newDesc(
+		nodeWorkerEtaSeconds: newGauge(
 			"node_worker_eta_seconds",
 			"Tdarr node worker estimated time remaining in seconds",
 			workerLabelPair, instance,
 		),
-		nodeWorkerPid: newDesc(
+		nodeWorkerPid: newGauge(
 			"node_worker_pid",
 			"Tdarr node worker process ID",
 			workerLabelPair, instance,
@@ -237,8 +237,8 @@ func NewTdarrNodeMetrics(runConfig config.Config) *TdarrNodeMetrics {
 // descs returns the node metrics' descs in Describe order. The TdarrCollector's Describe
 // appends this to its own descs so it never reaches into TdarrNodeMetrics field-by-field —
 // the node metric set is owned and ordered here, in one place.
-func (m *TdarrNodeMetrics) descs() []*prometheus.Desc {
-	return []*prometheus.Desc{
+func (m *TdarrNodeMetrics) descs() []typedDesc {
+	return []typedDesc{
 		m.nodeInfo,
 		m.nodeUptime,
 		m.nodeHeapUsedMb,
@@ -290,11 +290,11 @@ func (n *TdarrNodeCollector) GetNodeData() (map[string]TdarrNode, error) {
 // emitPerType emits a gauge metric for all four known (worker_type, compute_type)
 // dimensions using values from the provided TdarrNodeJobs struct. This ensures
 // zero-value series are always emitted even when no workers of a given type are active.
-func emitPerType(ch chan<- prometheus.Metric, desc *prometheus.Desc, nodeId, nodeName string, jobs TdarrNodeJobs) {
-	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(jobs.TranscodeCpu), nodeId, nodeName, workerTypeTranscode, computeTypeCpu)
-	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(jobs.TranscodeGpu), nodeId, nodeName, workerTypeTranscode, computeTypeGpu)
-	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(jobs.HealthCheckCpu), nodeId, nodeName, workerTypeHealthCheck, computeTypeCpu)
-	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(jobs.HealthCheckGpu), nodeId, nodeName, workerTypeHealthCheck, computeTypeGpu)
+func emitPerType(ch chan<- prometheus.Metric, desc typedDesc, nodeId, nodeName string, jobs TdarrNodeJobs) {
+	ch <- desc.mustNewConstMetric(float64(jobs.TranscodeCpu), nodeId, nodeName, workerTypeTranscode, computeTypeCpu)
+	ch <- desc.mustNewConstMetric(float64(jobs.TranscodeGpu), nodeId, nodeName, workerTypeTranscode, computeTypeGpu)
+	ch <- desc.mustNewConstMetric(float64(jobs.HealthCheckCpu), nodeId, nodeName, workerTypeHealthCheck, computeTypeCpu)
+	ch <- desc.mustNewConstMetric(float64(jobs.HealthCheckGpu), nodeId, nodeName, workerTypeHealthCheck, computeTypeGpu)
 }
 
 // workerCountResult is the per-dim aggregate returned by  countWorkersByType.

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -91,9 +91,11 @@ type TdarrNodeMetrics struct {
 }
 
 type TdarrNodeCollector struct {
-	config  config.Config
-	api     tdarrAPI // shared with the parent TdarrCollector (same base URL)
-	metrics *TdarrNodeMetrics
+	// Only the node API path is read at collect time; the instance label is
+	// baked into the descs at construction, so the full config bag is not stored.
+	nodePath string
+	api      tdarrAPI // shared with the parent TdarrCollector (same base URL)
+	metrics  *TdarrNodeMetrics
 }
 
 func NewTdarrNodeMetrics(runConfig config.Config) *TdarrNodeMetrics {
@@ -268,16 +270,16 @@ func (m *TdarrNodeMetrics) descs() []*prometheus.Desc {
 // into the node collector so node requests reuse the same HTTP client.
 func NewTdarrNodeCollector(runConfig config.Config, api tdarrAPI) *TdarrNodeCollector {
 	return &TdarrNodeCollector{
-		config:  runConfig,
-		api:     api,
-		metrics: NewTdarrNodeMetrics(runConfig),
+		nodePath: runConfig.TdarrNodePath,
+		api:      api,
+		metrics:  NewTdarrNodeMetrics(runConfig),
 	}
 }
 
 func (n *TdarrNodeCollector) GetNodeData() (map[string]TdarrNode, error) {
 	// get node data
 	nodeData := map[string]TdarrNode{}
-	nodeHttpErr := n.api.DoRequest(n.config.TdarrNodePath, &nodeData)
+	nodeHttpErr := n.api.DoRequest(n.nodePath, &nodeData)
 	if nodeHttpErr != nil {
 		return nil, fmt.Errorf("get node data: %w", nodeHttpErr)
 	}

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -279,8 +279,7 @@ func (n *TdarrNodeCollector) GetNodeData() (map[string]TdarrNode, error) {
 	nodeData := map[string]TdarrNode{}
 	nodeHttpErr := n.api.DoRequest(n.config.TdarrNodePath, &nodeData)
 	if nodeHttpErr != nil {
-		log.Error().Err(nodeHttpErr).Msg("Failed to get node data for Tdarr exporter")
-		return nil, nodeHttpErr
+		return nil, fmt.Errorf("get node data: %w", nodeHttpErr)
 	}
 	log.Debug().Interface("response", nodeData).Msg("Node Api Response")
 	return nodeData, nil

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -262,7 +262,7 @@ func NewTdarrNodeCollector(runConfig config.Config) *TdarrNodeCollector {
 }
 
 func (n *TdarrNodeCollector) GetNodeData() (map[string]TdarrNode, error) {
-	httpClient, err := client.NewRequestClient(n.config.UrlParsed, n.config.VerifySsl, n.config.ApiKey)
+	httpClient, err := client.NewRequestClient(n.config.UrlParsed, n.config.VerifySsl, n.config.HttpTimeoutSeconds, n.config.ApiKey)
 	if err != nil {
 		log.Error().
 			Err(err).Msg("Failed to create http request client for Tdarr, ensure proper URL is provided")

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -281,7 +281,7 @@ func (n *TdarrNodeCollector) GetNodeData() (map[string]TdarrNode, error) {
 	nodeData := map[string]TdarrNode{}
 	nodeHttpErr := n.api.DoRequest(n.nodePath, &nodeData)
 	if nodeHttpErr != nil {
-		return nil, fmt.Errorf("get node data: %w", nodeHttpErr)
+		return nil, fmt.Errorf("get node data: %w: %w", ErrUpstream, nodeHttpErr)
 	}
 	log.Debug().Interface("response", nodeData).Msg("Node Api Response")
 	return nodeData, nil

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/homeylab/tdarr-exporter/internal/config"
@@ -276,10 +277,10 @@ func NewTdarrNodeCollector(runConfig config.Config, api tdarrAPI) *TdarrNodeColl
 	}
 }
 
-func (n *TdarrNodeCollector) GetNodeData() (map[string]TdarrNode, error) {
+func (n *TdarrNodeCollector) GetNodeData(ctx context.Context) (map[string]TdarrNode, error) {
 	// get node data
 	nodeData := map[string]TdarrNode{}
-	nodeHttpErr := n.api.DoRequest(n.nodePath, &nodeData)
+	nodeHttpErr := n.api.DoRequest(ctx, n.nodePath, &nodeData)
 	if nodeHttpErr != nil {
 		return nil, fmt.Errorf("get node data: %w: %w", ErrUpstream, nodeHttpErr)
 	}

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/homeylab/tdarr-exporter/internal/config"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 )
 
 // Known worker type / compute type label values used for per-type metric emission.
@@ -97,6 +97,7 @@ type TdarrNodeCollector struct {
 	nodePath string
 	api      tdarrAPI // shared with the parent TdarrCollector (same base URL)
 	metrics  *TdarrNodeMetrics
+	logger   zerolog.Logger // shared with the parent TdarrCollector
 }
 
 func NewTdarrNodeMetrics(runConfig config.Config) *TdarrNodeMetrics {
@@ -269,11 +270,12 @@ func (m *TdarrNodeMetrics) descs() []typedDesc {
 
 // NewTdarrNodeCollector wires the shared tdarrAPI (built by the parent collector)
 // into the node collector so node requests reuse the same HTTP client.
-func NewTdarrNodeCollector(runConfig config.Config, api tdarrAPI) *TdarrNodeCollector {
+func NewTdarrNodeCollector(runConfig config.Config, api tdarrAPI, logger zerolog.Logger) *TdarrNodeCollector {
 	return &TdarrNodeCollector{
 		nodePath: runConfig.TdarrNodePath,
 		api:      api,
 		metrics:  NewTdarrNodeMetrics(runConfig),
+		logger:   logger,
 	}
 }
 
@@ -284,7 +286,7 @@ func (n *TdarrNodeCollector) GetNodeData(ctx context.Context) (map[string]TdarrN
 	if nodeHttpErr != nil {
 		return nil, fmt.Errorf("get node data: %w: %w", ErrUpstream, nodeHttpErr)
 	}
-	log.Debug().Interface("response", nodeData).Msg("Node Api Response")
+	n.logger.Debug().Interface("response", nodeData).Msg("Node Api Response")
 	return nodeData, nil
 }
 
@@ -310,8 +312,8 @@ type workerCountResult struct {
 
 // countWorkersByType counts active workers in the provided workers map grouped
 // by their WorkerType field (parsed into worker_type + compute_type). Unknown
-// API strings are bucketed by raw value so caller can emit (raw, "unknown", count)
-// series. A warning is logged for each occurrence of an unknown type.
+// API strings are bucketed by raw value so the caller can emit (raw, "unknown",
+// count) series and warn on them. Pure: no logging or I/O.
 func countWorkersByType(workers map[string]TdarrNodeWorkers) workerCountResult {
 	result := workerCountResult{
 		known:   make(map[workerTypeDim]int, len(knownWorkerTypeDims)),
@@ -323,7 +325,6 @@ func countWorkersByType(workers map[string]TdarrNodeWorkers) workerCountResult {
 	for _, w := range workers {
 		wt, ct := parseWorkerType(w.WorkerType)
 		if ct == computeTypeUnknown {
-			log.Warn().Str("workerType", w.WorkerType).Msg("Unknown worker type encountered; bucketing under 'unknown'")
 			result.unknown[w.WorkerType]++
 			continue
 		}

--- a/internal/collector/tdarr_nodes_test.go
+++ b/internal/collector/tdarr_nodes_test.go
@@ -1,0 +1,464 @@
+package collector
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// ---------------------------------------------------------------------------
+// parseEtaSeconds
+// ---------------------------------------------------------------------------
+
+func TestParseEtaSeconds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantSecs  int64
+		wantValid bool
+	}{
+		{
+			name:      "zero eta",
+			input:     "0:00:00",
+			wantSecs:  0,
+			wantValid: true,
+		},
+		{
+			name:      "single-digit hour",
+			input:     "1:02:03",
+			wantSecs:  1*3600 + 2*60 + 3,
+			wantValid: true,
+		},
+		{
+			name:      "multi-digit hours",
+			input:     "12:34:56",
+			wantSecs:  12*3600 + 34*60 + 56,
+			wantValid: true,
+		},
+		{
+			name:      "large hours value",
+			input:     "100:00:00",
+			wantSecs:  100 * 3600,
+			wantValid: true,
+		},
+		{
+			name:      "only minutes and seconds without hours separator",
+			input:     "30:45",
+			wantSecs:  0,
+			wantValid: false,
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			wantSecs:  0,
+			wantValid: false,
+		},
+		{
+			name:      "non-numeric",
+			input:     "N/A",
+			wantSecs:  0,
+			wantValid: false,
+		},
+		{
+			name:      "too many segments",
+			input:     "1:2:3:4",
+			// fmt.Sscanf reads exactly three integers and succeeds; the trailing ":4" is ignored.
+			// Actual behavior: n==3, err==nil -> returns (1*3600+2*60+3, true).
+			wantSecs:  1*3600 + 2*60 + 3,
+			wantValid: true,
+		},
+		{
+			name:      "partial input missing last segment",
+			input:     "1:02",
+			wantSecs:  0,
+			wantValid: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseEtaSeconds(tc.input)
+			if ok != tc.wantValid {
+				t.Errorf("parseEtaSeconds(%q) valid=%v, want %v", tc.input, ok, tc.wantValid)
+			}
+			if got != tc.wantSecs {
+				t.Errorf("parseEtaSeconds(%q) seconds=%d, want %d", tc.input, got, tc.wantSecs)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseWorkerType
+// ---------------------------------------------------------------------------
+
+func TestParseWorkerType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		input           string
+		wantWorkerType  string
+		wantComputeType string
+	}{
+		{
+			name:            "transcodecpu",
+			input:           "transcodecpu",
+			wantWorkerType:  workerTypeTranscode,
+			wantComputeType: computeTypeCpu,
+		},
+		{
+			name:            "transcodegpu",
+			input:           "transcodegpu",
+			wantWorkerType:  workerTypeTranscode,
+			wantComputeType: computeTypeGpu,
+		},
+		{
+			name:            "healthcheckcpu",
+			input:           "healthcheckcpu",
+			wantWorkerType:  workerTypeHealthCheck,
+			wantComputeType: computeTypeCpu,
+		},
+		{
+			name:            "healthcheckgpu",
+			input:           "healthcheckgpu",
+			wantWorkerType:  workerTypeHealthCheck,
+			wantComputeType: computeTypeGpu,
+		},
+		{
+			name:            "unknown preserves raw string as worker_type",
+			input:           "somefuturetype",
+			wantWorkerType:  "somefuturetype",
+			wantComputeType: computeTypeUnknown,
+		},
+		{
+			name:            "empty string is unknown",
+			input:           "",
+			wantWorkerType:  "",
+			wantComputeType: computeTypeUnknown,
+		},
+		{
+			name:            "case-sensitive: uppercase is unknown",
+			input:           "TranscodeCpu",
+			wantWorkerType:  "TranscodeCpu",
+			wantComputeType: computeTypeUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			wt, ct := parseWorkerType(tc.input)
+			if wt != tc.wantWorkerType {
+				t.Errorf("parseWorkerType(%q) workerType=%q, want %q", tc.input, wt, tc.wantWorkerType)
+			}
+			if ct != tc.wantComputeType {
+				t.Errorf("parseWorkerType(%q) computeType=%q, want %q", tc.input, ct, tc.wantComputeType)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// countWorkersByType
+// ---------------------------------------------------------------------------
+
+func TestCountWorkersByType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty workers map returns all four known dims at zero", func(t *testing.T) {
+		t.Parallel()
+		result := countWorkersByType(map[string]TdarrNodeWorkers{})
+
+		// All four known dims must be present with value 0.
+		for _, dim := range knownWorkerTypeDims {
+			got, ok := result.known[dim]
+			if !ok {
+				t.Errorf("dim {%s,%s} missing from known map", dim.workerType, dim.computeType)
+				continue
+			}
+			if got != 0 {
+				t.Errorf("dim {%s,%s}: want 0, got %d", dim.workerType, dim.computeType, got)
+			}
+		}
+		if len(result.unknown) != 0 {
+			t.Errorf("unknown map: want empty, got %v", result.unknown)
+		}
+	})
+
+	t.Run("known worker types are counted per dim", func(t *testing.T) {
+		t.Parallel()
+		workers := map[string]TdarrNodeWorkers{
+			"w1": {WorkerType: "transcodecpu"},
+			"w2": {WorkerType: "transcodecpu"},
+			"w3": {WorkerType: "transcodegpu"},
+			"w4": {WorkerType: "healthcheckcpu"},
+			// healthcheckgpu intentionally absent → must still appear as 0.
+		}
+		result := countWorkersByType(workers)
+
+		want := map[workerTypeDim]int{
+			{workerTypeTranscode, computeTypeCpu}:   2,
+			{workerTypeTranscode, computeTypeGpu}:   1,
+			{workerTypeHealthCheck, computeTypeCpu}: 1,
+			{workerTypeHealthCheck, computeTypeGpu}: 0,
+		}
+		for dim, wantCount := range want {
+			got, ok := result.known[dim]
+			if !ok {
+				t.Errorf("dim {%s,%s} missing from known map", dim.workerType, dim.computeType)
+				continue
+			}
+			if got != wantCount {
+				t.Errorf("dim {%s,%s}: want %d, got %d", dim.workerType, dim.computeType, wantCount, got)
+			}
+		}
+		if len(result.unknown) != 0 {
+			t.Errorf("unknown map: want empty, got %v", result.unknown)
+		}
+	})
+
+	t.Run("unknown worker types bucket by raw API string", func(t *testing.T) {
+		t.Parallel()
+		workers := map[string]TdarrNodeWorkers{
+			"w1": {WorkerType: "transcodecpu"},
+			"w2": {WorkerType: "futuretype"},
+			"w3": {WorkerType: "futuretype"},
+			"w4": {WorkerType: "anothertype"},
+		}
+		result := countWorkersByType(workers)
+
+		// Known dim for transcodecpu.
+		gotCpu := result.known[workerTypeDim{workerTypeTranscode, computeTypeCpu}]
+		if gotCpu != 1 {
+			t.Errorf("transcodecpu count: want 1, got %d", gotCpu)
+		}
+
+		// Unknown bucket: raw strings preserved, not collapsed.
+		if result.unknown["futuretype"] != 2 {
+			t.Errorf("unknown[futuretype]: want 2, got %d", result.unknown["futuretype"])
+		}
+		if result.unknown["anothertype"] != 1 {
+			t.Errorf("unknown[anothertype]: want 1, got %d", result.unknown["anothertype"])
+		}
+		// Verify unknown bucket does NOT lump distinct strings together.
+		if len(result.unknown) != 2 {
+			t.Errorf("unknown bucket length: want 2 distinct keys, got %d: %v", len(result.unknown), result.unknown)
+		}
+	})
+
+	t.Run("all workers unknown, known dims all zero", func(t *testing.T) {
+		t.Parallel()
+		workers := map[string]TdarrNodeWorkers{
+			"w1": {WorkerType: "mystery"},
+		}
+		result := countWorkersByType(workers)
+
+		for _, dim := range knownWorkerTypeDims {
+			got := result.known[dim]
+			if got != 0 {
+				t.Errorf("dim {%s,%s}: want 0, got %d", dim.workerType, dim.computeType, got)
+			}
+		}
+		if result.unknown["mystery"] != 1 {
+			t.Errorf("unknown[mystery]: want 1, got %d", result.unknown["mystery"])
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// emitPerType
+// ---------------------------------------------------------------------------
+
+// drainMetricChannel reads all metrics from ch (non-blocking after ch is closed
+// or all items have been sent) and returns them as a slice.
+func drainMetricChannel(ch <-chan prometheus.Metric) []prometheus.Metric {
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	return metrics
+}
+
+// readMetric extracts the dto.Metric from a prometheus.Metric.
+func readMetric(t *testing.T, m prometheus.Metric) *dto.Metric {
+	t.Helper()
+	d := &dto.Metric{}
+	if err := m.Write(d); err != nil {
+		t.Fatalf("Write metric: %v", err)
+	}
+	return d
+}
+
+// labelValue returns the value of the named label from a dto.Metric, or "" if not found.
+func labelValue(d *dto.Metric, name string) string {
+	for _, lp := range d.GetLabel() {
+		if lp.GetName() == name {
+			return lp.GetValue()
+		}
+	}
+	return ""
+}
+
+func TestEmitPerType(t *testing.T) {
+	t.Parallel()
+
+	desc := prometheus.NewDesc(
+		"test_node_worker_count",
+		"test gauge for emitPerType",
+		[]string{"node_id", "node_name", "worker_type", "compute_type"},
+		nil,
+	)
+
+	t.Run("emits exactly four metrics", func(t *testing.T) {
+		t.Parallel()
+		ch := make(chan prometheus.Metric, 10)
+		jobs := TdarrNodeJobs{
+			TranscodeCpu:   1,
+			TranscodeGpu:   2,
+			HealthCheckCpu: 3,
+			HealthCheckGpu: 4,
+		}
+		emitPerType(ch, desc, "node-1", "mynode", jobs)
+		close(ch)
+
+		metrics := drainMetricChannel(ch)
+		if len(metrics) != 4 {
+			t.Fatalf("emitPerType: want 4 metrics, got %d", len(metrics))
+		}
+	})
+
+	t.Run("emitted metrics have correct label values and numeric values", func(t *testing.T) {
+		t.Parallel()
+		ch := make(chan prometheus.Metric, 10)
+		jobs := TdarrNodeJobs{
+			TranscodeCpu:   1,
+			TranscodeGpu:   2,
+			HealthCheckCpu: 3,
+			HealthCheckGpu: 4,
+		}
+		emitPerType(ch, desc, "node-42", "testnode", jobs)
+		close(ch)
+
+		// Collect and index by (worker_type, compute_type).
+		type dimKey struct{ wt, ct string }
+		byDim := make(map[dimKey]float64)
+		for _, m := range drainMetricChannel(ch) {
+			d := readMetric(t, m)
+			wt := labelValue(d, "worker_type")
+			ct := labelValue(d, "compute_type")
+			byDim[dimKey{wt, ct}] = d.GetGauge().GetValue()
+
+			// Verify node labels.
+			if got := labelValue(d, "node_id"); got != "node-42" {
+				t.Errorf("node_id: want node-42, got %q", got)
+			}
+			if got := labelValue(d, "node_name"); got != "testnode" {
+				t.Errorf("node_name: want testnode, got %q", got)
+			}
+		}
+
+		want := map[dimKey]float64{
+			{workerTypeTranscode, computeTypeCpu}:   1,
+			{workerTypeTranscode, computeTypeGpu}:   2,
+			{workerTypeHealthCheck, computeTypeCpu}: 3,
+			{workerTypeHealthCheck, computeTypeGpu}: 4,
+		}
+		for k, wantVal := range want {
+			got, ok := byDim[k]
+			if !ok {
+				t.Errorf("dim {%s,%s} not emitted", k.wt, k.ct)
+				continue
+			}
+			if got != wantVal {
+				t.Errorf("dim {%s,%s}: want %.0f, got %.0f", k.wt, k.ct, wantVal, got)
+			}
+		}
+	})
+
+	t.Run("zero-value series are emitted for all four dims", func(t *testing.T) {
+		t.Parallel()
+		ch := make(chan prometheus.Metric, 10)
+		// All fields zero — emitPerType must still emit four series.
+		jobs := TdarrNodeJobs{}
+		emitPerType(ch, desc, "node-0", "zeronode", jobs)
+		close(ch)
+
+		type dimKey struct{ wt, ct string }
+		seen := make(map[dimKey]float64)
+		for _, m := range drainMetricChannel(ch) {
+			d := readMetric(t, m)
+			wt := labelValue(d, "worker_type")
+			ct := labelValue(d, "compute_type")
+			seen[dimKey{wt, ct}] = d.GetGauge().GetValue()
+		}
+
+		expectedDims := []dimKey{
+			{workerTypeTranscode, computeTypeCpu},
+			{workerTypeTranscode, computeTypeGpu},
+			{workerTypeHealthCheck, computeTypeCpu},
+			{workerTypeHealthCheck, computeTypeGpu},
+		}
+		for _, dim := range expectedDims {
+			val, ok := seen[dim]
+			if !ok {
+				t.Errorf("dim {%s,%s} not emitted for zero-value jobs", dim.wt, dim.ct)
+				continue
+			}
+			if val != 0 {
+				t.Errorf("dim {%s,%s}: want 0, got %v", dim.wt, dim.ct, val)
+			}
+		}
+		if len(seen) != 4 {
+			t.Errorf("want exactly 4 dims, got %d: %v", len(seen), seen)
+		}
+	})
+
+	t.Run("emitted metric dim order covers all four known dims exactly", func(t *testing.T) {
+		t.Parallel()
+		ch := make(chan prometheus.Metric, 10)
+		jobs := TdarrNodeJobs{TranscodeCpu: 5, TranscodeGpu: 6, HealthCheckCpu: 7, HealthCheckGpu: 8}
+		emitPerType(ch, desc, "n1", "nn", jobs)
+		close(ch)
+
+		type dimKey struct{ wt, ct string }
+		var dims []dimKey
+		for _, m := range drainMetricChannel(ch) {
+			d := readMetric(t, m)
+			dims = append(dims, dimKey{labelValue(d, "worker_type"), labelValue(d, "compute_type")})
+		}
+		// Sort both expected and actual for a stable comparison (avoids ordering assumptions).
+		expectedDims := []dimKey{
+			{workerTypeTranscode, computeTypeCpu},
+			{workerTypeTranscode, computeTypeGpu},
+			{workerTypeHealthCheck, computeTypeCpu},
+			{workerTypeHealthCheck, computeTypeGpu},
+		}
+		sort.Slice(dims, func(i, j int) bool {
+			if dims[i].wt != dims[j].wt {
+				return dims[i].wt < dims[j].wt
+			}
+			return dims[i].ct < dims[j].ct
+		})
+		sort.Slice(expectedDims, func(i, j int) bool {
+			if expectedDims[i].wt != expectedDims[j].wt {
+				return expectedDims[i].wt < expectedDims[j].wt
+			}
+			return expectedDims[i].ct < expectedDims[j].ct
+		})
+		if len(dims) != len(expectedDims) {
+			t.Fatalf("dim count: want %d, got %d", len(expectedDims), len(dims))
+		}
+		for i := range dims {
+			if dims[i] != expectedDims[i] {
+				t.Errorf("dim[%d]: want {%s,%s}, got {%s,%s}", i,
+					expectedDims[i].wt, expectedDims[i].ct, dims[i].wt, dims[i].ct)
+			}
+		}
+	})
+}

--- a/internal/collector/tdarr_nodes_test.go
+++ b/internal/collector/tdarr_nodes_test.go
@@ -308,12 +308,15 @@ func labelValue(d *dto.Metric, name string) string {
 func TestEmitPerType(t *testing.T) {
 	t.Parallel()
 
-	desc := prometheus.NewDesc(
-		"test_node_worker_count",
-		"test gauge for emitPerType",
-		[]string{"node_id", "node_name", "worker_type", "compute_type"},
-		nil,
-	)
+	desc := typedDesc{
+		desc: prometheus.NewDesc(
+			"test_node_worker_count",
+			"test gauge for emitPerType",
+			[]string{"node_id", "node_name", "worker_type", "compute_type"},
+			nil,
+		),
+		valueType: prometheus.GaugeValue,
+	}
 
 	t.Run("emits exactly four metrics", func(t *testing.T) {
 		t.Parallel()

--- a/internal/collector/tdarr_nodes_test.go
+++ b/internal/collector/tdarr_nodes_test.go
@@ -64,8 +64,8 @@ func TestParseEtaSeconds(t *testing.T) {
 			wantValid: false,
 		},
 		{
-			name:      "too many segments",
-			input:     "1:2:3:4",
+			name:  "too many segments",
+			input: "1:2:3:4",
 			// fmt.Sscanf reads exactly three integers and succeeds; the trailing ":4" is ignored.
 			// Actual behavior: n==3, err==nil -> returns (1*3600+2*60+3, true).
 			wantSecs:  1*3600 + 2*60 + 3,

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -2,11 +2,7 @@ package collector
 
 import (
 	"encoding/json"
-	"io"
-	"net/http"
-	"net/http/httptest"
 	"net/url"
-	"sync/atomic"
 	"testing"
 
 	"github.com/homeylab/tdarr-exporter/internal/config"
@@ -14,10 +10,12 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-// newTestConfig builds a Config pointing at serverURL with sane test defaults.
-func newTestConfig(t *testing.T, serverURL string) config.Config {
+// newTestConfig builds a Config with sane test defaults. UrlParsed is set so the
+// config is well-formed; the injected fakeTdarrAPI never makes a network call.
+// HttpMaxConcurrency=1 keeps pie-fetch ordering deterministic and race-free.
+func newTestConfig(t *testing.T) config.Config {
 	t.Helper()
-	u, err := url.Parse(serverURL)
+	u, err := url.Parse("http://tdarr.test")
 	if err != nil {
 		t.Fatalf("parse url: %v", err)
 	}
@@ -30,7 +28,7 @@ func newTestConfig(t *testing.T, serverURL string) config.Config {
 		TdarrStatsPath:     "/api/v2/cruddb",
 		TdarrPieStatsPath:  "/api/v2/stats/get-pies",
 		TdarrNodePath:      "/api/v2/get-nodes",
-		HttpMaxConcurrency: 2,
+		HttpMaxConcurrency: 1,
 	}
 }
 
@@ -134,55 +132,23 @@ func validNodeBody() []byte {
 	return b
 }
 
-// parseCruddbMode reads the request body and extracts the "mode" field from the nested data object.
-func parseCruddbMode(r *http.Request) string {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return ""
-	}
-	var req TdarrMetricRequest
-	if err := json.Unmarshal(body, &req); err != nil {
-		return ""
-	}
-	return req.Data.Mode
-}
-
-// newFullSuccessServer builds a fake Tdarr API server that responds successfully to all endpoints.
-func newFullSuccessServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/api/v2/cruddb", func(w http.ResponseWriter, r *http.Request) {
-		mode := parseCruddbMode(r)
-		w.Header().Set("Content-Type", "application/json")
-		if mode == "getAll" {
-			_, _ = w.Write(validLibraryListBody())
-		} else {
-			_, _ = w.Write(validStatsBody())
-		}
-	})
-
-	mux.HandleFunc("/api/v2/stats/get-pies", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validPieBody())
-	})
-
-	mux.HandleFunc("/api/v2/get-nodes", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validNodeBody())
-	})
-
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return srv
+// newSuccessFakeAPI builds a fakeTdarrAPI that responds successfully to every
+// endpoint the collector calls, using the minimal valid bodies above. The single
+// library "lib1" drives one get-pies call keyed on its libraryId.
+func newSuccessFakeAPI(cfg config.Config) *fakeTdarrAPI {
+	api := newFakeTdarrAPI()
+	api.setResponse(fakeKey{path: cfg.TdarrStatsPath, disc: "StatisticsJSONDB"}, validStatsBody())
+	api.setResponse(fakeKey{path: cfg.TdarrStatsPath, disc: "LibrarySettingsJSONDB"}, validLibraryListBody())
+	api.setResponse(fakeKey{path: cfg.TdarrPieStatsPath, disc: "lib1"}, validPieBody())
+	api.setResponse(fakeKey{path: cfg.TdarrNodePath}, validNodeBody())
+	return api
 }
 
 // TestCollect_AllSuccess_UpEquals1 verifies tdarr_up == 1 when all API endpoints succeed,
 // and that general stats metrics such as tdarr_files_total are emitted.
 func TestCollect_AllSuccess_UpEquals1(t *testing.T) {
-	srv := newFullSuccessServer(t)
-	cfg := newTestConfig(t, srv.URL)
-	c := NewTdarrCollector(cfg)
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, newSuccessFakeAPI(cfg))
 
 	mfs := gatherMetricFamilies(t, c)
 	if upValueFromFamilies(mfs) != 1.0 {
@@ -194,73 +160,30 @@ func TestCollect_AllSuccess_UpEquals1(t *testing.T) {
 	}
 }
 
-// TestCollect_StatsAPIReturns404_UpEquals0 verifies tdarr_up == 0 when the stats endpoint fails,
-// and that no additional tdarr metrics beyond tdarr_up are emitted (early return path).
-func TestCollect_StatsAPIReturns404_UpEquals0(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v2/cruddb", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "not found", http.StatusNotFound)
-	})
-	mux.HandleFunc("/api/v2/stats/get-pies", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validPieBody())
-	})
-	mux.HandleFunc("/api/v2/get-nodes", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validNodeBody())
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
+// TestCollect_StatsAPIFails_UpEquals0 verifies tdarr_up == 0 when the stats-by-id cruddb
+// call fails, and that no additional tdarr metrics beyond tdarr_up are emitted (early return path).
+func TestCollect_StatsAPIFails_UpEquals0(t *testing.T) {
+	cfg := newTestConfig(t)
+	api := newSuccessFakeAPI(cfg)
+	api.setError(fakeKey{path: cfg.TdarrStatsPath, disc: "StatisticsJSONDB"}, statErr{"stats fetch failed"})
+	c := newTdarrCollectorWithAPI(cfg, api)
 
-	cfg := newTestConfig(t, srv.URL)
-	c := NewTdarrCollector(cfg)
-
-	reg := prometheus.NewRegistry()
-	reg.MustRegister(c)
-	mfs, err := reg.Gather()
-	if err != nil {
-		t.Fatalf("gather: %v", err)
+	mfs := gatherMetricFamilies(t, c)
+	if upValueFromFamilies(mfs) != 0.0 {
+		t.Errorf("tdarr_up: want 0.0, got %v", upValueFromFamilies(mfs))
 	}
-
-	upVal := -1.0
-	for _, mf := range mfs {
-		if mf.GetName() == "tdarr_up" {
-			upVal = mf.GetMetric()[0].GetGauge().GetValue()
-		} else if mf.GetName() == "tdarr_files_total" {
-			t.Errorf("unexpected metric emitted after early-return: %s", mf.GetName())
-		}
-	}
-	if upVal != 0.0 {
-		t.Errorf("tdarr_up: want 0.0, got %v", upVal)
+	if hasMetricFamily(mfs, "tdarr_files_total") {
+		t.Error("unexpected tdarr_files_total emitted after early-return on stats failure")
 	}
 }
 
 // TestCollect_LibraryListFails_UpEquals0 verifies tdarr_up == 0 when the library-list cruddb
-// call (mode=getAll) fails while the stats-by-id call succeeds.
+// call (collection=LibrarySettingsJSONDB) fails while the stats-by-id call succeeds.
 func TestCollect_LibraryListFails_UpEquals0(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v2/cruddb", func(w http.ResponseWriter, r *http.Request) {
-		mode := parseCruddbMode(r)
-		if mode == "getAll" {
-			http.Error(w, "internal error", http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validStatsBody())
-	})
-	mux.HandleFunc("/api/v2/stats/get-pies", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validPieBody())
-	})
-	mux.HandleFunc("/api/v2/get-nodes", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validNodeBody())
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	cfg := newTestConfig(t, srv.URL)
-	c := NewTdarrCollector(cfg)
+	cfg := newTestConfig(t)
+	api := newSuccessFakeAPI(cfg)
+	api.setError(fakeKey{path: cfg.TdarrStatsPath, disc: "LibrarySettingsJSONDB"}, statErr{"library list failed"})
+	c := newTdarrCollectorWithAPI(cfg, api)
 
 	got := getUpValue(t, c)
 	if got != 0.0 {
@@ -271,81 +194,28 @@ func TestCollect_LibraryListFails_UpEquals0(t *testing.T) {
 // TestCollect_NodeFetchFails_UpEquals0 verifies tdarr_up == 0 when the node endpoint fails,
 // and that general + pie stats metrics were still emitted before the node failure.
 func TestCollect_NodeFetchFails_UpEquals0(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v2/cruddb", func(w http.ResponseWriter, r *http.Request) {
-		mode := parseCruddbMode(r)
-		w.Header().Set("Content-Type", "application/json")
-		if mode == "getAll" {
-			_, _ = w.Write(validLibraryListBody())
-		} else {
-			_, _ = w.Write(validStatsBody())
-		}
-	})
-	mux.HandleFunc("/api/v2/stats/get-pies", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validPieBody())
-	})
-	mux.HandleFunc("/api/v2/get-nodes", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "internal error", http.StatusInternalServerError)
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
+	cfg := newTestConfig(t)
+	api := newSuccessFakeAPI(cfg)
+	api.setError(fakeKey{path: cfg.TdarrNodePath}, statErr{"node fetch failed"})
+	c := newTdarrCollectorWithAPI(cfg, api)
 
-	cfg := newTestConfig(t, srv.URL)
-	c := NewTdarrCollector(cfg)
-
-	reg := prometheus.NewRegistry()
-	reg.MustRegister(c)
-	mfs, err := reg.Gather()
-	if err != nil {
-		t.Fatalf("gather: %v", err)
+	mfs := gatherMetricFamilies(t, c)
+	if upValueFromFamilies(mfs) != 0.0 {
+		t.Errorf("tdarr_up: want 0.0, got %v", upValueFromFamilies(mfs))
 	}
-
-	upVal := -1.0
-	hasTotalFiles := false
-	for _, mf := range mfs {
-		switch mf.GetName() {
-		case "tdarr_up":
-			upVal = mf.GetMetric()[0].GetGauge().GetValue()
-		case "tdarr_files_total":
-			hasTotalFiles = true
-		}
-	}
-	if upVal != 0.0 {
-		t.Errorf("tdarr_up: want 0.0, got %v", upVal)
-	}
-	if !hasTotalFiles {
+	if !hasMetricFamily(mfs, "tdarr_files_total") {
 		t.Error("expected tdarr_files_total to be emitted despite node failure")
 	}
 }
 
-// TestCollect_PartialPieFailure_UpEquals0 verifies tdarr_up == 0 when all get-pies calls fail
-// (all workers encounter errors, setting partialFailure = true).
-// Note: returning 500 for all get-pies requests triggers the partial failure path since every
-// worker goroutine records a failure via c.partialFailure.Store(true).
+// TestCollect_PartialPieFailure_UpEquals0 verifies tdarr_up == 0 when the get-pies call fails
+// (the worker records a partial failure via c.partialFailure.Store(true)), while general stats
+// emitted before the pie fetch are still present.
 func TestCollect_PartialPieFailure_UpEquals0(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v2/cruddb", func(w http.ResponseWriter, r *http.Request) {
-		mode := parseCruddbMode(r)
-		w.Header().Set("Content-Type", "application/json")
-		if mode == "getAll" {
-			_, _ = w.Write(validLibraryListBody())
-		} else {
-			_, _ = w.Write(validStatsBody())
-		}
-	})
-	mux.HandleFunc("/api/v2/stats/get-pies", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "internal error", http.StatusInternalServerError)
-	})
-	mux.HandleFunc("/api/v2/get-nodes", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validNodeBody())
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	cfg := newTestConfig(t, srv.URL)
-	c := NewTdarrCollector(cfg)
+	cfg := newTestConfig(t)
+	api := newSuccessFakeAPI(cfg)
+	api.setError(fakeKey{path: cfg.TdarrPieStatsPath, disc: "lib1"}, statErr{"pie fetch failed"})
+	c := newTdarrCollectorWithAPI(cfg, api)
 
 	mfs := gatherMetricFamilies(t, c)
 	if upValueFromFamilies(mfs) != 0.0 {
@@ -367,39 +237,14 @@ func TestCollect_PartialPieFailure_UpEquals0(t *testing.T) {
 // flag would leak across scrapes: scrape 2 would still report tdarr_up == 0 even when all
 // endpoints succeed.
 func TestCollect_ConsecutiveScrapes_PartialFlagResets(t *testing.T) {
-	// pieFailure controls whether get-pies returns an error. 1 = fail, 0 = succeed.
-	var pieFailure atomic.Int32
-	pieFailure.Store(1) // scrape 1: fail
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v2/cruddb", func(w http.ResponseWriter, r *http.Request) {
-		mode := parseCruddbMode(r)
-		w.Header().Set("Content-Type", "application/json")
-		if mode == "getAll" {
-			_, _ = w.Write(validLibraryListBody())
-		} else {
-			_, _ = w.Write(validStatsBody())
-		}
-	})
-	mux.HandleFunc("/api/v2/stats/get-pies", func(w http.ResponseWriter, r *http.Request) {
-		if pieFailure.Load() == 1 {
-			http.Error(w, "internal error", http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validPieBody())
-	})
-	mux.HandleFunc("/api/v2/get-nodes", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validNodeBody())
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	cfg := newTestConfig(t, srv.URL)
-	c := NewTdarrCollector(cfg)
+	cfg := newTestConfig(t)
+	api := newSuccessFakeAPI(cfg)
+	pieKey := fakeKey{path: cfg.TdarrPieStatsPath, disc: "lib1"}
 
 	// Scrape 1: pie fails → tdarr_up should be 0.
+	api.setError(pieKey, statErr{"pie fetch failed"})
+	c := newTdarrCollectorWithAPI(cfg, api)
+
 	// Use a fresh registry each scrape to avoid "already registered" errors.
 	reg1 := prometheus.NewRegistry()
 	reg1.MustRegister(c)
@@ -407,18 +252,12 @@ func TestCollect_ConsecutiveScrapes_PartialFlagResets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scrape 1 gather: %v", err)
 	}
-	up1 := -1.0
-	for _, mf := range mfs1 {
-		if mf.GetName() == "tdarr_up" {
-			up1 = mf.GetMetric()[0].GetGauge().GetValue()
-		}
-	}
-	if up1 != 0.0 {
+	if up1 := upValueFromFamilies(mfs1); up1 != 0.0 {
 		t.Errorf("scrape 1 tdarr_up: want 0.0, got %v", up1)
 	}
 
 	// Flip to success mode for scrape 2.
-	pieFailure.Store(0)
+	delete(api.errors, pieKey)
 	// Reset the stats cache so the collector re-fetches library pie stats
 	// (cache hit avoids pie calls entirely, which would skip the test's purpose).
 	c.statsCache = NewTdarrLibStatsCache()
@@ -430,13 +269,7 @@ func TestCollect_ConsecutiveScrapes_PartialFlagResets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scrape 2 gather: %v", err)
 	}
-	up2 := -1.0
-	for _, mf := range mfs2 {
-		if mf.GetName() == "tdarr_up" {
-			up2 = mf.GetMetric()[0].GetGauge().GetValue()
-		}
-	}
-	if up2 != 1.0 {
+	if up2 := upValueFromFamilies(mfs2); up2 != 1.0 {
 		t.Errorf("scrape 2 tdarr_up: want 1.0, got %v (partialFailure flag leaked from scrape 1)", up2)
 	}
 }
@@ -445,35 +278,12 @@ func TestCollect_ConsecutiveScrapes_PartialFlagResets(t *testing.T) {
 // returns an unparseable tdarrScore string, and that no data metrics beyond tdarr_up are emitted
 // (score parse failure in collect() returns early, before any ch <- emissions).
 func TestCollect_StatsScoreUnparseable_UpEquals0(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v2/cruddb", func(w http.ResponseWriter, r *http.Request) {
-		mode := parseCruddbMode(r)
-		w.Header().Set("Content-Type", "application/json")
-		if mode == "getAll" {
-			_, _ = w.Write(validLibraryListBody())
-		} else {
-			m := TdarrMetric{
-				TotalFileCount:   10,
-				TdarrScore:       "not-a-float",
-				HealthCheckScore: "0",
-			}
-			b, _ := json.Marshal(m)
-			_, _ = w.Write(b)
-		}
-	})
-	mux.HandleFunc("/api/v2/stats/get-pies", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validPieBody())
-	})
-	mux.HandleFunc("/api/v2/get-nodes", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validNodeBody())
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	cfg := newTestConfig(t, srv.URL)
-	c := NewTdarrCollector(cfg)
+	cfg := newTestConfig(t)
+	api := newSuccessFakeAPI(cfg)
+	m := TdarrMetric{TotalFileCount: 10, TdarrScore: "not-a-float", HealthCheckScore: "0"}
+	b, _ := json.Marshal(m)
+	api.setResponse(fakeKey{path: cfg.TdarrStatsPath, disc: "StatisticsJSONDB"}, b)
+	c := newTdarrCollectorWithAPI(cfg, api)
 
 	mfs := gatherMetricFamilies(t, c)
 	if upValueFromFamilies(mfs) != 0.0 {
@@ -488,35 +298,12 @@ func TestCollect_StatsScoreUnparseable_UpEquals0(t *testing.T) {
 // returns an unparseable healthCheckScore string, and that no data metrics beyond tdarr_up are
 // emitted (health score parse failure in collect() returns early, before any ch <- emissions).
 func TestCollect_HealthScoreUnparseable_UpEquals0(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v2/cruddb", func(w http.ResponseWriter, r *http.Request) {
-		mode := parseCruddbMode(r)
-		w.Header().Set("Content-Type", "application/json")
-		if mode == "getAll" {
-			_, _ = w.Write(validLibraryListBody())
-		} else {
-			m := TdarrMetric{
-				TotalFileCount:   10,
-				TdarrScore:       "0",
-				HealthCheckScore: "garbage",
-			}
-			b, _ := json.Marshal(m)
-			_, _ = w.Write(b)
-		}
-	})
-	mux.HandleFunc("/api/v2/stats/get-pies", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validPieBody())
-	})
-	mux.HandleFunc("/api/v2/get-nodes", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(validNodeBody())
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	cfg := newTestConfig(t, srv.URL)
-	c := NewTdarrCollector(cfg)
+	cfg := newTestConfig(t)
+	api := newSuccessFakeAPI(cfg)
+	m := TdarrMetric{TotalFileCount: 10, TdarrScore: "0", HealthCheckScore: "garbage"}
+	b, _ := json.Marshal(m)
+	api.setResponse(fakeKey{path: cfg.TdarrStatsPath, disc: "StatisticsJSONDB"}, b)
+	c := newTdarrCollectorWithAPI(cfg, api)
 
 	mfs := gatherMetricFamilies(t, c)
 	if upValueFromFamilies(mfs) != 0.0 {
@@ -531,9 +318,8 @@ func TestCollect_HealthScoreUnparseable_UpEquals0(t *testing.T) {
 // in a strict prometheus.Registry does not produce a describe/collect mismatch error.
 // This guards against upMetric or any other descriptor being missing from Describe().
 func TestCollect_RegisteredInRegistry_NoDescribeError(t *testing.T) {
-	srv := newFullSuccessServer(t)
-	cfg := newTestConfig(t, srv.URL)
-	c := NewTdarrCollector(cfg)
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, newSuccessFakeAPI(cfg))
 
 	reg := prometheus.NewRegistry()
 	if err := reg.Register(c); err != nil {

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/url"
@@ -362,7 +363,7 @@ func TestCollect_ErrorCause(t *testing.T) {
 
 			// Drain emissions into a buffered channel so collect() never blocks.
 			ch := make(chan prometheus.Metric, 512)
-			err := c.collect(ch)
+			err := c.collect(context.Background(), ch)
 			close(ch)
 
 			if err == nil {
@@ -372,6 +373,36 @@ func TestCollect_ErrorCause(t *testing.T) {
 				t.Errorf("collect error = %v; want errors.Is(..., %v)", err, tc.wantCause)
 			}
 		})
+	}
+}
+
+// TestCollect_ContextCancelled_Aborts verifies the context seam: when the
+// collector's baseCtx is already cancelled, the very first request aborts and
+// collect() returns an error that carries both the cancellation cause and the
+// ErrUpstream category — i.e. a scrape in flight at shutdown unwinds instead of
+// running to completion.
+func TestCollect_ContextCancelled_Aborts(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, newSuccessFakeAPI(cfg))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before collecting
+	c.baseCtx = ctx
+
+	ch := make(chan prometheus.Metric, 512)
+	err := c.collect(ctx, ch)
+	close(ch)
+
+	if err == nil {
+		t.Fatal("collect: want error from cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("collect error = %v; want errors.Is(..., context.Canceled)", err)
+	}
+	if !errors.Is(err, ErrUpstream) {
+		t.Errorf("collect error = %v; want errors.Is(..., ErrUpstream)", err)
 	}
 }
 

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/json"
 	"net/url"
+	"regexp"
 	"testing"
 
 	"github.com/homeylab/tdarr-exporter/internal/config"
@@ -327,5 +328,73 @@ func TestCollect_RegisteredInRegistry_NoDescribeError(t *testing.T) {
 	}
 	if _, err := reg.Gather(); err != nil {
 		t.Fatalf("gather: %v", err)
+	}
+}
+
+// descFqNameRe extracts the fqName from a *prometheus.Desc's String() form, e.g.
+// `Desc{fqName: "tdarr_files_total", ...}`. The fqName is not exported any other way.
+var descFqNameRe = regexp.MustCompile(`fqName: "([^"]*)"`)
+
+func descFqName(t *testing.T, d *prometheus.Desc) string {
+	t.Helper()
+	m := descFqNameRe.FindStringSubmatch(d.String())
+	if m == nil {
+		t.Fatalf("could not extract fqName from desc: %s", d.String())
+	}
+	return m[1]
+}
+
+// TestDescribe_EmitsAllDescs locks the Describe drift hazard: Prometheus does NOT flag a
+// desc that silently drops out of Describe (it only errors on a Collect desc that was never
+// described), so a missing Describe entry is invisible without an explicit count assertion.
+// This test calls Describe, collects every emitted desc, and asserts both the exact total
+// count (collector + node descs) and that a representative sample of fqNames is present.
+func TestDescribe_EmitsAllDescs(t *testing.T) {
+	t.Parallel()
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, newSuccessFakeAPI(cfg))
+
+	// Drain Describe into a slice. Buffer generously so the send never blocks.
+	ch := make(chan *prometheus.Desc, 256)
+	c.Describe(ch)
+	close(ch)
+
+	var descs []*prometheus.Desc
+	fqNames := make(map[string]int)
+	for d := range ch {
+		descs = append(descs, d)
+		fqNames[descFqName(t, d)]++
+	}
+
+	// 23 collector descs + 24 node descs. Adding/removing a metric must update this number,
+	// which is exactly the point: the count is the tripwire for a dropped Describe entry.
+	const wantCollectorDescs = 23
+	const wantNodeDescs = 24
+	wantTotal := wantCollectorDescs + wantNodeDescs
+	if len(descs) != wantTotal {
+		t.Fatalf("Describe emitted %d descs, want %d (collector %d + node %d)",
+			len(descs), wantTotal, wantCollectorDescs, wantNodeDescs)
+	}
+
+	// No duplicate fqName should appear — each metric is described exactly once.
+	for name, n := range fqNames {
+		if n != 1 {
+			t.Errorf("fqName %q described %d times, want 1", name, n)
+		}
+	}
+
+	// Representative sample spanning collector totals, the up gauge, the drift counter,
+	// and both node-level and worker-level node descs.
+	wantPresent := []string{
+		"tdarr_files_total",
+		"tdarr_up",
+		"tdarr_unknown_status_total",
+		"tdarr_node_info",
+		"tdarr_node_worker_info",
+	}
+	for _, name := range wantPresent {
+		if fqNames[name] == 0 {
+			t.Errorf("Describe missing expected desc %q", name)
+		}
 	}
 }

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"encoding/json"
+	"errors"
 	"net/url"
 	"regexp"
 	"testing"
@@ -312,6 +313,65 @@ func TestCollect_HealthScoreUnparseable_UpEquals0(t *testing.T) {
 	}
 	if hasMetricFamily(mfs, "tdarr_files_total") {
 		t.Error("expected no tdarr_files_total: health score parse failure should return before any data emissions")
+	}
+}
+
+// TestCollect_ErrorCause verifies that collect() wraps the sentinel matching the
+// failure category, so callers/tests can branch on the cause via errors.Is rather
+// than matching error strings. Each case drives a distinct failure boundary.
+func TestCollect_ErrorCause(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		setup     func(cfg config.Config, api *fakeTdarrAPI)
+		wantCause error
+	}{
+		{
+			name: "stats API failure is ErrUpstream",
+			setup: func(cfg config.Config, api *fakeTdarrAPI) {
+				api.setError(fakeKey{path: cfg.TdarrStatsPath, disc: "StatisticsJSONDB"}, statErr{"boom"})
+			},
+			wantCause: ErrUpstream,
+		},
+		{
+			name: "node fetch failure is ErrUpstream",
+			setup: func(cfg config.Config, api *fakeTdarrAPI) {
+				api.setError(fakeKey{path: cfg.TdarrNodePath}, statErr{"boom"})
+			},
+			wantCause: ErrUpstream,
+		},
+		{
+			name: "unparseable score is ErrParse",
+			setup: func(cfg config.Config, api *fakeTdarrAPI) {
+				m := TdarrMetric{TotalFileCount: 1, TdarrScore: "not-a-float", HealthCheckScore: "0"}
+				b, _ := json.Marshal(m)
+				api.setResponse(fakeKey{path: cfg.TdarrStatsPath, disc: "StatisticsJSONDB"}, b)
+			},
+			wantCause: ErrParse,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := newTestConfig(t)
+			api := newSuccessFakeAPI(cfg)
+			tc.setup(cfg, api)
+			c := newTdarrCollectorWithAPI(cfg, api)
+
+			// Drain emissions into a buffered channel so collect() never blocks.
+			ch := make(chan prometheus.Metric, 512)
+			err := c.collect(ch)
+			close(ch)
+
+			if err == nil {
+				t.Fatalf("collect: want error wrapping %v, got nil", tc.wantCause)
+			}
+			if !errors.Is(err, tc.wantCause) {
+				t.Errorf("collect error = %v; want errors.Is(..., %v)", err, tc.wantCause)
+			}
+		})
 	}
 }
 

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -1,16 +1,19 @@
 package collector
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"net/url"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/homeylab/tdarr-exporter/internal/config"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/rs/zerolog"
 )
 
 // newTestConfig builds a Config with sane test defaults. UrlParsed is set so the
@@ -373,6 +376,29 @@ func TestCollect_ErrorCause(t *testing.T) {
 				t.Errorf("collect error = %v; want errors.Is(..., %v)", err, tc.wantCause)
 			}
 		})
+	}
+}
+
+// TestCollect_InjectedLogger_CapturesOutput verifies the logger seam: a logger
+// injected into the collector receives its log output, so tests can capture or
+// silence logs without touching the package global. Drives the Collect error path
+// and asserts the "Collection cycle failed" line lands in the injected buffer.
+func TestCollect_InjectedLogger_CapturesOutput(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfig(t)
+	api := newSuccessFakeAPI(cfg)
+	api.setError(fakeKey{path: cfg.TdarrStatsPath, disc: "StatisticsJSONDB"}, statErr{"boom"})
+	c := newTdarrCollectorWithAPI(cfg, api)
+
+	var buf bytes.Buffer
+	c.logger = zerolog.New(&buf)
+
+	// Collect swallows the error after logging it via the injected logger.
+	gatherMetricFamilies(t, c)
+
+	if !strings.Contains(buf.String(), "Collection cycle failed") {
+		t.Errorf("injected logger did not capture the failure log; buffer = %q", buf.String())
 	}
 }
 

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -366,9 +366,9 @@ func TestDescribe_EmitsAllDescs(t *testing.T) {
 		fqNames[descFqName(t, d)]++
 	}
 
-	// 23 collector descs + 24 node descs. Adding/removing a metric must update this number,
+	// 24 collector descs + 24 node descs. Adding/removing a metric must update this number,
 	// which is exactly the point: the count is the tripwire for a dropped Describe entry.
-	const wantCollectorDescs = 23
+	const wantCollectorDescs = 24
 	const wantNodeDescs = 24
 	wantTotal := wantCollectorDescs + wantNodeDescs
 	if len(descs) != wantTotal {
@@ -389,6 +389,7 @@ func TestDescribe_EmitsAllDescs(t *testing.T) {
 		"tdarr_files_total",
 		"tdarr_up",
 		"tdarr_unknown_status_total",
+		"tdarr_library_audio_resolutions",
 		"tdarr_node_info",
 		"tdarr_node_worker_info",
 	}

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -483,9 +483,9 @@ func TestDescribe_EmitsAllDescs(t *testing.T) {
 		fqNames[descFqName(t, d)]++
 	}
 
-	// 24 collector descs + 24 node descs. Adding/removing a metric must update this number,
+	// 23 collector descs + 24 node descs. Adding/removing a metric must update this number,
 	// which is exactly the point: the count is the tripwire for a dropped Describe entry.
-	const wantCollectorDescs = 24
+	const wantCollectorDescs = 23
 	const wantNodeDescs = 24
 	wantTotal := wantCollectorDescs + wantNodeDescs
 	if len(descs) != wantTotal {
@@ -506,7 +506,7 @@ func TestDescribe_EmitsAllDescs(t *testing.T) {
 		"tdarr_files_total",
 		"tdarr_up",
 		"tdarr_unknown_status_total",
-		"tdarr_library_audio_resolutions",
+		"tdarr_library_audio_containers",
 		"tdarr_node_info",
 		"tdarr_node_worker_info",
 	}

--- a/internal/collector/testdata/expected_output.txt
+++ b/internal/collector/testdata/expected_output.txt
@@ -1,0 +1,217 @@
+# HELP tdarr_avg_num_streams Tdarr average number of streams in video
+# TYPE tdarr_avg_num_streams gauge
+tdarr_avg_num_streams{tdarr_instance="tdarr.localdomain"} 3.5
+# HELP tdarr_files_total Tdarr total file count - includes files in ignore lists within each library
+# TYPE tdarr_files_total gauge
+tdarr_files_total{tdarr_instance="tdarr.localdomain"} 1500
+# HELP tdarr_health_check_score_pct Tdarr health check score percentage - how much of your libraries has been health checked by tdarr
+# TYPE tdarr_health_check_score_pct gauge
+tdarr_health_check_score_pct{tdarr_instance="tdarr.localdomain"} 93.33
+# HELP tdarr_health_checks_total Tdarr total health check count for all libraries
+# TYPE tdarr_health_checks_total gauge
+tdarr_health_checks_total{tdarr_instance="tdarr.localdomain"} 1400
+# HELP tdarr_library_audio_codecs Tdarr audio codecs for library by type
+# TYPE tdarr_library_audio_codecs gauge
+tdarr_library_audio_codecs{codec="aac",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 310
+tdarr_library_audio_codecs{codec="flac",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 180
+tdarr_library_audio_codecs{codec="opus",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 10
+# HELP tdarr_library_audio_containers Tdarr video containers for library by type
+# TYPE tdarr_library_audio_containers gauge
+tdarr_library_audio_containers{container_type="m4a",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 10
+tdarr_library_audio_containers{container_type="mkv",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 490
+# HELP tdarr_library_files_total Tdarr total files in library
+# TYPE tdarr_library_files_total gauge
+tdarr_library_files_total{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 500
+tdarr_library_files_total{library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 1000
+# HELP tdarr_library_health_checks Tdarr health checks for library by status
+# TYPE tdarr_library_health_checks gauge
+tdarr_library_health_checks{library_id="lib-audio-01",library_name="Music",status="cancelled",tdarr_instance="tdarr.localdomain"} 5
+tdarr_library_health_checks{library_id="lib-audio-01",library_name="Music",status="error",tdarr_instance="tdarr.localdomain"} 10
+tdarr_library_health_checks{library_id="lib-audio-01",library_name="Music",status="queued",tdarr_instance="tdarr.localdomain"} 15
+tdarr_library_health_checks{library_id="lib-audio-01",library_name="Music",status="success",tdarr_instance="tdarr.localdomain"} 420
+tdarr_library_health_checks{library_id="lib-video-01",library_name="Shows",status="cancelled",tdarr_instance="tdarr.localdomain"} 2
+tdarr_library_health_checks{library_id="lib-video-01",library_name="Shows",status="error",tdarr_instance="tdarr.localdomain"} 18
+tdarr_library_health_checks{library_id="lib-video-01",library_name="Shows",status="queued",tdarr_instance="tdarr.localdomain"} 5
+tdarr_library_health_checks{library_id="lib-video-01",library_name="Shows",status="success",tdarr_instance="tdarr.localdomain"} 880
+# HELP tdarr_library_health_checks_total Tdarr total health checks for library by status
+# TYPE tdarr_library_health_checks_total gauge
+tdarr_library_health_checks_total{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 450
+tdarr_library_health_checks_total{library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 950
+# HELP tdarr_library_size_diff_gb Tdarr size difference (+/-) in GB for library
+# TYPE tdarr_library_size_diff_gb gauge
+tdarr_library_size_diff_gb{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 15.5
+tdarr_library_size_diff_gb{library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 30.25
+# HELP tdarr_library_transcodes Tdarr transcodes for library by status
+# TYPE tdarr_library_transcodes gauge
+tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="cancelled",tdarr_instance="tdarr.localdomain"} 0
+tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="error",tdarr_instance="tdarr.localdomain"} 3
+tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="hold",tdarr_instance="tdarr.localdomain"} 0
+tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="ignored",tdarr_instance="tdarr.localdomain"} 0
+tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="not required",tdarr_instance="tdarr.localdomain"} 200
+tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="pending",tdarr_instance="tdarr.localdomain"} 7
+tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="queued",tdarr_instance="tdarr.localdomain"} 2
+tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="success",tdarr_instance="tdarr.localdomain"} 100
+tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="cancelled",tdarr_instance="tdarr.localdomain"} 1
+tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="error",tdarr_instance="tdarr.localdomain"} 12
+tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="hold",tdarr_instance="tdarr.localdomain"} 3
+tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="ignored",tdarr_instance="tdarr.localdomain"} 2
+tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="not required",tdarr_instance="tdarr.localdomain"} 400
+tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="queued",tdarr_instance="tdarr.localdomain"} 8
+tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="success",tdarr_instance="tdarr.localdomain"} 250
+# HELP tdarr_library_transcodes_total Tdarr total transcodes for library by status
+# TYPE tdarr_library_transcodes_total gauge
+tdarr_library_transcodes_total{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 150
+tdarr_library_transcodes_total{library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 700
+# HELP tdarr_library_video_codecs Tdarr video codecs for library by type
+# TYPE tdarr_library_video_codecs gauge
+tdarr_library_video_codecs{codec="h264",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 20
+tdarr_library_video_codecs{codec="h264",library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 370
+tdarr_library_video_codecs{codec="hevc",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 480
+tdarr_library_video_codecs{codec="hevc",library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 620
+tdarr_library_video_codecs{codec="av1",library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 10
+# HELP tdarr_library_video_containers Tdarr video containers for library by type
+# TYPE tdarr_library_video_containers gauge
+tdarr_library_video_containers{container_type="mkv",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 490
+tdarr_library_video_containers{container_type="mkv",library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 920
+tdarr_library_video_containers{container_type="mp4",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 10
+tdarr_library_video_containers{container_type="mp4",library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 80
+# HELP tdarr_library_video_resolutions Tdarr video resolutions for library by type
+# TYPE tdarr_library_video_resolutions gauge
+tdarr_library_video_resolutions{library_id="lib-audio-01",library_name="Music",resolution="1080p",tdarr_instance="tdarr.localdomain"} 450
+tdarr_library_video_resolutions{library_id="lib-audio-01",library_name="Music",resolution="720p",tdarr_instance="tdarr.localdomain"} 50
+tdarr_library_video_resolutions{library_id="lib-video-01",library_name="Shows",resolution="1080p",tdarr_instance="tdarr.localdomain"} 700
+tdarr_library_video_resolutions{library_id="lib-video-01",library_name="Shows",resolution="4kuhd",tdarr_instance="tdarr.localdomain"} 200
+tdarr_library_video_resolutions{library_id="lib-video-01",library_name="Shows",resolution="720p",tdarr_instance="tdarr.localdomain"} 100
+# HELP tdarr_node_heap_total_mb Tdarr node heap total in MB
+# TYPE tdarr_node_heap_total_mb gauge
+tdarr_node_heap_total_mb{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain"} 128
+tdarr_node_heap_total_mb{node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain"} 64
+# HELP tdarr_node_heap_used_mb Tdarr node heap used in MB
+# TYPE tdarr_node_heap_used_mb gauge
+tdarr_node_heap_used_mb{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain"} 72.8
+tdarr_node_heap_used_mb{node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain"} 45.3
+# HELP tdarr_node_host_cpu_percent Tdarr node cpu percent used
+# TYPE tdarr_node_host_cpu_percent gauge
+tdarr_node_host_cpu_percent{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain"} 85.4
+tdarr_node_host_cpu_percent{node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain"} 2.1
+# HELP tdarr_node_host_mem_total_gb Total memory in GB for host that Tdarr node is running on
+# TYPE tdarr_node_host_mem_total_gb gauge
+tdarr_node_host_mem_total_gb{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain"} 16
+tdarr_node_host_mem_total_gb{node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain"} 8
+# HELP tdarr_node_host_mem_used_gb Memory used in GB for host that Tdarr node is running on
+# TYPE tdarr_node_host_mem_used_gb gauge
+tdarr_node_host_mem_used_gb{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain"} 6.2
+tdarr_node_host_mem_used_gb{node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain"} 2.5
+# HELP tdarr_node_info Tdarr node identity information
+# TYPE tdarr_node_info gauge
+tdarr_node_info{gpu_can_do_cpu="true",gpu_select="nvidia:0",node_id="node-busy-1",node_name="BusyNode",node_pid="2001",node_priority="1",tdarr_instance="tdarr.localdomain"} 1
+tdarr_node_info{gpu_can_do_cpu="false",gpu_select="-",node_id="node-idle-1",node_name="IdleNode",node_pid="1001",node_priority="0",tdarr_instance="tdarr.localdomain"} 1
+# HELP tdarr_node_max_gpu_workers Maximum number of GPU workers configured for the Tdarr node
+# TYPE tdarr_node_max_gpu_workers gauge
+tdarr_node_max_gpu_workers{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain"} 1
+tdarr_node_max_gpu_workers{node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain"} 0
+# HELP tdarr_node_paused 1 if the Tdarr node is paused, 0 otherwise
+# TYPE tdarr_node_paused gauge
+tdarr_node_paused{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain"} 0
+tdarr_node_paused{node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain"} 0
+# HELP tdarr_node_queue_length Current queue length on the Tdarr node by worker_type and compute_type
+# TYPE tdarr_node_queue_length gauge
+tdarr_node_queue_length{compute_type="cpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 1
+tdarr_node_queue_length{compute_type="cpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 3
+tdarr_node_queue_length{compute_type="gpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 0
+tdarr_node_queue_length{compute_type="gpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 0
+tdarr_node_queue_length{compute_type="cpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 0
+tdarr_node_queue_length{compute_type="cpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 0
+tdarr_node_queue_length{compute_type="gpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 0
+tdarr_node_queue_length{compute_type="gpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 0
+# HELP tdarr_node_schedule_enabled 1 if scheduled operation is enabled on the Tdarr node, 0 otherwise
+# TYPE tdarr_node_schedule_enabled gauge
+tdarr_node_schedule_enabled{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain"} 1
+tdarr_node_schedule_enabled{node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain"} 0
+# HELP tdarr_node_uptime_seconds Tdarr node uptime in seconds
+# TYPE tdarr_node_uptime_seconds gauge
+tdarr_node_uptime_seconds{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain"} 14400
+tdarr_node_uptime_seconds{node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain"} 7200
+# HELP tdarr_node_worker_count Number of active workers on the Tdarr node by worker_type and compute_type
+# TYPE tdarr_node_worker_count gauge
+tdarr_node_worker_count{compute_type="cpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 0
+tdarr_node_worker_count{compute_type="cpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 1
+tdarr_node_worker_count{compute_type="gpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 0
+tdarr_node_worker_count{compute_type="gpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 0
+tdarr_node_worker_count{compute_type="cpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 0
+tdarr_node_worker_count{compute_type="cpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 0
+tdarr_node_worker_count{compute_type="gpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 0
+tdarr_node_worker_count{compute_type="gpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 0
+# HELP tdarr_node_worker_est_file_size_gb Tdarr node worker estimated output file size in GB
+# TYPE tdarr_node_worker_est_file_size_gb gauge
+tdarr_node_worker_est_file_size_gb{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 4.2
+# HELP tdarr_node_worker_eta_seconds Tdarr node worker estimated time remaining in seconds
+# TYPE tdarr_node_worker_eta_seconds gauge
+tdarr_node_worker_eta_seconds{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 90
+# HELP tdarr_node_worker_fps Tdarr node worker frames per second
+# TYPE tdarr_node_worker_fps gauge
+tdarr_node_worker_fps{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 125
+# HELP tdarr_node_worker_info Tdarr node worker identity and categorical state (always 1)
+# TYPE tdarr_node_worker_info gauge
+tdarr_node_worker_info{compute_type="cpu",flow_worker="false",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_connected="true",worker_file="/media/shows/Show S01E01.mkv",worker_id="worker-tc-01",worker_idle="false",worker_plugin_id="Tdarr_Plugin_MC93_Migz1FFMPEG",worker_plugin_position="3",worker_status="Transcoding",worker_type="transcode"} 1
+# HELP tdarr_node_worker_job_start_timestamp_seconds Tdarr node worker job start time as Unix timestamp in seconds
+# TYPE tdarr_node_worker_job_start_timestamp_seconds gauge
+tdarr_node_worker_job_start_timestamp_seconds{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 1.7e+09
+# HELP tdarr_node_worker_limit Configured worker limit on the Tdarr node by worker_type and compute_type
+# TYPE tdarr_node_worker_limit gauge
+tdarr_node_worker_limit{compute_type="cpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 1
+tdarr_node_worker_limit{compute_type="cpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 2
+tdarr_node_worker_limit{compute_type="gpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 0
+tdarr_node_worker_limit{compute_type="gpu",node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 1
+tdarr_node_worker_limit{compute_type="cpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 1
+tdarr_node_worker_limit{compute_type="cpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 2
+tdarr_node_worker_limit{compute_type="gpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="healthcheck"} 0
+tdarr_node_worker_limit{compute_type="gpu",node_id="node-idle-1",node_name="IdleNode",tdarr_instance="tdarr.localdomain",worker_type="transcode"} 0
+# HELP tdarr_node_worker_original_file_size_gb Tdarr node worker original file size in GB
+# TYPE tdarr_node_worker_original_file_size_gb gauge
+tdarr_node_worker_original_file_size_gb{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 4.5
+# HELP tdarr_node_worker_output_file_size_gb Tdarr node worker current output file size in GB
+# TYPE tdarr_node_worker_output_file_size_gb gauge
+tdarr_node_worker_output_file_size_gb{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 2.1
+# HELP tdarr_node_worker_percentage Tdarr node worker transcode/healthcheck progress percentage
+# TYPE tdarr_node_worker_percentage gauge
+tdarr_node_worker_percentage{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 45.75
+# HELP tdarr_node_worker_pid Tdarr node worker process ID
+# TYPE tdarr_node_worker_pid gauge
+tdarr_node_worker_pid{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 5432
+# HELP tdarr_node_worker_start_timestamp_seconds Tdarr node worker current plugin step start time as Unix timestamp in seconds
+# TYPE tdarr_node_worker_start_timestamp_seconds gauge
+tdarr_node_worker_start_timestamp_seconds{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 1.70000005e+09
+# HELP tdarr_node_worker_status_timestamp_seconds Tdarr node worker last status update time as Unix timestamp in seconds
+# TYPE tdarr_node_worker_status_timestamp_seconds gauge
+tdarr_node_worker_status_timestamp_seconds{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 1.7000001e+09
+# HELP tdarr_score_pct Tdarr score percentage - how much of your libraries has been handled by tdarr
+# TYPE tdarr_score_pct gauge
+tdarr_score_pct{tdarr_instance="tdarr.localdomain"} 78.5
+# HELP tdarr_size_diff_gb Tdarr size difference (+/-) in GB
+# TYPE tdarr_size_diff_gb gauge
+tdarr_size_diff_gb{tdarr_instance="tdarr.localdomain"} 45.75
+# HELP tdarr_stream_stats_bit_rate Tdarr stream stats bit rate
+# TYPE tdarr_stream_stats_bit_rate gauge
+tdarr_stream_stats_bit_rate{stat_type="average",tdarr_instance="tdarr.localdomain"} 3.5e+06
+tdarr_stream_stats_bit_rate{stat_type="highest",tdarr_instance="tdarr.localdomain"} 2e+07
+tdarr_stream_stats_bit_rate{stat_type="total",tdarr_instance="tdarr.localdomain"} 1.75e+09
+# HELP tdarr_stream_stats_duration Tdarr stream stats duration
+# TYPE tdarr_stream_stats_duration gauge
+tdarr_stream_stats_duration{stat_type="average",tdarr_instance="tdarr.localdomain"} 2400
+tdarr_stream_stats_duration{stat_type="highest",tdarr_instance="tdarr.localdomain"} 9000
+tdarr_stream_stats_duration{stat_type="total",tdarr_instance="tdarr.localdomain"} 1.2e+06
+# HELP tdarr_stream_stats_num_frames Tdarr stream stats number of frames
+# TYPE tdarr_stream_stats_num_frames gauge
+tdarr_stream_stats_num_frames{stat_type="average",tdarr_instance="tdarr.localdomain"} 57600
+tdarr_stream_stats_num_frames{stat_type="highest",tdarr_instance="tdarr.localdomain"} 216000
+tdarr_stream_stats_num_frames{stat_type="total",tdarr_instance="tdarr.localdomain"} 2.88e+07
+# HELP tdarr_transcodes_total Tdarr total transcode count for all libraries
+# TYPE tdarr_transcodes_total gauge
+tdarr_transcodes_total{tdarr_instance="tdarr.localdomain"} 850
+# HELP tdarr_unknown_status_total Count of pie status values not in the known enum, by job_kind (transcode|healthcheck) and status label. A non-zero value indicates Tdarr emitted a status that the exporter does not pre-emit zeros for. Use increase(tdarr_unknown_status_total[24h]) > 0 to alert on API drift.
+# TYPE tdarr_unknown_status_total counter
+tdarr_unknown_status_total{job_kind="transcode",status="pending",tdarr_instance="tdarr.localdomain"} 1
+# HELP tdarr_up 1 if the last collection cycle succeeded, 0 otherwise (Tdarr API error, response parse error, or partial pie-stats fetch). Distinct from prometheus built-in 'up' which indicates exporter process reachability.
+# TYPE tdarr_up gauge
+tdarr_up{tdarr_instance="tdarr.localdomain"} 1

--- a/internal/collector/testdata/expected_output.txt
+++ b/internal/collector/testdata/expected_output.txt
@@ -19,10 +19,6 @@ tdarr_library_audio_codecs{codec="opus",library_id="lib-audio-01",library_name="
 # TYPE tdarr_library_audio_containers gauge
 tdarr_library_audio_containers{container_type="m4a",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 10
 tdarr_library_audio_containers{container_type="mkv",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 490
-# HELP tdarr_library_audio_resolutions Tdarr audio resolutions for library by type
-# TYPE tdarr_library_audio_resolutions gauge
-tdarr_library_audio_resolutions{library_id="lib-audio-01",library_name="Music",resolution="1080p",tdarr_instance="tdarr.localdomain"} 460
-tdarr_library_audio_resolutions{library_id="lib-audio-01",library_name="Music",resolution="720p",tdarr_instance="tdarr.localdomain"} 40
 # HELP tdarr_library_files_total Tdarr total files in library
 # TYPE tdarr_library_files_total gauge
 tdarr_library_files_total{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 500

--- a/internal/collector/testdata/expected_output.txt
+++ b/internal/collector/testdata/expected_output.txt
@@ -15,7 +15,7 @@ tdarr_health_checks_total{tdarr_instance="tdarr.localdomain"} 1400
 tdarr_library_audio_codecs{codec="aac",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 310
 tdarr_library_audio_codecs{codec="flac",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 180
 tdarr_library_audio_codecs{codec="opus",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 10
-# HELP tdarr_library_audio_containers Tdarr video containers for library by type
+# HELP tdarr_library_audio_containers Tdarr audio containers for library by type
 # TYPE tdarr_library_audio_containers gauge
 tdarr_library_audio_containers{container_type="m4a",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 10
 tdarr_library_audio_containers{container_type="mkv",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 490

--- a/internal/collector/testdata/expected_output.txt
+++ b/internal/collector/testdata/expected_output.txt
@@ -19,6 +19,10 @@ tdarr_library_audio_codecs{codec="opus",library_id="lib-audio-01",library_name="
 # TYPE tdarr_library_audio_containers gauge
 tdarr_library_audio_containers{container_type="m4a",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 10
 tdarr_library_audio_containers{container_type="mkv",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 490
+# HELP tdarr_library_audio_resolutions Tdarr audio resolutions for library by type
+# TYPE tdarr_library_audio_resolutions gauge
+tdarr_library_audio_resolutions{library_id="lib-audio-01",library_name="Music",resolution="1080p",tdarr_instance="tdarr.localdomain"} 460
+tdarr_library_audio_resolutions{library_id="lib-audio-01",library_name="Music",resolution="720p",tdarr_instance="tdarr.localdomain"} 40
 # HELP tdarr_library_files_total Tdarr total files in library
 # TYPE tdarr_library_files_total gauge
 tdarr_library_files_total{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 500

--- a/internal/collector/testdata/general_stats.json
+++ b/internal/collector/testdata/general_stats.json
@@ -1,0 +1,33 @@
+{
+  "totalFileCount": 1500,
+  "totalTranscodeCount": 850,
+  "totalHealthCheckCount": 1400,
+  "sizeDiff": 45.75,
+  "tdarrScore": "78.50",
+  "healthCheckScore": "93.33",
+  "avgNumberOfStreamsInVideo": 3.5,
+  "streamStats": {
+    "duration": {
+      "average": 2400,
+      "highest": 9000,
+      "total": 1200000
+    },
+    "bit_rate": {
+      "average": 3500000,
+      "highest": 20000000,
+      "total": 1750000000
+    },
+    "nb_frames": {
+      "average": 57600,
+      "highest": 216000,
+      "total": 28800000
+    }
+  },
+  "table0Count": 5,
+  "table1Count": 10,
+  "table2Count": 600,
+  "table3Count": 15,
+  "table4Count": 20,
+  "table5Count": 1300,
+  "table6Count": 30
+}

--- a/internal/collector/testdata/library_list.json
+++ b/internal/collector/testdata/library_list.json
@@ -1,0 +1,10 @@
+[
+  {
+    "_id": "lib-video-01",
+    "name": "Shows"
+  },
+  {
+    "_id": "lib-audio-01",
+    "name": "Music"
+  }
+]

--- a/internal/collector/testdata/nodes.json
+++ b/internal/collector/testdata/nodes.json
@@ -1,0 +1,119 @@
+{
+  "node-idle-1": {
+    "_id": "node-idle-1",
+    "nodeName": "IdleNode",
+    "remoteAddress": "192.168.1.10",
+    "config": {
+      "serverIP": "192.168.1.1",
+      "serverPort": "8265",
+      "priority": 0,
+      "processPid": 1001
+    },
+    "workerLimits": {
+      "transcodecpu": 2,
+      "transcodegpu": 0,
+      "healthcheckcpu": 1,
+      "healthcheckgpu": 0
+    },
+    "gpuSelect": "-",
+    "nodePaused": false,
+    "priority": 0,
+    "workers": {},
+    "resStats": {
+      "process": {
+        "uptime": 7200,
+        "heapUsedMB": "45.3",
+        "heapTotalMB": "64.0"
+      },
+      "os": {
+        "cpuPerc": "2.10",
+        "memUsedGB": "2.5",
+        "memTotalGB": "8.0"
+      }
+    },
+    "queueLengths": {
+      "transcodecpu": 0,
+      "transcodegpu": 0,
+      "healthcheckcpu": 0,
+      "healthcheckgpu": 0
+    },
+    "maxGpuWorkers": 0,
+    "scheduleEnabled": false,
+    "allowGpuDoCpu": false
+  },
+  "node-busy-1": {
+    "_id": "node-busy-1",
+    "nodeName": "BusyNode",
+    "remoteAddress": "192.168.1.11",
+    "config": {
+      "serverIP": "192.168.1.1",
+      "serverPort": "8265",
+      "priority": 1,
+      "processPid": 2001
+    },
+    "workerLimits": {
+      "transcodecpu": 2,
+      "transcodegpu": 1,
+      "healthcheckcpu": 1,
+      "healthcheckgpu": 0
+    },
+    "gpuSelect": "nvidia:0",
+    "nodePaused": false,
+    "priority": 1,
+    "workers": {
+      "worker-tc-01": {
+        "_id": "worker-tc-01",
+        "workerType": "transcodecpu",
+        "isFlowWorker": false,
+        "idle": false,
+        "file": "/media/shows/Show S01E01.mkv",
+        "originalfileSizeInGbytes": 4.5,
+        "percentage": 45.75,
+        "fps": 125,
+        "ETA": "0:01:30",
+        "status": "Transcoding",
+        "statusTs": 1700000100,
+        "job": {
+          "version": "2",
+          "start": 1700000000,
+          "type": "transcode",
+          "jobId": "job-abc-123"
+        },
+        "process": {
+          "connected": true,
+          "pid": 5432,
+          "cliType": "ffmpeg"
+        },
+        "lastPluginDetails": {
+          "source": "community",
+          "id": "Tdarr_Plugin_MC93_Migz1FFMPEG",
+          "number": "3"
+        },
+        "startTime": 1700000050,
+        "outputFileSizeInGbytes": 2.1,
+        "estSize": 4.2
+      }
+    },
+    "resStats": {
+      "process": {
+        "uptime": 14400,
+        "heapUsedMB": "72.8",
+        "heapTotalMB": "128.0"
+      },
+      "os": {
+        "cpuPerc": "85.40",
+        "memUsedGB": "6.2",
+        "memTotalGB": "16.0"
+      }
+    },
+    "queueLengths": {
+      "transcodecpu": 3,
+      "transcodegpu": 0,
+      "healthcheckcpu": 1,
+      "healthcheckgpu": 0
+    },
+    "maxGpuWorkers": 1,
+    "scheduleEnabled": true,
+    "allowGpuDoCpu": true
+  }
+}

--- a/internal/collector/testdata/pie_stats_lib_audio_01.json
+++ b/internal/collector/testdata/pie_stats_lib_audio_01.json
@@ -46,7 +46,10 @@
         {"name": "mkv", "value": 490},
         {"name": "m4a", "value": 10}
       ],
-      "resolutions": []
+      "resolutions": [
+        {"name": "1080p", "value": 460},
+        {"name": "720p", "value": 40}
+      ]
     }
   }
 }

--- a/internal/collector/testdata/pie_stats_lib_audio_01.json
+++ b/internal/collector/testdata/pie_stats_lib_audio_01.json
@@ -45,10 +45,6 @@
       "containers": [
         {"name": "mkv", "value": 490},
         {"name": "m4a", "value": 10}
-      ],
-      "resolutions": [
-        {"name": "1080p", "value": 460},
-        {"name": "720p", "value": 40}
       ]
     }
   }

--- a/internal/collector/testdata/pie_stats_lib_audio_01.json
+++ b/internal/collector/testdata/pie_stats_lib_audio_01.json
@@ -1,0 +1,52 @@
+{
+  "pieStats": {
+    "totalFiles": 500,
+    "totalTranscodeCount": 150,
+    "sizeDiff": 15.5,
+    "totalHealthCheckCount": 450,
+    "status": {
+      "transcode": [
+        {"name": "Not required", "value": 200},
+        {"name": "Transcode success", "value": 100},
+        {"name": "Transcode error", "value": 3},
+        {"name": "Queued", "value": 2},
+        {"name": "Hold", "value": 0},
+        {"name": "Ignored", "value": 0},
+        {"name": "Cancelled", "value": 0},
+        {"name": "Pending", "value": 7}
+      ],
+      "healthCheck": [
+        {"name": "Success", "value": 420},
+        {"name": "Error", "value": 10},
+        {"name": "Queued", "value": 15},
+        {"name": "Cancelled", "value": 5}
+      ]
+    },
+    "video": {
+      "codecs": [
+        {"name": "hevc", "value": 480},
+        {"name": "h264", "value": 20}
+      ],
+      "containers": [
+        {"name": "mkv", "value": 490},
+        {"name": "mp4", "value": 10}
+      ],
+      "resolutions": [
+        {"name": "1080p", "value": 450},
+        {"name": "720p", "value": 50}
+      ]
+    },
+    "audio": {
+      "codecs": [
+        {"name": "aac", "value": 310},
+        {"name": "flac", "value": 180},
+        {"name": "opus", "value": 10}
+      ],
+      "containers": [
+        {"name": "mkv", "value": 490},
+        {"name": "m4a", "value": 10}
+      ],
+      "resolutions": []
+    }
+  }
+}

--- a/internal/collector/testdata/pie_stats_lib_video_01.json
+++ b/internal/collector/testdata/pie_stats_lib_video_01.json
@@ -1,0 +1,46 @@
+{
+  "pieStats": {
+    "totalFiles": 1000,
+    "totalTranscodeCount": 700,
+    "sizeDiff": 30.25,
+    "totalHealthCheckCount": 950,
+    "status": {
+      "transcode": [
+        {"name": "Not required", "value": 400},
+        {"name": "Transcode success", "value": 250},
+        {"name": "Transcode error", "value": 12},
+        {"name": "Queued", "value": 8},
+        {"name": "Hold", "value": 3},
+        {"name": "Ignored", "value": 2},
+        {"name": "Cancelled", "value": 1}
+      ],
+      "healthCheck": [
+        {"name": "Success", "value": 880},
+        {"name": "Error", "value": 18},
+        {"name": "Queued", "value": 5},
+        {"name": "Cancelled", "value": 2}
+      ]
+    },
+    "video": {
+      "codecs": [
+        {"name": "hevc", "value": 620},
+        {"name": "h264", "value": 370},
+        {"name": "av1", "value": 10}
+      ],
+      "containers": [
+        {"name": "mkv", "value": 920},
+        {"name": "mp4", "value": 80}
+      ],
+      "resolutions": [
+        {"name": "1080p", "value": 700},
+        {"name": "4kUHD", "value": 200},
+        {"name": "720p", "value": 100}
+      ]
+    },
+    "audio": {
+      "codecs": [],
+      "containers": [],
+      "resolutions": []
+    }
+  }
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,7 +125,10 @@ func applyEnvDefaults(getenv func(string) string) (Config, error) {
 // parseUrl validates and parses the provided url. A missing scheme defaults to
 // https. It returns an error instead of exiting on parse failure.
 func parseUrl(urlString string) (*url.URL, error) {
-	if !strings.HasPrefix(urlString, "http") {
+	// Detect a scheme by the "://" separator, not a "http" prefix: HasPrefix("http")
+	// both misfires on scheme-less hosts that happen to start with "http"
+	// (e.g. "http-server.lan") and mangles non-http schemes.
+	if !strings.Contains(urlString, "://") {
 		log.Warn().Str("url", urlString).Msg("No URL scheme provided, defaulting to https")
 		urlString = "https://" + urlString
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"flag"
+	"fmt"
 	"net/url"
 	"os"
 	"strconv"
@@ -19,6 +20,7 @@ const (
 	envPrometheusPath     = "PROMETHEUS_PATH"
 	envLogLevel           = "LOG_LEVEL"
 	envHttpMaxConcurrency = "HTTP_MAX_CONCURRENCY"
+	envHttpTimeoutSeconds = "HTTP_TIMEOUT_SECONDS"
 )
 
 type Config struct {
@@ -37,32 +39,27 @@ type Config struct {
 	HttpMaxConcurrency int
 }
 
-// func setLoggerDefaults() {
-// 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
-// }
-
-func setLoggerLevel(logLevel string) {
-	// set up global log level for zerolog
-	level := strings.ToLower(logLevel)
-	switch level {
+// parseLogLevel maps a string log level to a zerolog.Level. It returns an error
+// on an unknown level and does NOT mutate the global zerolog level (callers
+// apply the level themselves).
+func parseLogLevel(logLevel string) (zerolog.Level, error) {
+	switch strings.ToLower(logLevel) {
 	case "trace":
-		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+		return zerolog.TraceLevel, nil
 	case "debug":
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+		return zerolog.DebugLevel, nil
 	case "info":
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		return zerolog.InfoLevel, nil
 	case "warn":
-		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+		return zerolog.WarnLevel, nil
 	case "error":
-		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+		return zerolog.ErrorLevel, nil
 	case "fatal":
-		zerolog.SetGlobalLevel(zerolog.FatalLevel)
+		return zerolog.FatalLevel, nil
 	case "panic":
-		zerolog.SetGlobalLevel(zerolog.PanicLevel)
+		return zerolog.PanicLevel, nil
 	default:
-		log.Fatal().
-			Str("log_level", logLevel).
-			Msg("Improper log level given!")
+		return zerolog.NoLevel, fmt.Errorf("improper log level given: %q", logLevel)
 	}
 }
 
@@ -74,6 +71,7 @@ func getDefaults() Config {
 		PrometheusPort:     "9090",
 		PrometheusPath:     "/metrics",
 		HttpTimeoutSeconds: 15,
+		// path fields are intentionally not overridable via env/flag.
 		TdarrStatsPath:     "/api/v2/cruddb",
 		TdarrNodePath:      "/api/v2/get-nodes",
 		TdarrPieStatsPath:  "/api/v2/stats/get-pies",
@@ -81,82 +79,105 @@ func getDefaults() Config {
 	}
 }
 
-func newDefaults() Config {
-	// get defaults and then replace them with env vars if specified
+// applyEnvDefaults overlays environment variables on top of getDefaults using
+// the injected getenv. precedence: defaults -> env (flags are layered later).
+func applyEnvDefaults(getenv func(string) string) (Config, error) {
 	defaults := getDefaults()
-	if tdarrUrlEnv := os.Getenv(envTdarrUrl); tdarrUrlEnv != "" {
+	if tdarrUrlEnv := getenv(envTdarrUrl); tdarrUrlEnv != "" {
 		defaults.url = tdarrUrlEnv
 	}
-	if tdarrApiKeyEnv := os.Getenv(envTdarrApiKey); tdarrApiKeyEnv != "" {
+	if tdarrApiKeyEnv := getenv(envTdarrApiKey); tdarrApiKeyEnv != "" {
 		defaults.ApiKey = tdarrApiKeyEnv
 	}
-	if sslVerifyEnv := os.Getenv(envSslVerify); sslVerifyEnv != "" {
+	if sslVerifyEnv := getenv(envSslVerify); sslVerifyEnv != "" {
 		boolValue, err := strconv.ParseBool(sslVerifyEnv)
 		if err != nil {
-			log.Fatal().
-				Err(err).
-				Msg("Invalid value for verify_ssl! Please provide one of true or false.")
+			return Config{}, fmt.Errorf("invalid value for verify_ssl, please provide one of true or false: %w", err)
 		}
 		defaults.VerifySsl = boolValue
 	}
-	if prometheusPortEnv := os.Getenv(envPrometheusPort); prometheusPortEnv != "" {
+	if prometheusPortEnv := getenv(envPrometheusPort); prometheusPortEnv != "" {
 		defaults.PrometheusPort = prometheusPortEnv
 	}
-	if prometheusPathEnv := os.Getenv(envPrometheusPath); prometheusPathEnv != "" {
+	if prometheusPathEnv := getenv(envPrometheusPath); prometheusPathEnv != "" {
 		defaults.PrometheusPath = prometheusPathEnv
 	}
-	if logLevelEnv := os.Getenv(envLogLevel); logLevelEnv != "" {
+	if logLevelEnv := getenv(envLogLevel); logLevelEnv != "" {
 		defaults.LogLevel = logLevelEnv
 	}
-	if httpMaxConcurrencyEnv := os.Getenv(envHttpMaxConcurrency); httpMaxConcurrencyEnv != "" {
+	if httpMaxConcurrencyEnv := getenv(envHttpMaxConcurrency); httpMaxConcurrencyEnv != "" {
 		intValue, err := strconv.Atoi(httpMaxConcurrencyEnv)
 		if err != nil {
-			log.Fatal().
-				Err(err).
-				Msg("Invalid value for http_max_concurrency! Please provide a valid integer.")
+			return Config{}, fmt.Errorf("invalid value for http_max_concurrency, please provide a valid integer: %w", err)
 		}
 		defaults.HttpMaxConcurrency = intValue
 	}
-	return defaults
+	if httpTimeoutEnv := getenv(envHttpTimeoutSeconds); httpTimeoutEnv != "" {
+		intValue, err := strconv.Atoi(httpTimeoutEnv)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid value for http_timeout_seconds, please provide a valid integer: %w", err)
+		}
+		defaults.HttpTimeoutSeconds = intValue
+	}
+	return defaults, nil
 }
 
-// also act as validation for provided url
-func parseUrl(urlString string) *url.URL {
-	// get hostname from url
+// parseUrl validates and parses the provided url. A missing scheme defaults to
+// https. It returns an error instead of exiting on parse failure.
+func parseUrl(urlString string) (*url.URL, error) {
 	if !strings.HasPrefix(urlString, "http") {
 		log.Warn().Str("url", urlString).Msg("No URL scheme provided, defaulting to https")
 		urlString = "https://" + urlString
 	}
-	url, err := url.Parse(urlString)
+	parsed, err := url.Parse(urlString)
 	if err != nil {
-		log.Fatal().Str("url", urlString).Err(err).Msg("Invalid url provided - failed to parse!")
+		return nil, fmt.Errorf("invalid url provided - failed to parse %q: %w", urlString, err)
 	}
-	return url
+	return parsed, nil
 }
 
-func NewConfig() Config {
-	defaults := newDefaults()
-	url := flag.String("url", defaults.url, "valid url for tdarr instance, ex: https://tdarr.somedomain.com")
-	apiKeyAuth := flag.String("api_key", defaults.ApiKey, "api token for tdarr instance if authentication is enabled")
-	sslVerify := flag.Bool("verify_ssl", defaults.VerifySsl, "verify ssl certificates from tdarr")
-	promPort := flag.String("prometheus_port", defaults.PrometheusPort, "port for prometheus exporter")
-	promPath := flag.String("prometheus_path", defaults.PrometheusPath, "path to use for prometheus exporter")
-	logLevel := flag.String("log_level", defaults.LogLevel, "log level to use, see link for possible values: https://pkg.go.dev/github.com/rs/zerolog#Level")
-	httpMaxConcurrency := flag.Int("http_max_concurrency", defaults.HttpMaxConcurrency, "maximum number of concurrent http requests to make when requesting per Library stats")
-	flag.Parse()
+// parseConfig is the pure, testable core of configuration loading. It applies
+// precedence defaults -> env -> flags using the injected flag set, args, and
+// getenv, and returns validation errors instead of exiting. It does NOT mutate
+// any global state (including the zerolog level).
+func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (Config, error) {
+	defaults, err := applyEnvDefaults(getenv)
+	if err != nil {
+		return Config{}, err
+	}
+
+	url := fs.String("url", defaults.url, "valid url for tdarr instance, ex: https://tdarr.somedomain.com")
+	apiKeyAuth := fs.String("api_key", defaults.ApiKey, "api token for tdarr instance if authentication is enabled")
+	sslVerify := fs.Bool("verify_ssl", defaults.VerifySsl, "verify ssl certificates from tdarr")
+	promPort := fs.String("prometheus_port", defaults.PrometheusPort, "port for prometheus exporter")
+	promPath := fs.String("prometheus_path", defaults.PrometheusPath, "path to use for prometheus exporter")
+	logLevel := fs.String("log_level", defaults.LogLevel, "log level to use, see link for possible values: https://pkg.go.dev/github.com/rs/zerolog#Level")
+	httpMaxConcurrency := fs.Int("http_max_concurrency", defaults.HttpMaxConcurrency, "maximum number of concurrent http requests to make when requesting per Library stats")
+	httpTimeoutSeconds := fs.Int("http_timeout_seconds", defaults.HttpTimeoutSeconds, "timeout in seconds for http requests to the tdarr instance")
+
+	if err := fs.Parse(args); err != nil {
+		return Config{}, err
+	}
+
 	if *url == "" {
-		log.Fatal().
-			Msg("A valid url needs to be provided!")
+		return Config{}, fmt.Errorf("a valid url needs to be provided")
 	}
 	if *httpMaxConcurrency <= 0 {
-		log.Fatal().
-			Msg("http_max_concurrency must be at least 1 (single connection)!")
+		return Config{}, fmt.Errorf("http_max_concurrency must be at least 1 (single connection)")
+	}
+	if *httpTimeoutSeconds <= 0 {
+		return Config{}, fmt.Errorf("http_timeout_seconds must be at least 1")
 	}
 
-	setLoggerLevel(*logLevel)
+	// validate the log level here (without mutating global state).
+	if _, err := parseLogLevel(*logLevel); err != nil {
+		return Config{}, err
+	}
 
-	urlParsed := parseUrl(*url)
-	log.Info().Str("url", urlParsed.String()).Msg("Using provided full url for tdarr instance")
+	urlParsed, err := parseUrl(*url)
+	if err != nil {
+		return Config{}, err
+	}
 
 	return Config{
 		url:                *url,
@@ -167,14 +188,30 @@ func NewConfig() Config {
 		PrometheusPort:     *promPort,
 		PrometheusPath:     *promPath,
 		LogLevel:           *logLevel,
-		HttpTimeoutSeconds: defaults.HttpTimeoutSeconds,
+		HttpTimeoutSeconds: *httpTimeoutSeconds,
+		// path fields are intentionally not overridable.
 		TdarrStatsPath:     defaults.TdarrStatsPath,
 		TdarrNodePath:      defaults.TdarrNodePath,
 		TdarrPieStatsPath:  defaults.TdarrPieStatsPath,
 		HttpMaxConcurrency: *httpMaxConcurrency,
-	}
+	}, nil
 }
 
-// func init() {
-// 	setLoggerDefaults()
-// }
+// NewConfig is the production entrypoint (composition root). It wires os.Args
+// and os.Getenv into the testable parseConfig core, then applies the global
+// side effects (log level mutation, fatal on error, startup logging) that must
+// not live in the testable core.
+func NewConfig() Config {
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	cfg, err := parseConfig(fs, os.Args[1:], os.Getenv)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to load configuration")
+	}
+
+	// parseConfig already validated the log level; apply it globally here.
+	level, _ := parseLogLevel(cfg.LogLevel)
+	zerolog.SetGlobalLevel(level)
+
+	log.Info().Str("url", cfg.UrlParsed.String()).Msg("Using provided full url for tdarr instance")
+	return cfg
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,272 @@
+package config
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// envFunc returns a getenv-compatible function backed by the given map.
+func envFunc(env map[string]string) func(string) string {
+	return func(key string) string {
+		return env[key]
+	}
+}
+
+func newFS() *flag.FlagSet {
+	return flag.NewFlagSet("test", flag.ContinueOnError)
+}
+
+func TestParseConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	// url must come from somewhere (empty url is an error), so supply it via env
+	// while leaving everything else to defaults.
+	env := map[string]string{envTdarrUrl: "https://tdarr.example.com"}
+	cfg, err := parseConfig(newFS(), nil, envFunc(env))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel = %q, want info", cfg.LogLevel)
+	}
+	if !cfg.VerifySsl {
+		t.Errorf("VerifySsl = %v, want true", cfg.VerifySsl)
+	}
+	if cfg.PrometheusPort != "9090" {
+		t.Errorf("PrometheusPort = %q, want 9090", cfg.PrometheusPort)
+	}
+	if cfg.PrometheusPath != "/metrics" {
+		t.Errorf("PrometheusPath = %q, want /metrics", cfg.PrometheusPath)
+	}
+	if cfg.HttpTimeoutSeconds != 15 {
+		t.Errorf("HttpTimeoutSeconds = %d, want 15", cfg.HttpTimeoutSeconds)
+	}
+	if cfg.HttpMaxConcurrency != 3 {
+		t.Errorf("HttpMaxConcurrency = %d, want 3", cfg.HttpMaxConcurrency)
+	}
+	if cfg.ApiKey != "" {
+		t.Errorf("ApiKey = %q, want empty", cfg.ApiKey)
+	}
+	if cfg.TdarrStatsPath != "/api/v2/cruddb" {
+		t.Errorf("TdarrStatsPath = %q, want /api/v2/cruddb", cfg.TdarrStatsPath)
+	}
+	if cfg.TdarrNodePath != "/api/v2/get-nodes" {
+		t.Errorf("TdarrNodePath = %q, want /api/v2/get-nodes", cfg.TdarrNodePath)
+	}
+	if cfg.TdarrPieStatsPath != "/api/v2/stats/get-pies" {
+		t.Errorf("TdarrPieStatsPath = %q, want /api/v2/stats/get-pies", cfg.TdarrPieStatsPath)
+	}
+}
+
+func TestParseConfigEnvOverrides(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		envTdarrUrl:           "https://env.example.com",
+		envTdarrApiKey:        "secret-key",
+		envSslVerify:          "false",
+		envPrometheusPort:     "8080",
+		envPrometheusPath:     "/custom",
+		envLogLevel:           "debug",
+		envHttpMaxConcurrency: "7",
+		envHttpTimeoutSeconds: "42",
+	}
+	cfg, err := parseConfig(newFS(), nil, envFunc(env))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.url != "https://env.example.com" {
+		t.Errorf("url = %q, want https://env.example.com", cfg.url)
+	}
+	if cfg.ApiKey != "secret-key" {
+		t.Errorf("ApiKey = %q, want secret-key", cfg.ApiKey)
+	}
+	if cfg.VerifySsl {
+		t.Errorf("VerifySsl = %v, want false", cfg.VerifySsl)
+	}
+	if cfg.PrometheusPort != "8080" {
+		t.Errorf("PrometheusPort = %q, want 8080", cfg.PrometheusPort)
+	}
+	if cfg.PrometheusPath != "/custom" {
+		t.Errorf("PrometheusPath = %q, want /custom", cfg.PrometheusPath)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want debug", cfg.LogLevel)
+	}
+	if cfg.HttpMaxConcurrency != 7 {
+		t.Errorf("HttpMaxConcurrency = %d, want 7", cfg.HttpMaxConcurrency)
+	}
+	if cfg.HttpTimeoutSeconds != 42 {
+		t.Errorf("HttpTimeoutSeconds = %d, want 42", cfg.HttpTimeoutSeconds)
+	}
+}
+
+func TestParseConfigFlagsOverrideEnv(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		envTdarrUrl:           "https://env.example.com",
+		envTdarrApiKey:        "env-key",
+		envSslVerify:          "true",
+		envPrometheusPort:     "8080",
+		envPrometheusPath:     "/env",
+		envLogLevel:           "warn",
+		envHttpMaxConcurrency: "2",
+		envHttpTimeoutSeconds: "20",
+	}
+	args := []string{
+		"-url", "https://flag.example.com",
+		"-api_key", "flag-key",
+		"-verify_ssl=false",
+		"-prometheus_port", "7000",
+		"-prometheus_path", "/flag",
+		"-log_level", "error",
+		"-http_max_concurrency", "9",
+		"-http_timeout_seconds", "99",
+	}
+	cfg, err := parseConfig(newFS(), args, envFunc(env))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.url != "https://flag.example.com" {
+		t.Errorf("url = %q, want flag value", cfg.url)
+	}
+	if cfg.ApiKey != "flag-key" {
+		t.Errorf("ApiKey = %q, want flag-key", cfg.ApiKey)
+	}
+	if cfg.VerifySsl {
+		t.Errorf("VerifySsl = %v, want false (flag overrides env)", cfg.VerifySsl)
+	}
+	if cfg.PrometheusPort != "7000" {
+		t.Errorf("PrometheusPort = %q, want 7000", cfg.PrometheusPort)
+	}
+	if cfg.PrometheusPath != "/flag" {
+		t.Errorf("PrometheusPath = %q, want /flag", cfg.PrometheusPath)
+	}
+	if cfg.LogLevel != "error" {
+		t.Errorf("LogLevel = %q, want error", cfg.LogLevel)
+	}
+	if cfg.HttpMaxConcurrency != 9 {
+		t.Errorf("HttpMaxConcurrency = %d, want 9", cfg.HttpMaxConcurrency)
+	}
+	if cfg.HttpTimeoutSeconds != 99 {
+		t.Errorf("HttpTimeoutSeconds = %d, want 99", cfg.HttpTimeoutSeconds)
+	}
+}
+
+func TestParseConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		env  map[string]string
+		args []string
+	}{
+		{
+			name: "invalid verify_ssl",
+			env:  map[string]string{envTdarrUrl: "https://x.com", envSslVerify: "notabool"},
+		},
+		{
+			name: "invalid http_max_concurrency",
+			env:  map[string]string{envTdarrUrl: "https://x.com", envHttpMaxConcurrency: "notanint"},
+		},
+		{
+			name: "invalid http_timeout_seconds",
+			env:  map[string]string{envTdarrUrl: "https://x.com", envHttpTimeoutSeconds: "notanint"},
+		},
+		{
+			name: "empty url",
+			env:  map[string]string{},
+		},
+		{
+			name: "http_max_concurrency <= 0",
+			env:  map[string]string{envTdarrUrl: "https://x.com", envHttpMaxConcurrency: "0"},
+		},
+		{
+			name: "http_timeout_seconds <= 0",
+			env:  map[string]string{envTdarrUrl: "https://x.com", envHttpTimeoutSeconds: "0"},
+		},
+		{
+			name: "invalid url",
+			env:  map[string]string{envTdarrUrl: "https://exa mple.com/\x7f"},
+		},
+		{
+			name: "unknown log level",
+			env:  map[string]string{envTdarrUrl: "https://x.com", envLogLevel: "verbose"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseConfig(newFS(), tc.args, envFunc(tc.env))
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestParseConfigUrlSchemeDefaulting(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{envTdarrUrl: "tdarr.example.com"}
+	cfg, err := parseConfig(newFS(), nil, envFunc(env))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := cfg.UrlParsed.String(); got != "https://tdarr.example.com" {
+		t.Errorf("UrlParsed = %q, want https://tdarr.example.com", got)
+	}
+	if cfg.UrlParsed.Scheme != "https" {
+		t.Errorf("scheme = %q, want https", cfg.UrlParsed.Scheme)
+	}
+	if cfg.InstanceName != "tdarr.example.com" {
+		t.Errorf("InstanceName = %q, want tdarr.example.com", cfg.InstanceName)
+	}
+}
+
+func TestParseLogLevel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  zerolog.Level
+	}{
+		{"trace", zerolog.TraceLevel},
+		{"debug", zerolog.DebugLevel},
+		{"info", zerolog.InfoLevel},
+		{"warn", zerolog.WarnLevel},
+		{"error", zerolog.ErrorLevel},
+		{"fatal", zerolog.FatalLevel},
+		{"panic", zerolog.PanicLevel},
+		{"INFO", zerolog.InfoLevel}, // case-insensitive
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseLogLevel(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("parseLogLevel(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("unknown", func(t *testing.T) {
+		t.Parallel()
+		if _, err := parseLogLevel("nope"); err == nil {
+			t.Fatalf("expected error for unknown level, got nil")
+		}
+	})
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -216,20 +216,56 @@ func TestParseConfigErrors(t *testing.T) {
 func TestParseConfigUrlSchemeDefaulting(t *testing.T) {
 	t.Parallel()
 
-	env := map[string]string{envTdarrUrl: "tdarr.example.com"}
-	cfg, err := parseConfig(newFS(), nil, envFunc(env))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	cases := []struct {
+		name         string
+		url          string
+		wantURL      string
+		wantScheme   string
+		wantInstance string
+	}{
+		{
+			name:         "no scheme defaults to https",
+			url:          "tdarr.example.com",
+			wantURL:      "https://tdarr.example.com",
+			wantScheme:   "https",
+			wantInstance: "tdarr.example.com",
+		},
+		{
+			// Scheme detection is by "://", not a "http" prefix: a scheme-less host
+			// that starts with "http" must still get https:// prepended and a valid hostname.
+			name:         "http-prefixed scheme-less host still defaults to https",
+			url:          "http-server.lan",
+			wantURL:      "https://http-server.lan",
+			wantScheme:   "https",
+			wantInstance: "http-server.lan",
+		},
+		{
+			name:         "explicit http scheme preserved",
+			url:          "http://tdarr.local:8080",
+			wantURL:      "http://tdarr.local:8080",
+			wantScheme:   "http",
+			wantInstance: "tdarr.local",
+		},
 	}
-
-	if got := cfg.UrlParsed.String(); got != "https://tdarr.example.com" {
-		t.Errorf("UrlParsed = %q, want https://tdarr.example.com", got)
-	}
-	if cfg.UrlParsed.Scheme != "https" {
-		t.Errorf("scheme = %q, want https", cfg.UrlParsed.Scheme)
-	}
-	if cfg.InstanceName != "tdarr.example.com" {
-		t.Errorf("InstanceName = %q, want tdarr.example.com", cfg.InstanceName)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			env := map[string]string{envTdarrUrl: tc.url}
+			cfg, err := parseConfig(newFS(), nil, envFunc(env))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := cfg.UrlParsed.String(); got != tc.wantURL {
+				t.Errorf("UrlParsed = %q, want %q", got, tc.wantURL)
+			}
+			if cfg.UrlParsed.Scheme != tc.wantScheme {
+				t.Errorf("scheme = %q, want %q", cfg.UrlParsed.Scheme, tc.wantScheme)
+			}
+			if cfg.InstanceName != tc.wantInstance {
+				t.Errorf("InstanceName = %q, want %q", cfg.InstanceName, tc.wantInstance)
+			}
+		})
 	}
 }
 

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -1,0 +1,186 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func init() {
+	gin.SetMode(gin.ReleaseMode)
+}
+
+// newEngine wires a gin engine the same way internal/server/server.go does.
+func newEngine(reg *prometheus.Registry, tdarrInstance string) *gin.Engine {
+	router := gin.New()
+	router.Use(gin.Recovery())
+	router.NoRoute(func(c *gin.Context) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Route Not Found: Try /metrics"})
+	})
+	router.Use(RequestLogger())
+	router.GET("/metrics", MetricsHandler(reg, promhttp.HandlerOpts{}, tdarrInstance))
+	router.GET("/", IndexHandler())
+	router.GET("/healthz", HealthzHandler())
+	return router
+}
+
+func TestStaticHandlers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		method       string
+		path         string
+		wantStatus   int
+		wantContains string
+	}{
+		{
+			name:         "healthz returns ok json",
+			method:       http.MethodGet,
+			path:         "/healthz",
+			wantStatus:   http.StatusOK,
+			wantContains: `{"status":"ok"}`,
+		},
+		{
+			name:         "index returns html body",
+			method:       http.MethodGet,
+			path:         "/",
+			wantStatus:   http.StatusOK,
+			wantContains: "<h1>tdarr-exporter</h1>",
+		},
+		{
+			name:         "unknown route returns 404 json",
+			method:       http.MethodGet,
+			path:         "/does-not-exist",
+			wantStatus:   http.StatusNotFound,
+			wantContains: `"error":"Route Not Found: Try /metrics"`,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			engine := newEngine(prometheus.NewRegistry(), "test-instance")
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+
+			engine.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if !strings.Contains(rec.Body.String(), tc.wantContains) {
+				t.Fatalf("body = %q, want it to contain %q", rec.Body.String(), tc.wantContains)
+			}
+		})
+	}
+}
+
+func TestMetricsHandler(t *testing.T) {
+	t.Parallel()
+
+	const instance = "metrics-instance"
+	engine := newEngine(prometheus.NewRegistry(), instance)
+
+	doGet := func() *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		engine.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// First scrape. The scrape_requests_total counter is incremented in a
+	// deferred func that runs *after* promhttp has already written the body,
+	// so it is not visible until a later scrape. The scrape_duration gauge is
+	// registered eagerly, so it (and the const label) is present immediately.
+	rec := doGet()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("content-type = %q, want Prometheus text format (text/plain...)", ct)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"tdarr_scrape_duration_seconds",
+		`tdarr_instance="` + instance + `"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics body missing %q\nbody:\n%s", want, body)
+		}
+	}
+
+	// Second scrape: now the counter from the first request is exposed.
+	body2 := doGet().Body.String()
+	if !strings.Contains(body2, "tdarr_scrape_requests_total") {
+		t.Fatalf("metrics body missing %q\nbody:\n%s", "tdarr_scrape_requests_total", body2)
+	}
+	if !strings.Contains(body2, `tdarr_instance="`+instance+`"`) {
+		t.Fatalf("counter missing const label tdarr_instance=%q\nbody:\n%s", instance, body2)
+	}
+
+	// Third scrape: counter must have incremented relative to the second.
+	body3 := doGet().Body.String()
+	got2 := counterValue(t, body2, instance)
+	got3 := counterValue(t, body3, instance)
+	if got2 < 0 || got3 < 0 {
+		t.Fatalf("scrape_requests_total{code=\"200\"} not found: second=%v third=%v", got2, got3)
+	}
+	if got3 <= got2 {
+		t.Fatalf("scrape_requests_total did not increment: second=%v third=%v", got2, got3)
+	}
+}
+
+// counterValue extracts the tdarr_scrape_requests_total{code="200"} sample
+// value from a Prometheus text exposition body. Returns -1 if not present.
+func counterValue(t *testing.T, body, instance string) float64 {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "tdarr_scrape_requests_total{") &&
+			strings.Contains(line, `code="200"`) &&
+			strings.Contains(line, `tdarr_instance="`+instance+`"`) {
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				t.Fatalf("malformed counter line: %q", line)
+			}
+			var v float64
+			if _, err := fmt.Sscan(fields[len(fields)-1], &v); err != nil {
+				t.Fatalf("parse counter value %q: %v", fields[len(fields)-1], err)
+			}
+			return v
+		}
+	}
+	return -1
+}
+
+func TestRequestLoggerPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	const wantBody = "logger-passthrough-body"
+	router := gin.New()
+	router.Use(RequestLogger())
+	router.GET("/probe", func(c *gin.Context) {
+		c.String(http.StatusTeapot, wantBody)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("status = %d, want %d (RequestLogger altered status)", rec.Code, http.StatusTeapot)
+	}
+	if rec.Body.String() != wantBody {
+		t.Fatalf("body = %q, want %q (RequestLogger altered body)", rec.Body.String(), wantBody)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,7 +22,7 @@ type HttpServerConfig struct {
 	GracefulTimeout time.Duration
 }
 
-func ServeHttp(wg *sync.WaitGroup, registry *prometheus.Registry, runConfig HttpServerConfig, stopChan chan bool) {
+func ServeHttp(wg *sync.WaitGroup, registry *prometheus.Registry, runConfig HttpServerConfig, stopChan chan bool, errChan chan<- error) {
 	defer wg.Done()
 	router := gin.New()
 	// Recovery returns a middleware that recovers from any panics and writes a 500 if there was one.
@@ -53,9 +53,12 @@ func ServeHttp(wg *sync.WaitGroup, registry *prometheus.Registry, runConfig Http
 
 	go func() {
 		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-			log.Fatal().
+			// Propagate to the caller instead of os.Exit so the graceful
+			// shutdown path in main can run.
+			log.Error().
 				Err(err).
 				Msg("Failed to start HTTP Server")
+			errChan <- err
 		}
 	}()
 	log.Info().Msg("HTTP Server started")
@@ -68,9 +71,12 @@ func ServeHttp(wg *sync.WaitGroup, registry *prometheus.Registry, runConfig Http
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatal().
+		// Propagate to the caller instead of os.Exit so the WaitGroup still
+		// completes and main can finish its shutdown sequence.
+		log.Error().
 			Err(err).
 			Msg("Server shutdown failed")
+		errChan <- err
 	}
 	log.Info().Msg("HTTP Server shutdown gracefully")
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,7 +25,7 @@ func freePort(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("failed to find free port: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	_, port, err := net.SplitHostPort(ln.Addr().String())
 	if err != nil {
 		t.Fatalf("failed to split host/port: %v", err)
@@ -41,7 +41,7 @@ func waitForServer(t *testing.T, addr string, deadline time.Duration) {
 	for time.Now().Before(stop) {
 		conn, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
 		if err == nil {
-			conn.Close()
+			_ = conn.Close()
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -74,7 +74,7 @@ func TestServeHttpLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /healthz failed: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("GET /healthz status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
@@ -117,7 +117,7 @@ func TestServeHttpListenErrorDeliveredOnChannel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to occupy port: %v", err)
 	}
-	defer occupied.Close()
+	defer func() { _ = occupied.Close() }()
 	_, port, err := net.SplitHostPort(occupied.Addr().String())
 	if err != nil {
 		t.Fatalf("failed to split host/port: %v", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	gin.SetMode(gin.ReleaseMode)
+}
+
+// freePort returns an available TCP port on 127.0.0.1 by binding to :0 and
+// immediately releasing it. There is a small race window before ServeHttp
+// rebinds, which is acceptable for a test on the loopback interface.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	defer ln.Close()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split host/port: %v", err)
+	}
+	return port
+}
+
+// waitForServer polls the address with net.Dial until it accepts a connection
+// or the deadline passes. No time.Sleep loop over a fixed count.
+func waitForServer(t *testing.T, addr string, deadline time.Duration) {
+	t.Helper()
+	stop := time.Now().Add(deadline)
+	for time.Now().Before(stop) {
+		conn, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("server at %s did not become reachable within %s", addr, deadline)
+}
+
+func TestServeHttpLifecycle(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort("127.0.0.1", port)
+
+	wg := &sync.WaitGroup{}
+	stopChan := make(chan bool)
+	errChan := make(chan error, 1)
+	cfg := HttpServerConfig{
+		TdarrInstance:   "lifecycle",
+		ListenAddress:   "127.0.0.1",
+		PrometheusPort:  port,
+		PrometheusPath:  "/metrics",
+		GracefulTimeout: 5 * time.Second,
+	}
+
+	wg.Add(1)
+	go ServeHttp(wg, prometheus.NewRegistry(), cfg, stopChan, errChan)
+
+	waitForServer(t, addr, 2*time.Second)
+
+	// Confirm it actually serves a route.
+	resp, err := http.Get(fmt.Sprintf("http://%s/healthz", addr))
+	if err != nil {
+		t.Fatalf("GET /healthz failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /healthz status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// No spurious error should have been delivered while serving.
+	select {
+	case err := <-errChan:
+		t.Fatalf("unexpected error during normal serving: %v", err)
+	default:
+	}
+
+	// Trigger graceful shutdown and assert the WaitGroup completes (i.e.
+	// ServeHttp returned via wg.Done, not os.Exit).
+	stopChan <- true
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeHttp did not return / WaitGroup did not complete after shutdown")
+	}
+
+	// A clean shutdown must not deliver an error.
+	select {
+	case err := <-errChan:
+		t.Fatalf("unexpected error on clean shutdown: %v", err)
+	default:
+	}
+}
+
+func TestServeHttpListenErrorDeliveredOnChannel(t *testing.T) {
+	// Occupy a port so ListenAndServe fails with "address already in use"
+	// instead of crashing the process via log.Fatal/os.Exit.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to occupy port: %v", err)
+	}
+	defer occupied.Close()
+	_, port, err := net.SplitHostPort(occupied.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split host/port: %v", err)
+	}
+
+	wg := &sync.WaitGroup{}
+	stopChan := make(chan bool, 1)
+	errChan := make(chan error, 1)
+	cfg := HttpServerConfig{
+		TdarrInstance:   "listen-error",
+		ListenAddress:   "127.0.0.1",
+		PrometheusPort:  port,
+		PrometheusPath:  "/metrics",
+		GracefulTimeout: 1 * time.Second,
+	}
+
+	wg.Add(1)
+	go ServeHttp(wg, prometheus.NewRegistry(), cfg, stopChan, errChan)
+
+	select {
+	case err := <-errChan:
+		if err == nil {
+			t.Fatal("expected a non-nil ListenAndServe error on errChan")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("ListenAndServe error was not delivered on errChan")
+	}
+
+	// ServeHttp is still blocked on stopChan after the listen error (matching
+	// production wiring where main sends stop after receiving the error).
+	// Release it and confirm clean return.
+	stopChan <- true
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("ServeHttp did not return after stop following listen error")
+	}
+}


### PR DESCRIPTION
## Changes
- Fix 3 latent bugs: global `http.DefaultTransport` mutation (data race + nil-panic) → per-call `Clone()`; unguarded `statsCache` field read → `RLock` accessor; retry `backoff[i]` index panic → loop over `len(backoff)`.
- Fix `log.Fatal` inside the server goroutine bypassing graceful shutdown → errors propagate via a channel to `main`.
- Introduce a `tdarrAPI` client seam; decompose `collect()` into pure, table-tested units; drive `Describe` from a single desc list (with a drift test); make `config` parsing testable with isolated global state.
- Wire `HttpTimeoutSeconds` (previously dead) into the client and make it env/flag-overridable.
- Add metrics: standard `go_*`/`process_*` runtime series, `tdarr_exporter_build_info` + a `--version` flag, and `tdarr_library_audio_resolutions` (premium audio field that was parsed but never emitted).
- Cleanups: log-once + `%w` error wrapping, `interface{}`→`any`, `const METRIC_PREFIX`.
- Add the test suites (golden characterization + unit).

## Changes — review & hardening pass
Follow-up after a full review of the above. Each item verified behavior-preserving against the golden test (except where noted) with `-race` + pinned `golangci-lint`:
- **Lint:** check `Close()` errors in tests (was failing the `errcheck` stage of `task ci`).
- **Bug fix:** transport retry now classifies a 4xx/3xx that arrives *after* a 5xx retry as an error, instead of returning it as success (pre-existing latent; preserved for the first-attempt path). `parseUrl` detects a scheme via the `://` separator rather than a `http` prefix, so scheme-less hosts like `http-server.lan` are no longer misdetected.
- **Robustness:** the pie fan-in drain goroutine starts before `dataWg.Wait()`, so correctness no longer depends on `outChan` being buffered to the library count; `Describe` iterates its two desc sources separately (alias-safe).
- **Narrow config (M6):** collectors store only the fields read at collect time, not the whole `config.Config`.
- **typedDesc (M2):** bundle `*Desc` + `ValueType`; emit sites call `desc.mustNewConstMetric(v, …)` instead of repeating `prometheus.GaugeValue`. Output byte-identical.
- **Typed errors (M4):** `ErrUpstream`/`ErrParse` sentinels wrapped via multi-`%w` at collector boundaries; tests assert the cause of `tdarr_up=0` via `errors.Is`.
- **Context propagation (M5):** thread `context.Context` through the client seam (`NewRequestWithContext`) and collector; `main` wires a shutdown-cancellable context so a scrape in flight at SIGTERM aborts instead of running to completion. Per-request `HttpTimeoutSeconds` unchanged.
- **Logger injection (M1):** injectable `zerolog.Logger` on `RequestClient`/`ClientTransport`/`TdarrCollector` (defaulting to the global), so tests can capture/silence logs without mutating global state; pure helpers kept log-free.

## Motivation
The code worked but was largely untestable (0% on client/config/handlers/server, a 334-line `collect()`, a fresh client+transport built per request) and carried three concurrency/panic latents. Goal: fix the real bugs and make behavior testable without changing metric output. The hardening pass closes the remaining testability seams (errors-by-cause, context cancellation, logger injection) and the latent transport/URL edge cases surfaced during review.

## Test plan
- `go test ./... -race -count=1` green; `go vet ./...` clean; `gofmt`/`go mod tidy` clean.
- `golangci-lint` (pinned v2.12.2, matches CI): 0 issues.
- Golden `expected_output.txt` byte-identical through every refactor — the only intentional change is the additive `tdarr_library_audio_resolutions` series.
- New behavior tests: post-retry 4xx/3xx classification; URL scheme defaulting incl. `http`-prefixed host; `errors.Is` cause assertions; cancelled-context abort; injected-logger capture.
- `--version` verified end-to-end with injected ldflags.
- Coverage: collector ~93%, config 88%, client 84%, handlers 100%, server 84% (was 0% on all but collector).

## In-depth
- **Behavior changes (intentional):** (1) a 4xx/3xx after a 5xx retry is now an error not a success; (2) the unknown-worker-type warning now fires once per type with a count, instead of once per worker. Neither affects emitted metrics.
- **Deferred by design:** a whole-scrape *deadline* (`context.WithTimeout` in `Collect`) — distinct from per-request timeout; needs a config knob, not invented silently. Logger DI for `config`/`server` left on the global `log` — they are one-shot/composition code and injecting there would pollute signatures for no test value.
- **Known nits:** the server shutdown-error branch is untested (deterministic trigger is flaky); `cmd/exporter` wire-up stays ~0%.
- **Skipped by design:** `retryablehttp` and config libraries — small hand-rolled code kept, with the testability/guard fixes applied instead.
