### PR TITLE
feat: canonical promhttp handler metrics + Exporter Internals dashboard

### DIFF
--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -84,7 +84,298 @@
         "x": 0,
         "y": 0
       },
-      "id": 1,
+      "id": 103,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Tdarr server self-reported health from /api/v2/status: 1 = good (Healthy), 0 = problem. Raw status string is on tdarr_server_status_info.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "index": 0,
+                      "text": "Problem"
+                    },
+                    "1": {
+                      "index": 1,
+                      "text": "Healthy"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          },
+          "id": 64,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "value",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "tdarr_server_healthy{tdarr_instance=~\"$tdarr_instance\"}",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Server Status",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Tdarr server process uptime from /api/v2/status (Node.js process.uptime, seconds).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 1
+          },
+          "id": 63,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "tdarr_server_uptime_seconds{tdarr_instance=~\"$tdarr_instance\"}",
+              "instant": false,
+              "legendFormat": "uptime",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Server Uptime",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Tdarr server version reported by /api/v2/status.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 12,
+            "y": 1
+          },
+          "id": 61,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "name",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "tdarr_server_info{tdarr_instance=~\"$tdarr_instance\"}",
+              "instant": true,
+              "legendFormat": "{{version}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Tdarr Version",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Tdarr server operating system reported by /api/v2/status.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "id": 62,
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "name",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "tdarr_server_info{tdarr_instance=~\"$tdarr_instance\"}",
+              "instant": true,
+              "legendFormat": "{{os}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Tdarr OS",
+          "type": "stat"
+        }
+      ],
+      "title": "Tdarr Server",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 104,
       "panels": [
         {
           "datasource": {
@@ -133,7 +424,7 @@
             "h": 4,
             "w": 6,
             "x": 0,
-            "y": 5
+            "y": 1
           },
           "id": 2,
           "options": {
@@ -217,7 +508,7 @@
             "h": 4,
             "w": 6,
             "x": 6,
-            "y": 5
+            "y": 1
           },
           "id": 3,
           "options": {
@@ -289,7 +580,7 @@
             "h": 4,
             "w": 6,
             "x": 12,
-            "y": 5
+            "y": 1
           },
           "id": 4,
           "options": {
@@ -382,7 +673,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 5
+            "y": 1
           },
           "id": 5,
           "options": {
@@ -424,70 +715,6 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Tdarr server version reported by /api/v2/status.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "blue"
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 3,
-            "x": 12,
-            "y": 1
-          },
-          "id": 61,
-          "options": {
-            "colorMode": "none",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "auto",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "name",
-            "wideLayout": true
-          },
-          "pluginVersion": "12.0.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "tdarr_server_info{tdarr_instance=~\"$tdarr_instance\"}",
-              "instant": true,
-              "legendFormat": "{{version}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Tdarr Version",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
           "description": "Exporter build version from tdarr_exporter_build_info (set at build time via ldflags).",
           "fieldConfig": {
             "defaults": {
@@ -508,9 +735,9 @@
           },
           "gridPos": {
             "h": 4,
-            "w": 3,
-            "x": 15,
-            "y": 1
+            "w": 6,
+            "x": 0,
+            "y": 5
           },
           "id": 65,
           "options": {
@@ -552,71 +779,6 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Tdarr server operating system reported by /api/v2/status.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "blue"
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 6,
-            "x": 18,
-            "y": 1
-          },
-          "id": 62,
-          "options": {
-            "colorMode": "none",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "auto",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "name",
-            "wideLayout": true
-          },
-          "pluginVersion": "12.0.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "tdarr_server_info{tdarr_instance=~\"$tdarr_instance\"}",
-              "instant": true,
-              "legendFormat": "{{os}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Tdarr OS",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "Tdarr server process uptime from /api/v2/status (Node.js process.uptime, seconds).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -630,8 +792,7 @@
                     "color": "green"
                   }
                 ]
-              },
-              "unit": "s"
+              }
             },
             "overrides": []
           },
@@ -639,13 +800,13 @@
             "h": 4,
             "w": 6,
             "x": 6,
-            "y": 1
+            "y": 5
           },
-          "id": 63,
+          "id": 100,
           "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
             "orientation": "auto",
             "percentChangeColorMode": "standard",
             "reduceOptions": {
@@ -667,14 +828,13 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "tdarr_server_uptime_seconds{tdarr_instance=~\"$tdarr_instance\"}",
-              "instant": false,
-              "legendFormat": "uptime",
-              "range": true,
+              "expr": "promhttp_metric_handler_requests_in_flight{tdarr_instance=~\"$tdarr_instance\"}",
+              "instant": true,
+              "legendFormat": "{{tdarr_instance}}",
               "refId": "A"
             }
           ],
-          "title": "Server Uptime",
+          "title": "Requests In-Flight",
           "type": "stat"
         },
         {
@@ -682,66 +842,76 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Tdarr server self-reported health from /api/v2/status: 1 = good (Healthy), 0 = problem. Raw status string is on tdarr_server_status_info.",
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "mode": "palette-classic"
               },
