### PR TITLE
fix: recover from scrape panics, degrade to tdarr_up=0

### DIFF
--- a/internal/collector/fake_api_test.go
+++ b/internal/collector/fake_api_test.go
@@ -106,3 +106,15 @@ func (f *fakeTdarrAPI) DoRequest(ctx context.Context, path string, target any, q
 	}
 	return json.Unmarshal(body, target)
 }
+
+// panicAPI is a tdarrAPI whose every call panics, used to exercise Collect's
+// recover() path (a panic mid-scrape must degrade to tdarr_up=0, not crash).
+type panicAPI struct{}
+
+func (panicAPI) DoPostRequest(ctx context.Context, path string, target any, payload []byte) error {
+	panic("panicAPI: boom during scrape")
+}
+
+func (panicAPI) DoRequest(ctx context.Context, path string, target any, queryParams ...client.QueryParams) error {
+	panic("panicAPI: boom during scrape")
+}

--- a/internal/collector/fake_api_test.go
+++ b/internal/collector/fake_api_test.go
@@ -118,3 +118,17 @@ func (panicAPI) DoPostRequest(ctx context.Context, path string, target any, payl
 func (panicAPI) DoRequest(ctx context.Context, path string, target any, queryParams ...client.QueryParams) error {
 	panic("panicAPI: boom during scrape")
 }
+
+// partialPanicAPI succeeds the initial status GET — so emitServerMetrics writes real
+// metrics to ch — then panics on the first stats POST. It exercises Collect's recover()
+// path AFTER metrics are already in the channel (collect() fetches /status via DoRequest
+// before the stats DoPostRequest), unlike panicAPI which panics on the very first call.
+type partialPanicAPI struct{ statusBody []byte }
+
+func (a partialPanicAPI) DoRequest(ctx context.Context, path string, target any, queryParams ...client.QueryParams) error {
+	return json.Unmarshal(a.statusBody, target)
+}
+
+func (partialPanicAPI) DoPostRequest(ctx context.Context, path string, target any, payload []byte) error {
+	panic("partialPanicAPI: boom after server metrics emitted")
+}

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -523,6 +523,17 @@ func (c *TdarrCollector) Collect(ch chan<- prometheus.Metric) {
 	// mid-scrape, the in-flight HTTP requests abort.
 	ctx, cancel := context.WithCancel(c.baseCtx)
 	defer cancel()
+	// Recover from any panic in the scrape path so a single bad scrape degrades to
+	// tdarr_up=0 instead of crashing the process (client_golang's collectWorker has
+	// no recover of its own). Reset partialFailure here too: the normal Swap below is
+	// skipped on panic, so without this the flag would leak into the next scrape.
+	defer func() {
+		if r := recover(); r != nil {
+			c.partialFailure.Store(false)
+			c.logger.Error().Interface("panic", r).Msg("Panic during collection; emitting tdarr_up=0")
+			ch <- c.upMetric.mustNewConstMetric(0.0)
+		}
+	}()
 	err := c.collect(ctx, ch)
 	if err != nil {
 		c.logger.Error().Err(err).Msg("Collection cycle failed")

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -558,6 +558,30 @@ func TestCollect_PanicInScrape_UpZeroAndNoGatherError(t *testing.T) {
 	}
 }
 
+// TestCollect_PanicAfterPartialEmit_UpZeroWithPartialMetrics verifies the recover()
+// path when the panic fires AFTER some metrics are already on ch: the status fetch
+// succeeds and emitServerMetrics writes server series, then the stats POST panics.
+// Gather must still return nil, tdarr_up must be PRESENT at 0.0, and the pre-panic
+// server metric must survive (per-item Gather keeps already-accepted families).
+func TestCollect_PanicAfterPartialEmit_UpZeroWithPartialMetrics(t *testing.T) {
+	t.Parallel()
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, partialPanicAPI{statusBody: validStatusBody()})
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(c)
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather returned error on recovered mid-collect panic, want nil: %v", err)
+	}
+	if got := upValueFromFamilies(mfs); got != 0.0 {
+		t.Errorf("tdarr_up: want 0.0 present, got %v (-1 means absent)", got)
+	}
+	if !hasMetricFamily(mfs, "tdarr_server_uptime_seconds") {
+		t.Error("pre-panic server metric tdarr_server_uptime_seconds did not survive the recovered panic")
+	}
+}
+
 // TestDescribe_EmitsAllDescs locks the Describe drift hazard: Prometheus does NOT flag a
 // desc that silently drops out of Describe (it only errors on a Collect desc that was never
 // described), so a missing Describe entry is invisible without an explicit count assertion.

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -538,6 +538,26 @@ func descFqName(t *testing.T, d *prometheus.Desc) string {
 	return m[1]
 }
 
