### PR TITLE
feat: Tdarr server status metrics + dashboard panels

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,9 +11,10 @@ vars:
   RUN_IMAGE: gcr.io/distroless/static
   RUN_IMAGE_TAG: nonroot
 
-  # For local e2e testing (smoke tests)
-  TEST_IMAGE_NAME: docker.homeylab.org/tdarr-exporter
-  TEST_IMAGE_TAG: test
+  # For local e2e testing (smoke tests). TEST_IMAGE_NAME/TEST_IMAGE_TAG come from
+  # local/local.env (gitignored, loaded via dotenv) so the committed Taskfile
+  # carries no private registry. Cmds reference them as ${TEST_IMAGE_NAME:-tdarr-exporter}
+  # / ${TEST_IMAGE_TAG:-test}; dotenv only reaches cmds, not var-level sh.
   PORT: '9090'
   CONTAINER: tdarr-exporter-smoke
 
@@ -36,7 +37,7 @@ tasks:
     deps:
       - task: docker:build:local
     cmds:
-      - docker run -it -p {{.PORT}}:{{.PORT}} --rm --name {{.CONTAINER}}  -e TDARR_URL={{.TDARR_URL}} {{.TEST_IMAGE_NAME}}:{{.TEST_IMAGE_TAG}}
+      - docker run -it -p {{.PORT}}:{{.PORT}} --rm --name {{.CONTAINER}}  -e TDARR_URL={{.TDARR_URL}} ${TEST_IMAGE_NAME:-tdarr-exporter}:${TEST_IMAGE_TAG:-test}
 
   curl:
     desc: Curl /metrics endpoint on localhost:{{.PORT}}
@@ -107,7 +108,7 @@ tasks:
           --build-arg VERSION={{.VERSION}}
           --build-arg REVISION={{.REVISION}}
           --build-arg BUILDTIME={{.BUILDTIME}}
-          -t {{.TEST_IMAGE_NAME}}:{{.TEST_IMAGE_TAG}} .
+          -t ${TEST_IMAGE_NAME:-tdarr-exporter}:${TEST_IMAGE_TAG:-test} .
 
   docker:build:
     desc: Build multi-arch image (linux/amd64,linux/arm64) without pushing
@@ -123,7 +124,7 @@ tasks:
           --build-arg VERSION={{.VERSION}}
           --build-arg REVISION={{.REVISION}}
           --build-arg BUILDTIME={{.BUILDTIME}}
-          -t {{.TEST_IMAGE_NAME}}:{{.TEST_IMAGE_TAG}}
+          -t ${TEST_IMAGE_NAME:-tdarr-exporter}:${TEST_IMAGE_TAG:-test}
           --no-cache .
 
   docker:build:latest:
@@ -140,8 +141,8 @@ tasks:
           --build-arg VERSION={{.VERSION}}
           --build-arg REVISION={{.REVISION}}
           --build-arg BUILDTIME={{.BUILDTIME}}
-          -t {{.TEST_IMAGE_NAME}}:{{.TEST_IMAGE_TAG}}
-          -t {{.TEST_IMAGE_NAME}}:latest
+          -t ${TEST_IMAGE_NAME:-tdarr-exporter}:${TEST_IMAGE_TAG:-test}
+          -t ${TEST_IMAGE_NAME:-tdarr-exporter}:latest
           --no-cache .
 
   docker:buildx-setup:

--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -133,7 +133,7 @@
             "h": 4,
             "w": 6,
             "x": 0,
-            "y": 1
+            "y": 5
           },
           "id": 2,
           "options": {
@@ -217,7 +217,7 @@
             "h": 4,
             "w": 6,
             "x": 6,
-            "y": 1
+            "y": 5
           },
           "id": 3,
           "options": {
@@ -289,7 +289,7 @@
             "h": 4,
             "w": 6,
             "x": 12,
-            "y": 1
+            "y": 5
           },
           "id": 4,
           "options": {
@@ -382,7 +382,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 1
+            "y": 5
           },
           "id": 5,
           "options": {
@@ -417,6 +417,347 @@
             }
           ],
           "title": "Handler Errors (5m)",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Tdarr server version reported by /api/v2/status.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 12,
