### PR TITLE
ci: cross-compile arm64 via BUILDPLATFORM builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE_TAG=1.26.3-alpine
 ARG RUN_IMAGE=gcr.io/distroless/static
 ARG RUN_IMAGE_TAG=nonroot
 
-FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS builder
+FROM --platform=${BUILDPLATFORM} ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS builder
 
 # BuildKit auto-populates these per --platform target
 ARG TARGETOS


### PR DESCRIPTION
## Changes
- Pin the Dockerfile `builder` stage to the native build platform: `FROM --platform=${BUILDPLATFORM} ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS builder`.
- No other changes. `${BUILDPLATFORM}` is a BuildKit predefined arg (no `ARG` declaration needed).

## Motivation
The release build is multi-arch (`platforms: linux/amd64,linux/arm64` in `.github/actions/docker/action.yml`) on amd64 runners. Without a platform pin, the arm64 leg runs the `golang` builder image under QEMU emulation (~5–10× slower). The builder already cross-compiles Go (`CGO_ENABLED=0`, `GOOS=${TARGETOS}`, `GOARCH=${TARGETARCH}`, `GOARM=${TARGETVARIANT}`), so pinning the builder to `${BUILDPLATFORM}` makes it run native amd64 and emit the arm64 binary via Go cross-compilation. The runtime stage (`distroless/static`) is COPY-only, so it never emulates.

## Test plan
- `docker buildx build --platform linux/amd64,linux/arm64 .` succeeds and the arm64 leg no longer invokes QEMU for the build stage (builder runs amd64; Go cross-compiles).
- Resulting arm64 image runs on arm64 hardware.

## In-depth
Cross-compile wiring was already present; this only changes *where the builder runs*, not the output target arch. Pinning `${BUILDPLATFORM}` cannot accidentally lock the output to amd64 because `GOARCH` is driven by `${TARGETARCH}`. Braced var form used to match the rest of the Dockerfile.