### PR TITLE
fix: split File Descriptors panel into used-vs-limit graph + %-of-limit stat

### DIFF
--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -6103,7 +6103,7 @@
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "short"
             },
             "overrides": []
           },
@@ -6135,14 +6135,26 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "process_open_fds{job=~\".*tdarr.*\"} / process_max_fds{job=~\".*tdarr.*\"}",
+              "expr": "process_open_fds{job=~\".*tdarr.*\"}",
               "instant": false,
-              "legendFormat": "{{job}}",
+              "legendFormat": "used {{job}}",
               "range": true,
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "process_max_fds{job=~\".*tdarr.*\"}",
+              "instant": false,
+              "legendFormat": "limit {{job}}",
+              "range": true,
+              "refId": "B"
             }
           ],
-          "title": "File Descriptors",
+          "title": "File Descriptors (used vs limit)",
           "type": "timeseries"
         },
         {
@@ -6238,6 +6250,79 @@
           ],
           "title": "GC Pause (p75)",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Current open file descriptors as a fraction of the process limit (process_open_fds / process_max_fds). The limit is often the container default (~1M), so this normally reads near zero; watch for sustained climbs (descriptor leak) or values approaching 1.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.95
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 112,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "process_open_fds{job=~\".*tdarr.*\"} / process_max_fds{job=~\".*tdarr.*\"}",
+              "instant": true,
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ],
+          "title": "File Descriptors (% of limit)",
+          "type": "stat"
         }
       ],
       "title": "Exporter Internals (Go runtime)",


### PR DESCRIPTION
## Changes
- Exporter Internals (Go runtime) row, `examples/dashboard.json`:
  - Repurpose panel id 109 into a `short`-unit timeseries **File Descriptors (used vs limit)** with two lines: `process_open_fds{job=~".*tdarr.*"}` (used) and `process_max_fds{job=~".*tdarr.*"}` (limit).
  - Add a new stat panel id 112 **File Descriptors (% of limit)**: `process_open_fds / process_max_fds`, unit `percentunit`, latest value, thresholds green → yellow `0.8` → red `0.95`. Stacked directly below the timeseries.
- Both filter by `{job=~".*tdarr.*"}` (the `process_*` collectors do not carry a `tdarr_instance` label).

## Motivation
The original single panel rendered `process_open_fds / process_max_fds` (a 0–1 ratio) under a title that implied a raw count. The FD limit is usually the container default (~1M), so a lone ratio normally reads near zero and hides the actual descriptor count. The split shows real-time absolute used/limit numbers (leak detection) while keeping a normalized headroom stat with threshold coloring for at-a-glance status.

## Test plan
- `python3 -c "import json; json.load(open('examples/dashboard.json'))"` — valid.
- No duplicate panel IDs; grid positions within row 111 do not overlap (109 @ y17, new 112 @ y25).
- Manual: import into Grafana, confirm the two FD panels render and the stat colors by threshold. (Not yet visually confirmed — recommend an import check; will also be covered by the upcoming D1 dashboard pass.)

## In-depth
New stat panel cloned from the existing "Requests In-Flight" stat (same `options`/`reduceOptions`, `colorMode: background`) for consistency. Additive/non-breaking dashboard change; no metric, query-name, or unit contract change to any existing non-moved panel.