+            "y": 1
+          },
+          "id": 61,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "name",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "tdarr_server_info{tdarr_instance=~\"$tdarr_instance\"}",
+              "instant": true,
+              "legendFormat": "{{version}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Tdarr Version",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Exporter build version from tdarr_exporter_build_info (set at build time via ldflags).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 15,
+            "y": 1
+          },
+          "id": 65,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "name",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "tdarr_exporter_build_info",
+              "instant": true,
+              "legendFormat": "{{version}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Exporter Version",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Tdarr server operating system reported by /api/v2/status.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "id": 62,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "name",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "tdarr_server_info{tdarr_instance=~\"$tdarr_instance\"}",
+              "instant": true,
+              "legendFormat": "{{os}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Tdarr OS",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Tdarr server process uptime from /api/v2/status (Node.js process.uptime, seconds).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 1
+          },
+          "id": 63,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "tdarr_server_uptime_seconds{tdarr_instance=~\"$tdarr_instance\"}",
+              "instant": false,
+              "legendFormat": "uptime",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Server Uptime",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Tdarr server self-reported health from /api/v2/status: 1 = good (Healthy), 0 = problem. Raw status string is on tdarr_server_status_info.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "index": 0,
+                      "text": "Problem"
+                    },
+                    "1": {
+                      "index": 1,
+                      "text": "Healthy"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          },
+          "id": 64,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "value",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "tdarr_server_healthy{tdarr_instance=~\"$tdarr_instance\"}",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Server Status",
           "type": "stat"
         }
       ],

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -556,6 +556,19 @@ func shouldRefetch(cached tdarrCacheTotals, libStatsNil bool, metric *TdarrMetri
 }
 
 func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	// Fetch server status (/api/v2/status) first. Cheapest call and a liveness/version
+	// probe, so fail fast here before the heavier stats/pie/node work. Required: a failure
+	// returns an error like every other upstream fetch, flipping tdarr_up=0 via Collect().
+	serverStatus := &TdarrServerStatus{}
+	if err := c.api.DoRequest(ctx, c.statusPath, serverStatus); err != nil {
+		return fmt.Errorf("get server status: %w: %w", ErrUpstream, err)
+	}
+	if serverStatus.Status != "good" {
+		c.logger.Warn().Str("status", serverStatus.Status).
+			Msg("Tdarr server reported non-good status")
+	}
+	c.emitServerMetrics(ch, serverStatus)
+
 	// get server metrics
 	metricReqBody := getGeneralReqPayload("")
 	metric := &TdarrMetric{}
@@ -643,6 +656,14 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 	// get worker data for each node
 	c.emitNodeMetrics(ch, nodeData)
 	return nil
+}
+
+// emitServerMetrics emits the /api/v2/status-derived series: uptime gauge plus the
+// version/os and raw-status info gauges (value 1). Pure: reads status, writes to ch.
+func (c *TdarrCollector) emitServerMetrics(ch chan<- prometheus.Metric, status *TdarrServerStatus) {
+	ch <- c.serverUptime.mustNewConstMetric(float64(status.Uptime))
+	ch <- c.serverInfo.mustNewConstMetric(1, status.Version, status.Os)
+	ch <- c.serverStatus.mustNewConstMetric(1, status.Status)
 }
 
 // emitGeneralMetrics emits the top-level server gauges and stream-stats series for a

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -122,6 +122,7 @@ type TdarrCollector struct {
 	serverUptime          typedDesc
 	serverInfo            typedDesc
 	serverStatus          typedDesc
+	serverHealthy         typedDesc
 	// descsList is the collector's own descs in Describe order, assembled once in the
 	// constructor. Describe ranges over this plus the node collector's descs(), so a
 	// metric is registered for Describe in exactly one place (no field-by-field hand-list).
@@ -338,6 +339,11 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 				"Alert with tdarr_server_status_info{status!=\"good\"} == 1.",
 			[]string{"status"}, instance,
 		),