+// TestCollect_PanicInScrape_UpZeroAndNoGatherError verifies P1.4: a panic in the
+// scrape path is recovered, tdarr_up is PRESENT with value 0.0 (not absent), and
+// Gather returns no error — so the HTTP handler still serves 200 with tdarr_up=0
+// rather than crashing the process or surfacing a 500.
+func TestCollect_PanicInScrape_UpZeroAndNoGatherError(t *testing.T) {
+	t.Parallel()
+	cfg := newTestConfig(t)
+	c := newTdarrCollectorWithAPI(cfg, panicAPI{})
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(c)
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather returned error on recovered panic, want nil: %v", err)
+	}
+	if got := upValueFromFamilies(mfs); got != 0.0 {
+		t.Errorf("tdarr_up: want 0.0 present, got %v (-1 means absent)", got)
+	}
+}
+
 // TestDescribe_EmitsAllDescs locks the Describe drift hazard: Prometheus does NOT flag a
 // desc that silently drops out of Describe (it only errors on a Collect desc that was never
 // described), so a missing Describe entry is invisible without an explicit count assertion.

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -24,7 +24,7 @@ func newEngine(reg *prometheus.Registry, tdarrInstance string) *gin.Engine {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Route Not Found: Try /metrics"})
 	})
 	router.Use(RequestLogger())
-	router.GET("/metrics", MetricsHandler(reg, promhttp.HandlerOpts{}, tdarrInstance))
+	router.GET("/metrics", MetricsHandler(reg, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}, tdarrInstance))
 	router.GET("/", IndexHandler())
 	router.GET("/healthz", HealthzHandler())
 	return router
@@ -182,5 +182,36 @@ func TestRequestLoggerPassesThrough(t *testing.T) {
 	}
 	if rec.Body.String() != wantBody {
 		t.Fatalf("body = %q, want %q (RequestLogger altered body)", rec.Body.String(), wantBody)
+	}
+}
+
+// dupCollector emits the same metric twice, which makes Registry.Gather return a
+// "collected before with the same name and label values" error — a deterministic way
+// to drive the handler's gather-error path without a panic.
+type dupCollector struct{ desc *prometheus.Desc }
+
+func (d dupCollector) Describe(ch chan<- *prometheus.Desc) { ch <- d.desc }
+func (d dupCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(d.desc, prometheus.GaugeValue, 1)
+	ch <- prometheus.MustNewConstMetric(d.desc, prometheus.GaugeValue, 1)
+}
+
+// TestMetricsHandler_ContinueOnError_Serves200OnGatherError locks the ContinueOnError
+// wiring (matches production server.go): on a registry-level Gather error the handler
+// must still serve HTTP 200 with whatever could be gathered, NOT 500. Under the default
+// HTTPErrorOnError this would be 500, so the test fails if newEngine's opts regress.
+func TestMetricsHandler_ContinueOnError_Serves200OnGatherError(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(dupCollector{desc: prometheus.NewDesc("dup_metric", "duplicate on purpose", nil, nil)})
+	engine := newEngine(reg, "continue-on-error")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (ContinueOnError must not 500 on a Gather error)", rec.Code)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,7 +37,7 @@ func ServeHttp(wg *sync.WaitGroup, registry *prometheus.Registry, runConfig Http
 	// add middleware
 	router.Use(handlers.RequestLogger())
 	// add handlers
-	router.GET(runConfig.PrometheusPath, handlers.MetricsHandler(registry, promhttp.HandlerOpts{}, runConfig.TdarrInstance))
+	router.GET(runConfig.PrometheusPath, handlers.MetricsHandler(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}, runConfig.TdarrInstance))
 	router.GET("/", handlers.IndexHandler())
 	router.GET("/healthz", handlers.HealthzHandler())
 


### PR DESCRIPTION
## Changes
- Wrap `TdarrCollector.Collect` with a `recover()` defer: a panic in the scrape path now degrades to `tdarr_up=0` instead of crashing the process. The `partialFailure` flag is reset inside the defer because the normal `Swap(false)` is skipped on panic and would otherwise leak `tdarr_up=0` into the next healthy scrape.
- Set `ErrorHandling: promhttp.ContinueOnError` on the metrics `HandlerOpts` so a registry-level Gather error serves a partial `200` instead of blanking the whole scrape with a `500`.
- Tests: `panicAPI` (panics on the first call) and `partialPanicAPI` (panics after server metrics are already emitted to the channel) assert `tdarr_up=0` is PRESENT and `Gather` returns `nil`; `dupCollector` drives a deterministic Gather error and asserts the handler serves `200` under `ContinueOnError`.

## Motivation
`MustNewConstMetric` panics on any value-count / label-cardinality mismatch, and the node worker-info metric carries many hand-maintained labels. client_golang's `collectWorker` has no `recover()` of its own, so an unrecovered panic crashes the exporter process; `gin.Recovery()` only yields an empty `500`. This change makes a single bad scrape fail safe — the exporter stays up and `tdarr_up=0` signals the problem — instead of taking the process down.

## Verification
- `go build ./...`
- `go test ./... -race -count=1` — all packages green.
- Behavior locked by the three tests above (panic on first call, panic after partial emit, ContinueOnError 200-on-Gather-error).

## In-depth
- Source-verified against client_golang v1.23.2: on a recovered panic, `Gather` processes metrics per-item and keeps already-accepted families, so `tdarr_up=0` is PRESENT (not absent) with `err=nil`, and the handler serves `200`. Metrics emitted before the panic survive.
- `ErrorHandling: ContinueOnError` only changes the outcome when `Gather` returns a non-nil error (e.g. a checked-metric Desc/label collision); the recovered-panic path already returns `nil`. It is set regardless, for the genuine collision case.
- Part of a Prometheus best-practices effort. The additive observability work (canonical `promhttp_metric_handler_*` metrics + dashboard "Exporter Internals" panels) follows in a separate, non-breaking MINOR PR off `main`. The two branches are independent (not stacked).
