### PR TITLE
fix: remove dead tdarr_node_worker_pid metric

### DIFF
--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -2568,18 +2568,6 @@
               "instant": true,
               "legendFormat": "",
               "refId": "I"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum by (worker_id) (tdarr_node_worker_pid{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "J"
             }
           ],
           "title": "Flow Workers",
@@ -2614,8 +2602,7 @@
                     "Value #F",
                     "Value #G",
                     "Value #H",
-                    "Value #I",
-                    "Value #J"
+                    "Value #I"
                   ]
                 }
               }
@@ -2633,7 +2620,6 @@
                   "Value #G": 9,
                   "Value #H": 12,
                   "Value #I": 11,
-                  "Value #J": 2,
                   "compute_type": 14,
                   "flow_worker": 17,
                   "node_name": 0,
@@ -2654,8 +2640,7 @@
                   "Value #F": "Est Size (GB)",
                   "Value #G": "Out Size (GB)",
                   "Value #H": "Job Start",
-                  "Value #I": "Last Status Update",
-                  "Value #J": "PID"
+                  "Value #I": "Last Status Update"
                 }
               }
             }
@@ -3048,18 +3033,6 @@
               "instant": true,
               "legendFormat": "",
               "refId": "I"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "sum by (worker_id) (tdarr_node_worker_pid{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "J"
             }
           ],
           "title": "Health Check Workers",
@@ -3078,7 +3051,6 @@
                   "names": [
                     "node_name",
                     "worker_id",
-                    "Value #J",
                     "Value #B",
                     "Value #C",
                     "Value #D",
@@ -3106,7 +3078,6 @@
                   "Value #E": 8,
                   "Value #H": 10,
                   "Value #I": 9,
-                  "Value #J": 2,
                   "compute_type": 12,
                   "node_name": 0,
                   "worker_connected": 14,
@@ -3124,8 +3095,7 @@
                   "Value #F": "Est Size (GB)",
                   "Value #G": "Out Size (GB)",
                   "Value #H": "Job Start",
-                  "Value #I": "Last Status Update",
-                  "Value #J": "PID"
+                  "Value #I": "Last Status Update"
                 }
               }
             }
@@ -3494,18 +3464,6 @@
               "instant": true,
               "legendFormat": "",
               "refId": "I"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "sum by (worker_id) (tdarr_node_worker_pid{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "J"
             }
           ],
           "title": "Classic Plugin Workers",
@@ -3540,8 +3498,7 @@
                     "Value #F",
                     "Value #G",
                     "Value #H",
-                    "Value #I",
-                    "Value #J"
+                    "Value #I"
                   ]
                 }
               }
@@ -3559,7 +3516,6 @@
                   "Value #G": 11,
                   "Value #H": 14,
                   "Value #I": 13,
-                  "Value #J": 2,
                   "compute_type": 16,
                   "flow_worker": 17,
                   "node_name": 0,
@@ -3580,8 +3536,7 @@
                   "Value #F": "Est Size (GB)",
                   "Value #G": "Out Size (GB)",
                   "Value #H": "Job Start",
-                  "Value #I": "Last Status Update",
-                  "Value #J": "PID"
+                  "Value #I": "Last Status Update"
                 }
               }
             }

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -789,9 +789,6 @@ func (c *TdarrCollector) emitNodeMetrics(ch chan<- prometheus.Metric, nodeData m
 				float64(worker.StartTime), node.Id, node.Name, worker.Id)
 			ch <- m.nodeWorkerStatusTimestamp.mustNewConstMetric(
 				float64(worker.StatusTs), node.Id, node.Name, worker.Id)