+		serverHealthy: newGauge(
+			"server_healthy",
+			"1 if Tdarr server self-reported status is healthy (\"good\"/\"ok\"/\"healthy\", case-insensitive), 0 otherwise. Raw status string is on tdarr_server_status_info.",
+			nil, instance,
+		),
 		nodeCollector: NewTdarrNodeCollector(runConfig, api, log.Logger),
 	}
 
@@ -371,6 +377,7 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 		c.serverUptime,
 		c.serverInfo,
 		c.serverStatus,
+		c.serverHealthy,
 	}
 
 	return c
@@ -563,9 +570,9 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 	if err := c.api.DoRequest(ctx, c.statusPath, serverStatus); err != nil {
 		return fmt.Errorf("get server status: %w: %w", ErrUpstream, err)
 	}
-	if serverStatus.Status != "good" {
+	if !isHealthyServerStatus(serverStatus.Status) {
 		c.logger.Warn().Str("status", serverStatus.Status).
-			Msg("Tdarr server reported non-good status")
+			Msg("Tdarr server reported non-healthy status")
 	}
 	c.emitServerMetrics(ch, serverStatus)
 
@@ -664,6 +671,11 @@ func (c *TdarrCollector) emitServerMetrics(ch chan<- prometheus.Metric, status *
 	ch <- c.serverUptime.mustNewConstMetric(float64(status.Uptime))
 	ch <- c.serverInfo.mustNewConstMetric(1, status.Version, status.Os)
 	ch <- c.serverStatus.mustNewConstMetric(1, status.Status)
+	healthy := 0.0
+	if isHealthyServerStatus(status.Status) {
+		healthy = 1
+	}
+	ch <- c.serverHealthy.mustNewConstMetric(healthy)
 }
 
 // emitGeneralMetrics emits the top-level server gauges and stream-stats series for a

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -81,6 +81,7 @@ type TdarrCollector struct {
 	// consumed once in the constructor (client + descs) and never needed again.
 	statsPath      string
 	pieStatsPath   string
+	statusPath     string
 	maxConcurrency int
 	api            tdarrAPI // shared HTTP client, built once in the constructor
 	// baseCtx is the parent context for every scrape's HTTP requests. main wires in
@@ -118,6 +119,9 @@ type TdarrCollector struct {
 	unknownStatusTotal    typedDesc           // counter for status values not in known enum
 	nodeCollector         *TdarrNodeCollector // node data
 	upMetric              typedDesc
+	serverUptime          typedDesc
+	serverInfo            typedDesc
+	serverStatus          typedDesc
 	// descsList is the collector's own descs in Describe order, assembled once in the
 	// constructor. Describe ranges over this plus the node collector's descs(), so a
 	// metric is registered for Describe in exactly one place (no field-by-field hand-list).
@@ -193,6 +197,7 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 	c := &TdarrCollector{
 		statsPath:           runConfig.TdarrStatsPath,
 		pieStatsPath:        runConfig.TdarrPieStatsPath,
+		statusPath:          runConfig.TdarrStatusPath,
 		maxConcurrency:      runConfig.HttpMaxConcurrency,
 		api:                 api,
 		baseCtx:             context.Background(),
@@ -317,6 +322,22 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 				"Distinct from prometheus built-in 'up' which indicates exporter process reachability.",
 			nil, instance,
 		),
+		serverUptime: newGauge(
+			"server_uptime_seconds",
+			"Tdarr server process uptime in seconds, as reported by /api/v2/status",
+			nil, instance,
+		),
+		serverInfo: newGauge(
+			"server_info",
+			"Tdarr server build metadata (value always 1); version and OS exposed as labels",
+			[]string{"version", "os"}, instance,
+		),
+		serverStatus: newGauge(
+			"server_status_info",
+			"Tdarr server self-reported health (value always 1); raw status string exposed as the 'status' label. "+
+				"Alert with tdarr_server_status_info{status!=\"good\"} == 1.",
+			[]string{"status"}, instance,
+		),
 		nodeCollector: NewTdarrNodeCollector(runConfig, api, log.Logger),
 	}
 
@@ -347,6 +368,9 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 		c.pieAudioContainers,
 		c.unknownStatusTotal,
 		c.upMetric,
+		c.serverUptime,
+		c.serverInfo,
+		c.serverStatus,
 	}
 
 	return c

--- a/internal/collector/tdarr_enums.go
+++ b/internal/collector/tdarr_enums.go
@@ -76,6 +76,23 @@ func normalizePieStatuses(pie *TdarrPieStats, unknownCounter func(kind, status s
 	)
 }
 
+// healthyServerStatuses is the set of /api/v2/status "status" values treated as healthy
+// (tdarr_server_healthy = 1), compared case-insensitively. "good" is the value Tdarr is
+// observed to emit; "ok"/"healthy" are common synonyms included so a benign upstream rename
+// does not flip the gauge. Anything else maps to 0 (and a warn log fires in collect()).
+var healthyServerStatuses = map[string]struct{}{
+	"good":    {},
+	"ok":      {},
+	"healthy": {},
+}
+
+// isHealthyServerStatus reports whether the raw Tdarr status string is a known healthy
+// value. Case-insensitive; surrounding whitespace is trimmed before lookup.
+func isHealthyServerStatus(status string) bool {
+	_, ok := healthyServerStatuses[strings.ToLower(strings.TrimSpace(status))]
+	return ok
+}
+
 // normalizeStatusSlice builds a complete cleaned-label → value map for a single status kind.
 func normalizeStatusSlice(
 	raw []TdarrPieSlice,

--- a/internal/collector/tdarr_golden_test.go
+++ b/internal/collector/tdarr_golden_test.go
@@ -53,6 +53,7 @@ var collectorMetricNames = []string{
 	"tdarr_node_worker_start_timestamp_seconds",
 	"tdarr_node_worker_status_timestamp_seconds",
 	"tdarr_score_pct",
+	"tdarr_server_healthy",
 	"tdarr_server_info",
 	"tdarr_server_status_info",
 	"tdarr_server_uptime_seconds",

--- a/internal/collector/tdarr_golden_test.go
+++ b/internal/collector/tdarr_golden_test.go
@@ -53,6 +53,9 @@ var collectorMetricNames = []string{
 	"tdarr_node_worker_start_timestamp_seconds",
 	"tdarr_node_worker_status_timestamp_seconds",
 	"tdarr_score_pct",
+	"tdarr_server_info",
+	"tdarr_server_status_info",
+	"tdarr_server_uptime_seconds",
 	"tdarr_size_diff_gb",
 	"tdarr_stream_stats_bit_rate",
 	"tdarr_stream_stats_duration",
@@ -91,6 +94,7 @@ func newGoldenTestConfig(t *testing.T) config.Config {
 		TdarrStatsPath:     "/api/v2/cruddb",
 		TdarrPieStatsPath:  "/api/v2/stats/get-pies",
 		TdarrNodePath:      "/api/v2/get-nodes",
+		TdarrStatusPath:    "/api/v2/status",
 		HttpMaxConcurrency: 1,
 	}
 }
@@ -110,6 +114,7 @@ func newGoldenFakeAPI(t *testing.T, cfg config.Config) *fakeTdarrAPI {
 	api.setResponse(fakeKey{path: cfg.TdarrPieStatsPath, disc: "lib-video-01"}, readFixture(t, "pie_stats_lib_video_01.json"))
 	api.setResponse(fakeKey{path: cfg.TdarrPieStatsPath, disc: "lib-audio-01"}, readFixture(t, "pie_stats_lib_audio_01.json"))
 	api.setResponse(fakeKey{path: cfg.TdarrNodePath}, readFixture(t, "nodes.json"))
+	api.setResponse(fakeKey{path: cfg.TdarrStatusPath}, readFixture(t, "server_status.json"))
 	return api
 }
 

--- a/internal/collector/tdarr_models.go
+++ b/internal/collector/tdarr_models.go
@@ -48,6 +48,16 @@ type TdarrMetric struct {
 	HealthCheckFailed  int `json:"table6Count"` // includes "cancelled"
 }
 
+// TdarrServerStatus decodes GET /api/v2/status. Only the fields surfaced as
+// metrics/labels are mapped; isProduction/buildDate are intentionally omitted.
+// uptime is Tdarr's Node.js process.uptime(), i.e. seconds.
+type TdarrServerStatus struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+	Os      string `json:"os"`
+	Uptime  int64  `json:"uptime"`
+}
+
 // new api `api/v2/stats/get-pies` support
 type TdarrLibraryInfo struct {
 	LibraryId string `json:"_id"`

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -166,6 +167,9 @@ func TestCollect_ServerMetrics(t *testing.T) {
 	c := newTdarrCollectorWithAPI(cfg, newSuccessFakeAPI(cfg))
 
 	expected := `
+# HELP tdarr_server_healthy 1 if Tdarr server self-reported status is healthy ("good"/"ok"/"healthy", case-insensitive), 0 otherwise. Raw status string is on tdarr_server_status_info.
+# TYPE tdarr_server_healthy gauge
+tdarr_server_healthy{tdarr_instance="test-instance"} 1
 # HELP tdarr_server_info Tdarr server build metadata (value always 1); version and OS exposed as labels
 # TYPE tdarr_server_info gauge
 tdarr_server_info{os="linux",tdarr_instance="test-instance",version="2.77.01"} 1
@@ -177,8 +181,49 @@ tdarr_server_status_info{status="good",tdarr_instance="test-instance"} 1
 tdarr_server_uptime_seconds{tdarr_instance="test-instance"} 45
 `
 	if err := testutil.CollectAndCompare(c, strings.NewReader(expected),
-		"tdarr_server_uptime_seconds", "tdarr_server_info", "tdarr_server_status_info"); err != nil {
+		"tdarr_server_uptime_seconds", "tdarr_server_info", "tdarr_server_status_info", "tdarr_server_healthy"); err != nil {
 		t.Errorf("server metrics mismatch:\n%v", err)
+	}
+}
+
+// TestCollect_ServerHealthy verifies tdarr_server_healthy maps Tdarr's self-reported
+// status to 1 for known healthy synonyms (case-insensitive) and 0 for anything else.
+func TestCollect_ServerHealthy(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		status string
+		want   float64
+	}{
+		{"good", "good", 1},
+		{"ok synonym", "ok", 1},
+		{"healthy synonym", "healthy", 1},
+		{"uppercase good", "GOOD", 1},
+		{"surrounding whitespace", "  good  ", 1},
+		{"unknown status", "degraded", 0},
+		{"empty status", "", 0},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := newTestConfig(t)
+			api := newSuccessFakeAPI(cfg)
+			body := []byte(fmt.Sprintf(
+				`{"status":%q,"isProduction":true,"os":"linux","version":"2.77.01","buildDate":"x","uptime":45}`,
+				tc.status))
+			api.setResponse(fakeKey{path: cfg.TdarrStatusPath}, body)
+			c := newTdarrCollectorWithAPI(cfg, api)
+
+			expected := fmt.Sprintf(`
+# HELP tdarr_server_healthy 1 if Tdarr server self-reported status is healthy ("good"/"ok"/"healthy", case-insensitive), 0 otherwise. Raw status string is on tdarr_server_status_info.
+# TYPE tdarr_server_healthy gauge
+tdarr_server_healthy{tdarr_instance="test-instance"} %g
+`, tc.want)
+			if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "tdarr_server_healthy"); err != nil {
+				t.Errorf("server_healthy mismatch for status %q:\n%v", tc.status, err)
+			}
+		})
 	}
 }
 
