### PR TITLE
refactor!: drop redundant tdarr_scrape_requests_total

### DIFF
--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -701,7 +701,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(tdarr_scrape_requests_total{tdarr_instance=~\"$tdarr_instance\",code!~\"2..\"}[5m]))",
+              "expr": "sum(rate(promhttp_metric_handler_requests_total{tdarr_instance=~\"$tdarr_instance\",code!~\"2..\"}[5m]))",
               "instant": true,
               "legendFormat": "handler errors",
               "refId": "A"

--- a/internal/collector/tdarr_golden_test.go
+++ b/internal/collector/tdarr_golden_test.go
@@ -11,8 +11,8 @@ import (
 
 // collectorMetricNames is the exhaustive list of metric families emitted by
 // TdarrCollector.Collect.  Metrics that come from internal/handlers/metrics.go
-// (tdarr_scrape_duration_seconds, tdarr_scrape_requests_total) are intentionally
-// excluded so they cannot influence the comparison.
+// (tdarr_scrape_duration_seconds) are intentionally excluded so they cannot
+// influence the comparison.
 var collectorMetricNames = []string{
 	"tdarr_avg_num_streams",
 	"tdarr_files_total",

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -64,7 +64,6 @@ func TestStaticHandlers(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			engine := newEngine(prometheus.NewRegistry(), "test-instance")
@@ -145,7 +144,7 @@ func TestMetricsHandler(t *testing.T) {
 // value from a Prometheus text exposition body. Returns -1 if not present.
 func counterValue(t *testing.T, body, instance string) float64 {
 	t.Helper()
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if strings.HasPrefix(line, "promhttp_metric_handler_requests_total{") &&
 			strings.Contains(line, `code="200"`) &&
 			strings.Contains(line, `tdarr_instance="`+instance+`"`) {
@@ -220,7 +219,7 @@ func TestMetricsHandler_PromhttpInstrumented(t *testing.T) {
 	// The wrap is the point of P2.3: every handler-metric sample must carry tdarr_instance.
 	// Checking errors_total specifically locks the A1 fix — it is labeled only when
 	// opts.Registry points at the WRAPPED registry, not the raw one.
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if strings.HasPrefix(line, "promhttp_metric_handler_") &&
 			!strings.Contains(line, `tdarr_instance="`+instance+`"`) {
 			t.Fatalf("promhttp handler metric missing tdarr_instance label:\n%s", line)

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -96,10 +96,10 @@ func TestMetricsHandler(t *testing.T) {
 		return rec
 	}
 
-	// First scrape. The scrape_requests_total counter is incremented in a
-	// deferred func that runs *after* promhttp has already written the body,
-	// so it is not visible until a later scrape. The scrape_duration gauge is
-	// registered eagerly, so it (and the const label) is present immediately.
+	// First scrape. The promhttp_metric_handler_requests_total counter is incremented
+	// inside promhttp's InstrumentMetricHandler after the body is written, so it is
+	// not visible until a later scrape. The scrape_duration gauge is registered
+	// eagerly, so it (and the const label) is present immediately.
 	rec := doGet()
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -122,8 +122,8 @@ func TestMetricsHandler(t *testing.T) {
 
 	// Second scrape: now the counter from the first request is exposed.
 	body2 := doGet().Body.String()
-	if !strings.Contains(body2, "tdarr_scrape_requests_total") {
-		t.Fatalf("metrics body missing %q\nbody:\n%s", "tdarr_scrape_requests_total", body2)
+	if !strings.Contains(body2, "promhttp_metric_handler_requests_total") {
+		t.Fatalf("metrics body missing %q\nbody:\n%s", "promhttp_metric_handler_requests_total", body2)
 	}
 	if !strings.Contains(body2, `tdarr_instance="`+instance+`"`) {
 		t.Fatalf("counter missing const label tdarr_instance=%q\nbody:\n%s", instance, body2)
@@ -134,19 +134,19 @@ func TestMetricsHandler(t *testing.T) {
 	got2 := counterValue(t, body2, instance)
 	got3 := counterValue(t, body3, instance)
 	if got2 < 0 || got3 < 0 {
-		t.Fatalf("scrape_requests_total{code=\"200\"} not found: second=%v third=%v", got2, got3)
+		t.Fatalf("promhttp_metric_handler_requests_total{code=\"200\"} not found: second=%v third=%v", got2, got3)
 	}
 	if got3 <= got2 {
-		t.Fatalf("scrape_requests_total did not increment: second=%v third=%v", got2, got3)
+		t.Fatalf("promhttp_metric_handler_requests_total did not increment: second=%v third=%v", got2, got3)
 	}
 }
 
-// counterValue extracts the tdarr_scrape_requests_total{code="200"} sample
+// counterValue extracts the promhttp_metric_handler_requests_total{code="200"} sample
 // value from a Prometheus text exposition body. Returns -1 if not present.
 func counterValue(t *testing.T, body, instance string) float64 {
 	t.Helper()
 	for _, line := range strings.Split(body, "\n") {
-		if strings.HasPrefix(line, "tdarr_scrape_requests_total{") &&
+		if strings.HasPrefix(line, "promhttp_metric_handler_requests_total{") &&
 			strings.Contains(line, `code="200"`) &&
 			strings.Contains(line, `tdarr_instance="`+instance+`"`) {
 			fields := strings.Fields(line)

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -31,21 +30,13 @@ func RequestLogger() gin.HandlerFunc {
 
 func MetricsHandler(reg *prometheus.Registry, opts promhttp.HandlerOpts, tdarrInstance string) gin.HandlerFunc {
 	// static metrics always present
-	var (
-		// use promAuto to auto register with existing registry
-		scrapDuration = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Namespace:   METRIC_NAMESPACE,
-			Name:        "scrape_duration_seconds",
-			Help:        "Duration of the last scrape of metrics from exporter.",
-			ConstLabels: prometheus.Labels{"tdarr_instance": tdarrInstance},
-		})
-		requestCount = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace:   METRIC_NAMESPACE,
-			Name:        "scrape_requests_total",
-			Help:        "Total number of HTTP requests made.",
-			ConstLabels: prometheus.Labels{"tdarr_instance": tdarrInstance},
-		}, []string{"code"})
-	)
+	// use promAuto to auto register with existing registry
+	scrapDuration := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		Namespace:   METRIC_NAMESPACE,
+		Name:        "scrape_duration_seconds",
+		Help:        "Duration of the last scrape of metrics from exporter.",
+		ConstLabels: prometheus.Labels{"tdarr_instance": tdarrInstance},
+	})
 
 	// Wrap the registry so the promhttp handler's own counters carry tdarr_instance,
 	// matching the const label on the custom metrics above. HandlerFor keeps the raw
@@ -60,7 +51,6 @@ func MetricsHandler(reg *prometheus.Registry, opts promhttp.HandlerOpts, tdarrIn
 		start := time.Now()
 		defer func() {
 			scrapDuration.Set(time.Since(start).Seconds())
-			requestCount.WithLabelValues(fmt.Sprintf("%d", c.Writer.Status())).Inc()
 		}()
 		// promhttp serves back response
 		h.ServeHTTP(c.Writer, c.Request)


### PR DESCRIPTION
First `!` commit of the Prometheus best-practices **breaking batch** (one MAJOR release; release-please PR stays gated until the whole batch — P1.3 / P3.* / D1 — lands). Follows merged #84 #85 #86 #87.

## Changes
- Remove the custom `tdarr_scrape_requests_total` CounterVec and its `.Inc()` from `internal/handlers/metrics.go` (drops the now-unused `fmt` import).
- Repoint the "Handler Errors (5m)" dashboard stat (panel id 5) to `promhttp_metric_handler_requests_total` (same `{code}` label). Panels id 101 / id 102 untouched.
- Repoint `TestMetricsHandler` + `counterValue` to the promhttp counter; request-counting behavior and scrape-lag structure preserved.
- Trim the `tdarr_golden_test.go` exclusion comment to just `tdarr_scrape_duration_seconds`.
- Modernize `handlers_test.go` (`strings.Split`→`SplitSeq`, drop redundant loop-var copy) — separate commit, no behavior change.

**BREAKING CHANGE:** `tdarr_scrape_requests_total` is removed. Move queries/alerts to `promhttp_metric_handler_requests_total` (identical `{code}` label).

## Motivation
The custom counter exactly duplicated the canonical `promhttp_metric_handler_requests_total` added in #85: both count `/metrics` responses by HTTP `code`. `/metrics` is the only mounted route and has no auth, so the code domain is 200/500/503 for both — verified against a live scrape (custom metric absent, promhttp counter present with `tdarr_instance` + codes 200/500/503). `tdarr_scrape_duration_seconds` has no promhttp equivalent and is kept.

## Test plan
- `go build ./...` clean (catches the dropped `fmt`).
- `go test ./... -race` green.
- `gofmt -l` / `go vet ./internal/handlers/...` clean.
- Dashboard JSON parses.
- Live `/metrics` scrape confirms removal + promhttp counter behavior.

## In-depth
- Dashboard expr swap is JSON-valid but **not yet visually confirmed in Grafana** — covered by the upcoming D1 import-check.
- Merging this arms the pending release-please PR to MAJOR; that release PR is intentionally **not** merged until the full breaking batch is on `main`, so downstream migrates once.