-			ch <- m.nodeWorkerPid.mustNewConstMetric(
-				float64(worker.Process.Pid), node.Id, node.Name, worker.Id)
-
 			// ETA: parse "H:MM:SS" string into seconds; skip on parse failure
 			if etaSecs, ok := parseEtaSeconds(worker.Eta); ok {
 				ch <- m.nodeWorkerEtaSeconds.mustNewConstMetric(

--- a/internal/collector/tdarr_golden_test.go
+++ b/internal/collector/tdarr_golden_test.go
@@ -50,7 +50,6 @@ var collectorMetricNames = []string{
 	"tdarr_node_worker_original_file_size_gb",
 	"tdarr_node_worker_output_file_size_gb",
 	"tdarr_node_worker_percentage",
-	"tdarr_node_worker_pid",
 	"tdarr_node_worker_start_timestamp_seconds",
 	"tdarr_node_worker_status_timestamp_seconds",
 	"tdarr_score_pct",
@@ -127,7 +126,7 @@ func newGoldenFakeAPI(t *testing.T, cfg config.Config) *fakeTdarrAPI {
 //   - audio codecs (aac, flac, opus) and audio containers (mkv, m4a) for "Music" library
 //   - idle node "IdleNode" with no workers (zero-value worker count/limit/queue series emitted)
 //   - busy node "BusyNode" with one active transcode CPU worker exercising all per-worker gauges:
-//     percentage, fps, original/output/est file sizes, job_start/start/status timestamps, pid, eta_seconds
+//     percentage, fps, original/output/est file sizes, job_start/start/status timestamps, eta_seconds
 //   - tdarr_up = 1 on success path
 func TestCollect_Golden_FullFixture(t *testing.T) {
 	cfg := newGoldenTestConfig(t)

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -88,7 +88,6 @@ type TdarrNodeMetrics struct {
 	nodeWorkerStartTimestamp     typedDesc
 	nodeWorkerStatusTimestamp    typedDesc
 	nodeWorkerEtaSeconds         typedDesc
-	nodeWorkerPid                typedDesc
 }
 
 type TdarrNodeCollector struct {
@@ -228,11 +227,6 @@ func NewTdarrNodeMetrics(runConfig config.Config) *TdarrNodeMetrics {
 			"Tdarr node worker estimated time remaining in seconds",
 			workerLabelPair, instance,
 		),
-		nodeWorkerPid: newGauge(
-			"node_worker_pid",
-			"Tdarr node worker process ID",
-			workerLabelPair, instance,
-		),
 	}
 }
 
@@ -264,7 +258,6 @@ func (m *TdarrNodeMetrics) descs() []typedDesc {
 		m.nodeWorkerStartTimestamp,
 		m.nodeWorkerStatusTimestamp,
 		m.nodeWorkerEtaSeconds,
-		m.nodeWorkerPid,
 	}
 }
 

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -483,10 +483,10 @@ func TestDescribe_EmitsAllDescs(t *testing.T) {
 		fqNames[descFqName(t, d)]++
 	}
 
-	// 23 collector descs + 24 node descs. Adding/removing a metric must update this number,
+	// 23 collector descs + 23 node descs. Adding/removing a metric must update this number,
 	// which is exactly the point: the count is the tripwire for a dropped Describe entry.
 	const wantCollectorDescs = 23
-	const wantNodeDescs = 24
+	const wantNodeDescs = 23
 	wantTotal := wantCollectorDescs + wantNodeDescs
 	if len(descs) != wantTotal {
 		t.Fatalf("Describe emitted %d descs, want %d (collector %d + node %d)",

--- a/internal/collector/testdata/expected_output.txt
+++ b/internal/collector/testdata/expected_output.txt
@@ -176,9 +176,6 @@ tdarr_node_worker_output_file_size_gb{node_id="node-busy-1",node_name="BusyNode"
 # HELP tdarr_node_worker_percentage Tdarr node worker transcode/healthcheck progress percentage
 # TYPE tdarr_node_worker_percentage gauge
 tdarr_node_worker_percentage{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 45.75
-# HELP tdarr_node_worker_pid Tdarr node worker process ID
-# TYPE tdarr_node_worker_pid gauge
-tdarr_node_worker_pid{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 5432
 # HELP tdarr_node_worker_start_timestamp_seconds Tdarr node worker current plugin step start time as Unix timestamp in seconds
 # TYPE tdarr_node_worker_start_timestamp_seconds gauge
 tdarr_node_worker_start_timestamp_seconds{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain",worker_id="worker-tc-01"} 1.70000005e+09


### PR DESCRIPTION
## Changes

Removes the `tdarr_node_worker_pid` Prometheus metric (gauge) from the exporter and the example dashboard.

- Drop the gauge from the node collector: field declaration, `newGauge` registration, and `descs()` entry (`internal/collector/tdarr_nodes.go`).
- Stop emitting it in `emitNodeMetrics` (`internal/collector/tdarr.go`).
- Remove it from the golden fixture (`testdata/expected_output.txt`) and the metric-name list, and adjust the desc-count assertion `24 -> 23` (`tdarr_golden_test.go`, `tdarr_test.go`).
- Drop the PID column (series + transformation refs) from the three worker table panels in `examples/dashboard.json`.

Not changed (intentional):
- The `Process` struct in `tdarr_models.go` is retained — its `.Connected` field still feeds the `tdarr_node_worker_info` `worker_connected` label. Only the now-unused `.Pid` field remains.
- `tdarr_node_info` is untouched; the node's own pid is still exported via its `node_process_pid` label.
- `examples/archive/dashboard.v1.json` (archived) left as-is.

## Motivation

Tdarr `2.75.01` removed `workers.<id>.process.pid` from the `get-nodes` API response, so the gauge always emitted `0`. Confirmed against a live `2.75.01` node:

- The `get-nodes` payload no longer contains a `process` object inside worker entries.
- The node JS bundle (`/app/Tdarr_Node/srcug/workers/`) has zero `pid` references; `processPid` appears only in node config files.
- Pid now lives only in the node-level `processes` map, keyed by OS pid with no worker-id join key — so per-worker pid is unrecoverable.

The struct field and Jan 2024 commit history confirm the field was real previously; it was dropped upstream between then and `2.75.01`.

## Test plan

- `go build ./...` — passes.
- `go test ./internal/collector/...` — passes (golden characterization test `TestCollect_Golden_FullFixture` and `TestDescribe_EmitsAllDescs` updated and green).
- `python3 -m json.tool examples/dashboard.json` — valid JSON.
- `grep -rn "worker_pid|nodeWorkerPid|Value #J" internal/ examples/dashboard.json` — zero hits.

## In-depth

- **Breaking for dashboards**: the metric is removed, not renamed. Existing dashboards referencing `tdarr_node_worker_pid` will show "No data" for that series. Impact is cosmetic — the metric already reported `0` on Tdarr `2.75.01`. No PromQL join depended on it as a key; the worker table joins are driven by `worker_id` + `tdarr_node_worker_info`, both unaffected.
- **Alternative considered**: repurposing the metric to expose node-level process pids from the `processes` map. Rejected for this PR — that map has no worker-id join key, so it cannot preserve the per-worker dimension. A separate `tdarr_node_process_*` metric set (pid + rss/heap memory by filename) is a possible future enhancement.