@@ -515,9 +560,9 @@ func TestDescribe_EmitsAllDescs(t *testing.T) {
 		fqNames[descFqName(t, d)]++
 	}
 
-	// 26 collector descs + 23 node descs. Adding/removing a metric must update this number,
+	// 27 collector descs + 23 node descs. Adding/removing a metric must update this number,
 	// which is exactly the point: the count is the tripwire for a dropped Describe entry.
-	const wantCollectorDescs = 26
+	const wantCollectorDescs = 27
 	const wantNodeDescs = 23
 	wantTotal := wantCollectorDescs + wantNodeDescs
 	if len(descs) != wantTotal {

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/homeylab/tdarr-exporter/internal/config"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/rs/zerolog"
 )
@@ -34,6 +35,7 @@ func newTestConfig(t *testing.T) config.Config {
 		TdarrStatsPath:     "/api/v2/cruddb",
 		TdarrPieStatsPath:  "/api/v2/stats/get-pies",
 		TdarrNodePath:      "/api/v2/get-nodes",
+		TdarrStatusPath:    "/api/v2/status",
 		HttpMaxConcurrency: 1,
 	}
 }
@@ -138,6 +140,11 @@ func validNodeBody() []byte {
 	return b
 }
 
+// validStatusBody returns a valid /api/v2/status response body.
+func validStatusBody() []byte {
+	return []byte(`{"status":"good","isProduction":true,"os":"linux","version":"2.77.01","buildDate":"2026_05_29T12_20_24z","uptime":45}`)
+}
+
 // newSuccessFakeAPI builds a fakeTdarrAPI that responds successfully to every
 // endpoint the collector calls, using the minimal valid bodies above. The single
 // library "lib1" drives one get-pies call keyed on its libraryId.