-              "mappings": [
-                {
-                  "options": {
-                    "0": {
-                      "index": 0,
-                      "text": "Problem"
-                    },
-                    "1": {
-                      "index": 1,
-                      "text": "Healthy"
-                    }
-                  },
-                  "type": "value"
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
                 }
-              ],
+              },
+              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 1
+                    "color": "green"
                   }
                 ]
-              }
+              },
+              "unit": "reqps"
             },
             "overrides": []
           },
           "gridPos": {
-            "h": 4,
-            "w": 6,
+            "h": 8,
+            "w": 12,
             "x": 0,
-            "y": 1
+            "y": 9
           },
-          "id": 64,
+          "id": 101,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "auto",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "showPercentChange": false,
-            "textMode": "value",
-            "wideLayout": true
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
           },
           "pluginVersion": "12.0.1",
           "targets": [
@@ -751,17 +921,112 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "tdarr_server_healthy{tdarr_instance=~\"$tdarr_instance\"}",
-              "instant": true,
-              "legendFormat": "",
+              "expr": "sum by (code)(rate(promhttp_metric_handler_requests_total{tdarr_instance=~\"$tdarr_instance\"}[$__rate_interval]))",
+              "instant": false,
+              "legendFormat": "{{code}}",
+              "range": true,
               "refId": "A"
             }
           ],
-          "title": "Server Status",
-          "type": "stat"
+          "title": "HTTP Request Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 102,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (cause)(rate(promhttp_metric_handler_errors_total{tdarr_instance=~\"$tdarr_instance\"}[$__rate_interval]))",
+              "instant": false,
+              "legendFormat": "{{cause}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Handler Error Rate",
+          "type": "timeseries"
         }
       ],
-      "title": "Scrape Health",
+      "title": "Exporter / Scrape Health",
       "type": "row"
     },
     {
@@ -5398,6 +5663,584 @@
       ],
       "repeat": "node_name",
       "title": "Node: $node_name",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 200
+      },
+      "id": 111,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 105,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "go_goroutines{job=~\".*tdarr.*\"}",
+              "instant": false,
+              "legendFormat": "{{job}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Goroutines",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 106,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "go_memstats_heap_inuse_bytes{job=~\".*tdarr.*\"}",
+              "instant": false,
+              "legendFormat": "{{job}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Heap In-Use",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 107,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "process_resident_memory_bytes{job=~\".*tdarr.*\"}",
+              "instant": false,
+              "legendFormat": "{{job}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Resident Memory (RSS)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 108,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "rate(process_cpu_seconds_total{job=~\".*tdarr.*\"}[$__rate_interval])",
+              "instant": false,
+              "legendFormat": "{{job}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Process CPU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 109,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "process_open_fds{job=~\".*tdarr.*\"} / process_max_fds{job=~\".*tdarr.*\"}",
+              "instant": false,
+              "legendFormat": "{{job}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "File Descriptors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 110,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "go_gc_duration_seconds{quantile=\"0.75\",job=~\".*tdarr.*\"}",
+              "instant": false,
+              "legendFormat": "{{job}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GC Pause (p75)",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Exporter Internals (Go runtime)",
       "type": "row"
     },
     {

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -205,14 +205,25 @@ func TestMetricsHandler_PromhttpInstrumented(t *testing.T) {
 	doGet()         // first scrape arms the deferred requests_total increment
 	body := doGet() // second scrape exposes it
 
-	if !strings.Contains(body, "promhttp_metric_handler_requests_total") {
-		t.Fatalf("missing promhttp_metric_handler_requests_total\nbody:\n%s", body)
+	// All three standard handler series must be present. requests_total + in_flight come
+	// from InstrumentMetricHandler; errors_total is registered only because opts.Registry is
+	// set (the A1 fix) and is pre-seeded to 0, so it appears on every scrape.
+	for _, name := range []string{
+		"promhttp_metric_handler_requests_total",
+		"promhttp_metric_handler_requests_in_flight",
+		"promhttp_metric_handler_errors_total",
+	} {
+		if !strings.Contains(body, name+"{") {
+			t.Fatalf("missing %s series\nbody:\n%s", name, body)
+		}
 	}
-	// The wrap is the point of P2.3: every handler counter line must carry tdarr_instance.
+	// The wrap is the point of P2.3: every handler-metric sample must carry tdarr_instance.
+	// Checking errors_total specifically locks the A1 fix — it is labeled only when
+	// opts.Registry points at the WRAPPED registry, not the raw one.
 	for _, line := range strings.Split(body, "\n") {
-		if strings.HasPrefix(line, "promhttp_metric_handler_requests_total{") &&
+		if strings.HasPrefix(line, "promhttp_metric_handler_") &&
 			!strings.Contains(line, `tdarr_instance="`+instance+`"`) {
-			t.Fatalf("promhttp_metric_handler_requests_total missing tdarr_instance label:\n%s", line)
+			t.Fatalf("promhttp handler metric missing tdarr_instance label:\n%s", line)
 		}
 	}
 }

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -184,3 +184,35 @@ func TestRequestLoggerPassesThrough(t *testing.T) {
 		t.Fatalf("body = %q, want %q (RequestLogger altered body)", rec.Body.String(), wantBody)
 	}
 }
+
+// TestMetricsHandler_PromhttpInstrumented verifies P2.3: the standard
+// promhttp_metric_handler_* series are emitted and carry the tdarr_instance label
+// (injected via WrapRegistererWith). requests_total is incremented in a deferred
+// path after the body is written, so it is visible only on a later scrape.
+func TestMetricsHandler_PromhttpInstrumented(t *testing.T) {
+	t.Parallel()
+
+	const instance = "promhttp-instance"
+	engine := newEngine(prometheus.NewRegistry(), instance)
+
+	doGet := func() string {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		engine.ServeHTTP(rec, req)
+		return rec.Body.String()
+	}
+
+	doGet()         // first scrape arms the deferred requests_total increment
+	body := doGet() // second scrape exposes it
+
+	if !strings.Contains(body, "promhttp_metric_handler_requests_total") {
+		t.Fatalf("missing promhttp_metric_handler_requests_total\nbody:\n%s", body)
+	}
+	// The wrap is the point of P2.3: every handler counter line must carry tdarr_instance.
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "promhttp_metric_handler_requests_total{") &&
+			!strings.Contains(line, `tdarr_instance="`+instance+`"`) {
+			t.Fatalf("promhttp_metric_handler_requests_total missing tdarr_instance label:\n%s", line)
+		}
+	}
+}

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -47,7 +47,14 @@ func MetricsHandler(reg *prometheus.Registry, opts promhttp.HandlerOpts, tdarrIn
 		}, []string{"code"})
 	)
 