@@ -147,7 +154,32 @@ func newSuccessFakeAPI(cfg config.Config) *fakeTdarrAPI {
 	api.setResponse(fakeKey{path: cfg.TdarrStatsPath, disc: "LibrarySettingsJSONDB"}, validLibraryListBody())
 	api.setResponse(fakeKey{path: cfg.TdarrPieStatsPath, disc: "lib1"}, validPieBody())
 	api.setResponse(fakeKey{path: cfg.TdarrNodePath}, validNodeBody())
+	api.setResponse(fakeKey{path: cfg.TdarrStatusPath}, validStatusBody())
 	return api
+}
+
+// TestCollect_ServerMetrics verifies the three /api/v2/status-derived series:
+// uptime gauge, version/os info gauge, and the raw-label status info gauge.
+func TestCollect_ServerMetrics(t *testing.T) {
+	t.Parallel()
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, newSuccessFakeAPI(cfg))
+
+	expected := `
+# HELP tdarr_server_info Tdarr server build metadata (value always 1); version and OS exposed as labels
+# TYPE tdarr_server_info gauge
+tdarr_server_info{os="linux",tdarr_instance="test-instance",version="2.77.01"} 1
+# HELP tdarr_server_status_info Tdarr server self-reported health (value always 1); raw status string exposed as the 'status' label. Alert with tdarr_server_status_info{status!="good"} == 1.
+# TYPE tdarr_server_status_info gauge
+tdarr_server_status_info{status="good",tdarr_instance="test-instance"} 1
+# HELP tdarr_server_uptime_seconds Tdarr server process uptime in seconds, as reported by /api/v2/status
+# TYPE tdarr_server_uptime_seconds gauge
+tdarr_server_uptime_seconds{tdarr_instance="test-instance"} 45
+`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected),
+		"tdarr_server_uptime_seconds", "tdarr_server_info", "tdarr_server_status_info"); err != nil {
+		t.Errorf("server metrics mismatch:\n%v", err)
+	}
 }
 
 // TestCollect_AllSuccess_UpEquals1 verifies tdarr_up == 1 when all API endpoints succeed,

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -483,9 +483,9 @@ func TestDescribe_EmitsAllDescs(t *testing.T) {
 		fqNames[descFqName(t, d)]++
 	}
 
-	// 23 collector descs + 23 node descs. Adding/removing a metric must update this number,
+	// 26 collector descs + 23 node descs. Adding/removing a metric must update this number,
 	// which is exactly the point: the count is the tripwire for a dropped Describe entry.
-	const wantCollectorDescs = 23
+	const wantCollectorDescs = 26
 	const wantNodeDescs = 23
 	wantTotal := wantCollectorDescs + wantNodeDescs
 	if len(descs) != wantTotal {

--- a/internal/collector/testdata/expected_output.txt
+++ b/internal/collector/testdata/expected_output.txt
@@ -185,6 +185,15 @@ tdarr_node_worker_status_timestamp_seconds{node_id="node-busy-1",node_name="Busy
 # HELP tdarr_score_pct Tdarr score percentage - how much of your libraries has been handled by tdarr
 # TYPE tdarr_score_pct gauge
 tdarr_score_pct{tdarr_instance="tdarr.localdomain"} 78.5
+# HELP tdarr_server_info Tdarr server build metadata (value always 1); version and OS exposed as labels
+# TYPE tdarr_server_info gauge
+tdarr_server_info{os="linux",tdarr_instance="tdarr.localdomain",version="2.77.01"} 1
+# HELP tdarr_server_status_info Tdarr server self-reported health (value always 1); raw status string exposed as the 'status' label. Alert with tdarr_server_status_info{status!="good"} == 1.
+# TYPE tdarr_server_status_info gauge
+tdarr_server_status_info{status="good",tdarr_instance="tdarr.localdomain"} 1
+# HELP tdarr_server_uptime_seconds Tdarr server process uptime in seconds, as reported by /api/v2/status
+# TYPE tdarr_server_uptime_seconds gauge
+tdarr_server_uptime_seconds{tdarr_instance="tdarr.localdomain"} 45
 # HELP tdarr_size_diff_gb Tdarr size difference (+/-) in GB
 # TYPE tdarr_size_diff_gb gauge
 tdarr_size_diff_gb{tdarr_instance="tdarr.localdomain"} 45.75

--- a/internal/collector/testdata/expected_output.txt
+++ b/internal/collector/testdata/expected_output.txt
@@ -185,6 +185,9 @@ tdarr_node_worker_status_timestamp_seconds{node_id="node-busy-1",node_name="Busy
 # HELP tdarr_score_pct Tdarr score percentage - how much of your libraries has been handled by tdarr
 # TYPE tdarr_score_pct gauge
 tdarr_score_pct{tdarr_instance="tdarr.localdomain"} 78.5
+# HELP tdarr_server_healthy 1 if Tdarr server self-reported status is healthy ("good"/"ok"/"healthy", case-insensitive), 0 otherwise. Raw status string is on tdarr_server_status_info.
+# TYPE tdarr_server_healthy gauge
+tdarr_server_healthy{tdarr_instance="tdarr.localdomain"} 1
 # HELP tdarr_server_info Tdarr server build metadata (value always 1); version and OS exposed as labels
 # TYPE tdarr_server_info gauge
 tdarr_server_info{os="linux",tdarr_instance="tdarr.localdomain",version="2.77.01"} 1

--- a/internal/collector/testdata/server_status.json
+++ b/internal/collector/testdata/server_status.json
@@ -1,0 +1,8 @@
+{
+  "status": "good",
+  "isProduction": true,
+  "os": "linux",
+  "version": "2.77.01",
+  "buildDate": "2026_05_29T12_20_24z",
+  "uptime": 45
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	TdarrStatsPath     string
 	TdarrPieStatsPath  string
 	TdarrNodePath      string
+	TdarrStatusPath    string
 	HttpMaxConcurrency int
 }
 
@@ -75,6 +76,7 @@ func getDefaults() Config {
 		TdarrStatsPath:     "/api/v2/cruddb",
 		TdarrNodePath:      "/api/v2/get-nodes",
 		TdarrPieStatsPath:  "/api/v2/stats/get-pies",
+		TdarrStatusPath:    "/api/v2/status",
 		HttpMaxConcurrency: 3,
 	}
 }
@@ -196,6 +198,7 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 		TdarrStatsPath:     defaults.TdarrStatsPath,
 		TdarrNodePath:      defaults.TdarrNodePath,
 		TdarrPieStatsPath:  defaults.TdarrPieStatsPath,
+		TdarrStatusPath:    defaults.TdarrStatusPath,
 		HttpMaxConcurrency: *httpMaxConcurrency,
 	}, nil
 }