-	h := promhttp.HandlerFor(reg, opts)
+	// Wrap the registry so the promhttp handler's own counters carry tdarr_instance,
+	// matching the const label on the custom metrics above. HandlerFor keeps the raw
+	// reg (it gathers the real metrics); only the handler-internal counters are wrapped.
+	// Setting opts.Registry routes promhttp_metric_handler_errors_total through instReg
+	// too (it is registered only when opts.Registry != nil).
+	instReg := prometheus.WrapRegistererWith(prometheus.Labels{"tdarr_instance": tdarrInstance}, reg)
+	opts.Registry = instReg
+	h := promhttp.InstrumentMetricHandler(instReg, promhttp.HandlerFor(reg, opts))
 
 	return func(c *gin.Context) {
 		start := time.Now()


### PR DESCRIPTION
## Changes
- Serve the canonical promhttp handler metrics via `promhttp.InstrumentMetricHandler`, exposing `promhttp_metric_handler_requests_total{code}`, `promhttp_metric_handler_requests_in_flight`, and `promhttp_metric_handler_errors_total{cause}`.
- Wrap the registry with `WrapRegistererWith` so those handler-internal counters carry the `tdarr_instance` label, and set `opts.Registry` so `errors_total` is registered (it only emits when `opts.Registry` is non-nil). `HandlerFor` keeps the raw registry for gathering the real metrics.
- Dashboard (`examples/dashboard.json`): split the `Scrape Health` row into `Tdarr Server` (status/uptime/version/OS) and `Exporter / Scrape Health` (exporter up/collector success/scrape duration/handler errors/version), add three promhttp panels (requests in-flight, HTTP request rate by code, handler error rate by cause), and add a new `Exporter Internals (Go runtime)` row before Debug (goroutines, heap in-use, RSS, process CPU, file descriptors, GC pause p75).
- Tests: handler test asserts all three `promhttp_metric_handler_*` series carry `tdarr_instance`.

## Motivation
The exporter exposed no standard self-instrumentation for its own metrics endpoint. Adopting the conventional `promhttp_metric_handler_*` series (labeled per `tdarr_instance`) gives request/error/in-flight visibility using the recognized names, and the new dashboard panels surface the previously-emitted-but-unpaneled `go_*` / `process_*` runtime metrics plus the new promhttp series.

## Verification
- `go build ./...`
- `go test ./... -race -count=1` — all packages green.
- Live-verified via `task curl`: all three `promhttp_metric_handler_*` series present and carrying `tdarr_instance` (including `errors_total{cause}` pre-seeded to 0, which only appears because `opts.Registry` is set).

## In-depth
- **Additive / non-breaking.** No existing metric is removed or renamed. The redundant custom `tdarr_scrape_requests_total` (an exact duplicate of `promhttp_metric_handler_requests_total`) is intentionally left in place; its removal + panel repoint is a separate future breaking change.
- **Dashboard label nuance:** the promhttp panels filter by `tdarr_instance`; the `go_*` / `process_*` panels use the Prometheus scrape-target matcher `{job=~".*tdarr.*"}` instead, because those series are registered on the raw registry and carry no `tdarr_instance` label (this mirrors the existing `up{job=~".*tdarr.*"}` panel). Counters are `rate()`'d, gauges raw, base units set at display.
- Independent of (not stacked on) the P1.4 panic-safety PR; merged `main` into this branch to pick up that change and resolve the one shared `handlers_test.go` overlap (kept `newEngine` on `ContinueOnError` plus both new test functions).