### PR DESCRIPTION
## Changes

Adds Tdarr server status scraping and surfaces it as metrics + Grafana panels.

- New config `TdarrStatusPath` for `/api/v2/status` (default `/api/v2/status`).
- New `TdarrServerStatus` model (status, version, os, uptime).
- Collector fetches `/api/v2/status` first as a reachability gate; a DoRequest
  error fails the scrape (`tdarr_up 0`, nothing else emitted).
- New metrics:
  - `tdarr_server_uptime_seconds`
  - `tdarr_server_info{version,os}` (info metric, value 1)
  - `tdarr_server_status_info{status}` (raw status string label, value 1)
  - `tdarr_server_healthy` — boolean gauge, 1 when status is `good`/`ok`/`healthy`
    (case-insensitive, trimmed), 0 otherwise. A non-healthy status emits a warn log
    but does NOT fail the scrape.
- Golden fixture + table tests cover all server metrics and the healthy 0/1 branches.
- Dashboard (`examples/dashboard.json`) Scrape Health row reworked:
  - Row 1: Server Status (colored via `tdarr_server_healthy`), Server Uptime,
    Tdarr Version + Exporter Version (side-by-side, half-width each), Tdarr OS.
  - Row 2: exporter scrape panels (up, collector success, scrape duration, handler errors).

Separate chore commit: test image name/tag sourced from gitignored `local/local.env`
so the committed Taskfile carries no private registry (defaults to
`tdarr-exporter:test`). Unrelated to the feature; can be split out if preferred.

## Motivation

The dashboard's server status showed a neutral lowercase `good` with no color,
out of place next to other panels. A dedicated boolean health gauge lets the panel
be colored (red/green) while `tdarr_server_status_info` keeps the raw string as the
source of truth. Case-insensitive allowlist `{good, ok, healthy}` tolerates a benign
upstream rename without silently dropping the health signal.

## Test Plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./... -count=1` green (incl. golden fixture + `TestCollect_ServerHealthy`)
- [x] Validated against a live Tdarr scrape: `tdarr_server_healthy 1`, server
      info/status/uptime all correct.
- [ ] Import `examples/dashboard.json` into Grafana; confirm Server Status panel
      colors green on healthy / red on problem, and version panels sit side-by-side.

## In-depth

- **`info` vs boolean split:** the raw status string stays on `tdarr_server_status_info`
  (label metric) rather than in a value-bearing series, avoiding stale-1 / series churn
  when the string changes. The boolean gauge is the alertable/colorable signal.
- **Server status uses boolean + warn-log; pie statuses use counter + enum zero-fill +
  `tdarr_unknown_status_total`.** Different shapes: server status is a single binary
  signal (drift visible via the info label), pie statuses need zero-fill correctness and
  alertable drift. Deliberately did not downgrade the pie machinery.
- **Health failure ≠ unreachable.** Only DoRequest errors fail the scrape. On a status
  HTTP failure, only `tdarr_up 0` emits and `tdarr_server_healthy` goes absent (not 0),
  to avoid conflating reachability with self-reported health.
