### PR TITLE
feat!: move library_name to tdarr_library_info, key library metrics on library_id

### DIFF
--- a/examples/alerts.yaml
+++ b/examples/alerts.yaml
@@ -15,7 +15,7 @@ spec:
             description: One or more transcode tasks for Library {{ $labels.library_name }} has failed.
             summary: A tdarr transcode failed
           expr: |-
-            tdarr_library_transcodes{status="error"} > 0
+            tdarr_library_transcodes{status="error"} * on (library_id) group_left(library_name) tdarr_library_info > 0
           for: 5m
           labels:
             severity: warning

--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -1104,7 +1104,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sort_desc(sum by (library_name) (tdarr_library_files{tdarr_instance=~\"$tdarr_instance\"}))",
+              "expr": "sort_desc(sum by (library_name) (tdarr_library_files{tdarr_instance=~\"$tdarr_instance\"} * on (library_id, tdarr_instance) group_left(library_name) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}))",
               "instant": true,
               "legendFormat": "{{library_name}}",
               "refId": "A"
@@ -1179,7 +1179,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sort_desc(sum by (library_name) (tdarr_library_transcodes_completed_total{tdarr_instance=~\"$tdarr_instance\"}))",
+              "expr": "sort_desc(sum by (library_name) (tdarr_library_transcodes_completed_total{tdarr_instance=~\"$tdarr_instance\"} * on (library_id, tdarr_instance) group_left(library_name) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}))",
               "instant": true,
               "legendFormat": "{{library_name}}",
               "refId": "A"
@@ -1254,7 +1254,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sort_desc(sum by (library_name) (tdarr_library_health_checks_completed_total{tdarr_instance=~\"$tdarr_instance\"}))",
+              "expr": "sort_desc(sum by (library_name) (tdarr_library_health_checks_completed_total{tdarr_instance=~\"$tdarr_instance\"} * on (library_id, tdarr_instance) group_left(library_name) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}))",
               "instant": true,
               "legendFormat": "{{library_name}}",
               "refId": "A"
@@ -1330,7 +1330,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sort_desc(sum by (library_name) (tdarr_library_size_diff_bytes{tdarr_instance=~\"$tdarr_instance\"}))",
+              "expr": "sort_desc(sum by (library_name) (tdarr_library_size_diff_bytes{tdarr_instance=~\"$tdarr_instance\"} * on (library_id, tdarr_instance) group_left(library_name) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}))",
               "instant": true,
               "legendFormat": "{{library_name}}",
               "refId": "A"
@@ -1487,7 +1487,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (status) (tdarr_library_transcodes{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum by (status) (tdarr_library_transcodes{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": false,
               "legendFormat": "{{status}}",
               "range": true,
@@ -1580,7 +1580,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (status) (tdarr_library_health_checks{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum by (status) (tdarr_library_health_checks{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": false,
               "legendFormat": "{{status}}",
               "range": true,
@@ -1733,7 +1733,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(tdarr_library_files{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum(tdarr_library_files{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "files",
               "refId": "A"
@@ -1797,7 +1797,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(tdarr_library_transcodes_completed_total{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum(tdarr_library_transcodes_completed_total{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "transcodes",
               "refId": "A"
@@ -1861,7 +1861,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(tdarr_library_health_checks_completed_total{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum(tdarr_library_health_checks_completed_total{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "health checks",
               "refId": "A"
@@ -2056,7 +2056,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(tdarr_library_size_diff_bytes{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum(tdarr_library_size_diff_bytes{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "size diff",
               "refId": "A"
@@ -2476,7 +2476,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (status) (tdarr_library_transcodes{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum by (status) (tdarr_library_transcodes{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "{{status}}",
               "refId": "A"
@@ -2548,7 +2548,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (status) (tdarr_library_health_checks{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum by (status) (tdarr_library_health_checks{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "{{status}}",
               "refId": "A"
@@ -2620,7 +2620,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (codec) (tdarr_library_video_codecs{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum by (codec) (tdarr_library_video_codecs{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "{{codec}}",
               "refId": "A"
@@ -2694,7 +2694,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (resolution) (tdarr_library_video_resolutions{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum by (resolution) (tdarr_library_video_resolutions{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "{{resolution}}",
               "refId": "A"
@@ -2768,7 +2768,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (container_type) (tdarr_library_video_containers{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum by (container_type) (tdarr_library_video_containers{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "{{container_type}}",
               "refId": "A"
@@ -2842,7 +2842,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (codec) (tdarr_library_audio_codecs{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum by (codec) (tdarr_library_audio_codecs{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "{{codec}}",
               "refId": "A"
@@ -2916,7 +2916,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (container_type) (tdarr_library_audio_containers{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+              "expr": "sum by (container_type) (tdarr_library_audio_containers{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
               "instant": true,
               "legendFormat": "{{container_type}}",
               "refId": "A"
@@ -7055,14 +7055,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(tdarr_library_transcodes{tdarr_instance=~\"$tdarr_instance\"}, library_name)",
+        "definition": "label_values(tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}, library_name)",
         "includeAll": true,
         "label": "Library",
         "multi": true,
         "name": "library",
         "options": [],
         "query": {
-          "query": "label_values(tdarr_library_transcodes{tdarr_instance=~\"$tdarr_instance\"}, library_name)",
+          "query": "label_values(tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}, library_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -122,6 +122,7 @@ type TdarrCollector struct {
 	pieVideoResolutions   typedDesc
 	pieAudioCodecs        typedDesc
 	pieAudioContainers    typedDesc
+	pieLibraryInfo        typedDesc           // library_id → library_name mapping (value always 1)
 	unknownStatusTotal    typedDesc           // counter for status values not in known enum
 	nodeCollector         *TdarrNodeCollector // node data
 	upMetric              typedDesc
@@ -264,57 +265,62 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 		pieNumFiles: newGauge(
 			"library_files",
 			"Tdarr total files in library",
-			[]string{"library_name", "library_id"}, instance,
+			[]string{"library_id"}, instance,
 		),
 		pieNumTranscodes: newCounter(
 			"library_transcodes_completed_total",
 			"Tdarr completed transcodes for a library, counted over its lifetime; increments each time a transcode alters a file (the same file can transcode again after a flow/process change), failed jobs excluded",
-			[]string{"library_name", "library_id"}, instance,
+			[]string{"library_id"}, instance,
 		),
 		pieNumHealthChecks: newCounter(
 			"library_health_checks_completed_total",
 			"Tdarr completed health checks for a library, counted over its lifetime; increments each time a health check completes on a file, failed jobs excluded",
-			[]string{"library_name", "library_id"}, instance,
+			[]string{"library_id"}, instance,
 		),
 		pieSizeDiff: newGauge(
 			"library_size_diff_bytes",
 			"Tdarr net file-size change in bytes for library (positive = space saved, negative = grew); lifetime, includes files since deleted",
-			[]string{"library_name", "library_id"}, instance,
+			[]string{"library_id"}, instance,
 		),
 		pieTranscodes: newGauge(
 			"library_transcodes",
 			"Tdarr transcodes for library by status",
-			[]string{"library_name", "library_id", "status"}, instance,
+			[]string{"library_id", "status"}, instance,
 		),
 		pieHealthChecks: newGauge(
 			"library_health_checks",
 			"Tdarr health checks for library by status",
-			[]string{"library_name", "library_id", "status"}, instance,
+			[]string{"library_id", "status"}, instance,
 		),
 		pieVideoCodecs: newGauge(
 			"library_video_codecs",
 			"Tdarr video codecs for library by type",
-			[]string{"library_name", "library_id", "codec"}, instance,
+			[]string{"library_id", "codec"}, instance,
 		),
 		pieVideoContainers: newGauge(
 			"library_video_containers",
 			"Tdarr video containers for library by type",
-			[]string{"library_name", "library_id", "container_type"}, instance,
+			[]string{"library_id", "container_type"}, instance,
 		),
 		pieVideoResolutions: newGauge(
 			"library_video_resolutions",
 			"Tdarr video resolutions for library by type",
-			[]string{"library_name", "library_id", "resolution"}, instance,
+			[]string{"library_id", "resolution"}, instance,
 		),
 		pieAudioCodecs: newGauge(
 			"library_audio_codecs",
 			"Tdarr audio codecs for library by type",
-			[]string{"library_name", "library_id", "codec"}, instance,
+			[]string{"library_id", "codec"}, instance,
 		),
 		pieAudioContainers: newGauge(
 			"library_audio_containers",
 			"Tdarr audio containers for library by type",
-			[]string{"library_name", "library_id", "container_type"}, instance,
+			[]string{"library_id", "container_type"}, instance,
+		),
+		pieLibraryInfo: newGauge(
+			"library_info",
+			"Tdarr library metadata (value always 1); maps the stable library_id to its current library_name. Join other tdarr_library_* metrics on library_id to recover the name.",
+			[]string{"library_id", "library_name"}, instance,
 		),
 		unknownStatusTotal: newCounter(
 			"unknown_status_total",
@@ -378,6 +384,7 @@ func newTdarrCollectorWithAPI(runConfig config.Config, api tdarrAPI) *TdarrColle
 		c.pieVideoResolutions,
 		c.pieAudioCodecs,
 		c.pieAudioContainers,
+		c.pieLibraryInfo,
 		c.unknownStatusTotal,
 		c.upMetric,
 		c.serverUptime,
@@ -716,10 +723,10 @@ func (c *TdarrCollector) emitGeneralMetrics(ch chan<- prometheus.Metric, metric 
 
 // emitPieSlices emits one gauge per slice in a pie-slice list (codecs/containers/resolutions),
 // lowercasing the slice name as the final label. Shared by the five video/audio loops.
-func emitPieSlices(ch chan<- prometheus.Metric, desc typedDesc, libName, libId string, slices []TdarrPieSlice) {
+func emitPieSlices(ch chan<- prometheus.Metric, desc typedDesc, libId string, slices []TdarrPieSlice) {
 	for _, pieSlice := range slices {
 		ch <- desc.mustNewConstMetric(float64(pieSlice.Value),
-			libName, libId, strings.ToLower(pieSlice.Name))
+			libId, strings.ToLower(pieSlice.Name))
 	}
 }
 
@@ -727,25 +734,28 @@ func emitPieSlices(ch chan<- prometheus.Metric, desc typedDesc, libName, libId s
 // video/audio codec/container/resolution slices). Pure: reads pieData, writes to ch.
 func (c *TdarrCollector) emitPieMetrics(ch chan<- prometheus.Metric, pieData []*TdarrPieStats) {
 	for _, pie := range pieData {
-		ch <- c.pieNumFiles.mustNewConstMetric(float64(pie.PieStats.TotalFiles), pie.libraryName, pie.libraryId)
-		ch <- c.pieNumTranscodes.mustNewConstMetric(float64(pie.PieStats.TotalTranscodeCount), pie.libraryName, pie.libraryId)
-		ch <- c.pieNumHealthChecks.mustNewConstMetric(float64(pie.PieStats.TotalHealthCheckCount), pie.libraryName, pie.libraryId)
-		ch <- c.pieSizeDiff.mustNewConstMetric(pie.PieStats.SizeDiff*bytesPerGB, pie.libraryName, pie.libraryId)
+		// library_name lives only on the info metric; every other series keys on library_id so a
+		// library rename doesn't churn them. Dashboards join back on library_id to recover the name.
+		ch <- c.pieLibraryInfo.mustNewConstMetric(1, pie.libraryId, pie.libraryName)
+		ch <- c.pieNumFiles.mustNewConstMetric(float64(pie.PieStats.TotalFiles), pie.libraryId)
+		ch <- c.pieNumTranscodes.mustNewConstMetric(float64(pie.PieStats.TotalTranscodeCount), pie.libraryId)
+		ch <- c.pieNumHealthChecks.mustNewConstMetric(float64(pie.PieStats.TotalHealthCheckCount), pie.libraryId)
+		ch <- c.pieSizeDiff.mustNewConstMetric(pie.PieStats.SizeDiff*bytesPerGB, pie.libraryId)
 		// Emit transcode statuses from the normalized map (pre-cleaned labels, full enum coverage).
 		for status, count := range pie.NormalizedTranscodes {
 			ch <- c.pieTranscodes.mustNewConstMetric(float64(count),
-				pie.libraryName, pie.libraryId, status)
+				pie.libraryId, status)
 		}
 		// Emit health check statuses from the normalized map (pre-cleaned labels, full enum coverage).
 		for status, count := range pie.NormalizedHealthChecks {
 			ch <- c.pieHealthChecks.mustNewConstMetric(float64(count),
-				pie.libraryName, pie.libraryId, status)
+				pie.libraryId, status)
 		}
-		emitPieSlices(ch, c.pieVideoCodecs, pie.libraryName, pie.libraryId, pie.PieStats.Video.Codecs)
-		emitPieSlices(ch, c.pieVideoContainers, pie.libraryName, pie.libraryId, pie.PieStats.Video.Containers)
-		emitPieSlices(ch, c.pieVideoResolutions, pie.libraryName, pie.libraryId, pie.PieStats.Video.Resolutions)
-		emitPieSlices(ch, c.pieAudioCodecs, pie.libraryName, pie.libraryId, pie.PieStats.Audio.Codecs)
-		emitPieSlices(ch, c.pieAudioContainers, pie.libraryName, pie.libraryId, pie.PieStats.Audio.Containers)
+		emitPieSlices(ch, c.pieVideoCodecs, pie.libraryId, pie.PieStats.Video.Codecs)
+		emitPieSlices(ch, c.pieVideoContainers, pie.libraryId, pie.PieStats.Video.Containers)
+		emitPieSlices(ch, c.pieVideoResolutions, pie.libraryId, pie.PieStats.Video.Resolutions)
+		emitPieSlices(ch, c.pieAudioCodecs, pie.libraryId, pie.PieStats.Audio.Codecs)
+		emitPieSlices(ch, c.pieAudioContainers, pie.libraryId, pie.PieStats.Audio.Containers)
 	}
 }
 

--- a/internal/collector/tdarr_emit_test.go
+++ b/internal/collector/tdarr_emit_test.go
@@ -303,9 +303,15 @@ func TestEmitPieMetrics(t *testing.T) {
 		c.emitPieMetrics(ch, []*TdarrPieStats{pie})
 	})
 
+	// library_name lives only on the info metric now; value metrics key on library_id
+	if got := findOne(t, samples, "tdarr_library_info",
+		map[string]string{"library_id": "lib-audio-01", "library_name": "Music"}).value; got != 1 {
+		t.Errorf("library_info{lib-audio-01,Music} = %v, want 1", got)
+	}
+
 	// totals
 	if got := findOne(t, samples, "tdarr_library_files",
-		map[string]string{"library_name": "Music", "library_id": "lib-audio-01"}).value; got != 12 {
+		map[string]string{"library_id": "lib-audio-01"}).value; got != 12 {
 		t.Errorf("library_files = %v, want 12", got)
 	}
 	if got := findOne(t, samples, "tdarr_library_size_diff_bytes",
@@ -359,7 +365,7 @@ func TestEmitPieSlices_LowercasesNames(t *testing.T) {
 
 	slices := []TdarrPieSlice{{Name: "HEVC", Value: 3}, {Name: "Av1", Value: 9}}
 	samples := collectSamples(t, func(ch chan<- prometheus.Metric) {
-		emitPieSlices(ch, c.pieVideoCodecs, "Shows", "lib-video-01", slices)
+		emitPieSlices(ch, c.pieVideoCodecs, "lib-video-01", slices)
 	})
 
 	if len(samples) != 2 {
@@ -368,7 +374,7 @@ func TestEmitPieSlices_LowercasesNames(t *testing.T) {
 	var gotNames []string
 	for _, s := range samples {
 		gotNames = append(gotNames, s.labels["codec"])
-		if s.labels["library_name"] != "Shows" || s.labels["library_id"] != "lib-video-01" {
+		if s.labels["library_id"] != "lib-video-01" {
 			t.Errorf("unexpected library labels: %v", s.labels)
 		}
 	}

--- a/internal/collector/tdarr_golden_test.go
+++ b/internal/collector/tdarr_golden_test.go
@@ -23,6 +23,7 @@ var collectorMetricNames = []string{
 	"tdarr_library_files",
 	"tdarr_library_health_checks",
 	"tdarr_library_health_checks_completed_total",
+	"tdarr_library_info",
 	"tdarr_library_size_diff_bytes",
 	"tdarr_library_transcodes",
 	"tdarr_library_transcodes_completed_total",

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -602,9 +602,9 @@ func TestDescribe_EmitsAllDescs(t *testing.T) {
 		fqNames[descFqName(t, d)]++
 	}
 
-	// 27 collector descs + 26 node descs. Adding/removing a metric must update this number,
+	// 28 collector descs + 26 node descs. Adding/removing a metric must update this number,
 	// which is exactly the point: the count is the tripwire for a dropped Describe entry.
-	const wantCollectorDescs = 27
+	const wantCollectorDescs = 28
 	const wantNodeDescs = 26
 	wantTotal := wantCollectorDescs + wantNodeDescs
 	if len(descs) != wantTotal {

--- a/internal/collector/testdata/expected_output.txt
+++ b/internal/collector/testdata/expected_output.txt
@@ -12,76 +12,80 @@ tdarr_health_check_score_ratio{tdarr_instance="tdarr.localdomain"} 0.9333
 tdarr_health_checks_completed_total{tdarr_instance="tdarr.localdomain"} 1400
 # HELP tdarr_library_audio_codecs Tdarr audio codecs for library by type
 # TYPE tdarr_library_audio_codecs gauge
-tdarr_library_audio_codecs{codec="aac",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 310
-tdarr_library_audio_codecs{codec="flac",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 180
-tdarr_library_audio_codecs{codec="opus",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 10
+tdarr_library_audio_codecs{codec="aac",library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 310
+tdarr_library_audio_codecs{codec="flac",library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 180
+tdarr_library_audio_codecs{codec="opus",library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 10
 # HELP tdarr_library_audio_containers Tdarr audio containers for library by type
 # TYPE tdarr_library_audio_containers gauge
-tdarr_library_audio_containers{container_type="m4a",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 10
-tdarr_library_audio_containers{container_type="mkv",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 490
+tdarr_library_audio_containers{container_type="m4a",library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 10
+tdarr_library_audio_containers{container_type="mkv",library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 490
 # HELP tdarr_library_files Tdarr total files in library
 # TYPE tdarr_library_files gauge
-tdarr_library_files{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 500
-tdarr_library_files{library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 1000
+tdarr_library_files{library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 500
+tdarr_library_files{library_id="lib-video-01",tdarr_instance="tdarr.localdomain"} 1000
 # HELP tdarr_library_health_checks Tdarr health checks for library by status
 # TYPE tdarr_library_health_checks gauge
-tdarr_library_health_checks{library_id="lib-audio-01",library_name="Music",status="cancelled",tdarr_instance="tdarr.localdomain"} 5
-tdarr_library_health_checks{library_id="lib-audio-01",library_name="Music",status="error",tdarr_instance="tdarr.localdomain"} 10
-tdarr_library_health_checks{library_id="lib-audio-01",library_name="Music",status="queued",tdarr_instance="tdarr.localdomain"} 15
-tdarr_library_health_checks{library_id="lib-audio-01",library_name="Music",status="success",tdarr_instance="tdarr.localdomain"} 420
-tdarr_library_health_checks{library_id="lib-video-01",library_name="Shows",status="cancelled",tdarr_instance="tdarr.localdomain"} 2
-tdarr_library_health_checks{library_id="lib-video-01",library_name="Shows",status="error",tdarr_instance="tdarr.localdomain"} 18
-tdarr_library_health_checks{library_id="lib-video-01",library_name="Shows",status="queued",tdarr_instance="tdarr.localdomain"} 5
-tdarr_library_health_checks{library_id="lib-video-01",library_name="Shows",status="success",tdarr_instance="tdarr.localdomain"} 880
+tdarr_library_health_checks{library_id="lib-audio-01",status="cancelled",tdarr_instance="tdarr.localdomain"} 5
+tdarr_library_health_checks{library_id="lib-audio-01",status="error",tdarr_instance="tdarr.localdomain"} 10
+tdarr_library_health_checks{library_id="lib-audio-01",status="queued",tdarr_instance="tdarr.localdomain"} 15
+tdarr_library_health_checks{library_id="lib-audio-01",status="success",tdarr_instance="tdarr.localdomain"} 420
+tdarr_library_health_checks{library_id="lib-video-01",status="cancelled",tdarr_instance="tdarr.localdomain"} 2
+tdarr_library_health_checks{library_id="lib-video-01",status="error",tdarr_instance="tdarr.localdomain"} 18
+tdarr_library_health_checks{library_id="lib-video-01",status="queued",tdarr_instance="tdarr.localdomain"} 5
+tdarr_library_health_checks{library_id="lib-video-01",status="success",tdarr_instance="tdarr.localdomain"} 880
 # HELP tdarr_library_health_checks_completed_total Tdarr completed health checks for a library, counted over its lifetime; increments each time a health check completes on a file, failed jobs excluded
 # TYPE tdarr_library_health_checks_completed_total counter
-tdarr_library_health_checks_completed_total{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 450
-tdarr_library_health_checks_completed_total{library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 950
+tdarr_library_health_checks_completed_total{library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 450
+tdarr_library_health_checks_completed_total{library_id="lib-video-01",tdarr_instance="tdarr.localdomain"} 950
+# HELP tdarr_library_info Tdarr library metadata (value always 1); maps the stable library_id to its current library_name. Join other tdarr_library_* metrics on library_id to recover the name.
+# TYPE tdarr_library_info gauge
+tdarr_library_info{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 1
+tdarr_library_info{library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 1
 # HELP tdarr_library_size_diff_bytes Tdarr net file-size change in bytes for library (positive = space saved, negative = grew); lifetime, includes files since deleted
 # TYPE tdarr_library_size_diff_bytes gauge
-tdarr_library_size_diff_bytes{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 1.6642998272e+10
-tdarr_library_size_diff_bytes{library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 3.2480690176e+10
+tdarr_library_size_diff_bytes{library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 1.6642998272e+10
+tdarr_library_size_diff_bytes{library_id="lib-video-01",tdarr_instance="tdarr.localdomain"} 3.2480690176e+10
 # HELP tdarr_library_transcodes Tdarr transcodes for library by status
 # TYPE tdarr_library_transcodes gauge
-tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="cancelled",tdarr_instance="tdarr.localdomain"} 0
-tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="error",tdarr_instance="tdarr.localdomain"} 3
-tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="hold",tdarr_instance="tdarr.localdomain"} 0
-tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="ignored",tdarr_instance="tdarr.localdomain"} 0
-tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="not required",tdarr_instance="tdarr.localdomain"} 200
-tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="pending",tdarr_instance="tdarr.localdomain"} 7
-tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="queued",tdarr_instance="tdarr.localdomain"} 2
-tdarr_library_transcodes{library_id="lib-audio-01",library_name="Music",status="success",tdarr_instance="tdarr.localdomain"} 100
-tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="cancelled",tdarr_instance="tdarr.localdomain"} 1
-tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="error",tdarr_instance="tdarr.localdomain"} 12
-tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="hold",tdarr_instance="tdarr.localdomain"} 3
-tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="ignored",tdarr_instance="tdarr.localdomain"} 2
-tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="not required",tdarr_instance="tdarr.localdomain"} 400
-tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="queued",tdarr_instance="tdarr.localdomain"} 8
-tdarr_library_transcodes{library_id="lib-video-01",library_name="Shows",status="success",tdarr_instance="tdarr.localdomain"} 250
+tdarr_library_transcodes{library_id="lib-audio-01",status="cancelled",tdarr_instance="tdarr.localdomain"} 0
+tdarr_library_transcodes{library_id="lib-audio-01",status="error",tdarr_instance="tdarr.localdomain"} 3
+tdarr_library_transcodes{library_id="lib-audio-01",status="hold",tdarr_instance="tdarr.localdomain"} 0
+tdarr_library_transcodes{library_id="lib-audio-01",status="ignored",tdarr_instance="tdarr.localdomain"} 0
+tdarr_library_transcodes{library_id="lib-audio-01",status="not required",tdarr_instance="tdarr.localdomain"} 200
+tdarr_library_transcodes{library_id="lib-audio-01",status="pending",tdarr_instance="tdarr.localdomain"} 7
+tdarr_library_transcodes{library_id="lib-audio-01",status="queued",tdarr_instance="tdarr.localdomain"} 2
+tdarr_library_transcodes{library_id="lib-audio-01",status="success",tdarr_instance="tdarr.localdomain"} 100
+tdarr_library_transcodes{library_id="lib-video-01",status="cancelled",tdarr_instance="tdarr.localdomain"} 1
+tdarr_library_transcodes{library_id="lib-video-01",status="error",tdarr_instance="tdarr.localdomain"} 12
+tdarr_library_transcodes{library_id="lib-video-01",status="hold",tdarr_instance="tdarr.localdomain"} 3
+tdarr_library_transcodes{library_id="lib-video-01",status="ignored",tdarr_instance="tdarr.localdomain"} 2
+tdarr_library_transcodes{library_id="lib-video-01",status="not required",tdarr_instance="tdarr.localdomain"} 400
+tdarr_library_transcodes{library_id="lib-video-01",status="queued",tdarr_instance="tdarr.localdomain"} 8
+tdarr_library_transcodes{library_id="lib-video-01",status="success",tdarr_instance="tdarr.localdomain"} 250
 # HELP tdarr_library_transcodes_completed_total Tdarr completed transcodes for a library, counted over its lifetime; increments each time a transcode alters a file (the same file can transcode again after a flow/process change), failed jobs excluded
 # TYPE tdarr_library_transcodes_completed_total counter
-tdarr_library_transcodes_completed_total{library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 150
-tdarr_library_transcodes_completed_total{library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 700
+tdarr_library_transcodes_completed_total{library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 150
+tdarr_library_transcodes_completed_total{library_id="lib-video-01",tdarr_instance="tdarr.localdomain"} 700
 # HELP tdarr_library_video_codecs Tdarr video codecs for library by type
 # TYPE tdarr_library_video_codecs gauge
-tdarr_library_video_codecs{codec="av1",library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 10
-tdarr_library_video_codecs{codec="h264",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 20
-tdarr_library_video_codecs{codec="h264",library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 370
-tdarr_library_video_codecs{codec="hevc",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 480
-tdarr_library_video_codecs{codec="hevc",library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 620
+tdarr_library_video_codecs{codec="av1",library_id="lib-video-01",tdarr_instance="tdarr.localdomain"} 10
+tdarr_library_video_codecs{codec="h264",library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 20
+tdarr_library_video_codecs{codec="h264",library_id="lib-video-01",tdarr_instance="tdarr.localdomain"} 370
+tdarr_library_video_codecs{codec="hevc",library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 480
+tdarr_library_video_codecs{codec="hevc",library_id="lib-video-01",tdarr_instance="tdarr.localdomain"} 620
 # HELP tdarr_library_video_containers Tdarr video containers for library by type
 # TYPE tdarr_library_video_containers gauge
-tdarr_library_video_containers{container_type="mkv",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 490
-tdarr_library_video_containers{container_type="mkv",library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 920
-tdarr_library_video_containers{container_type="mp4",library_id="lib-audio-01",library_name="Music",tdarr_instance="tdarr.localdomain"} 10
-tdarr_library_video_containers{container_type="mp4",library_id="lib-video-01",library_name="Shows",tdarr_instance="tdarr.localdomain"} 80
+tdarr_library_video_containers{container_type="mkv",library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 490
+tdarr_library_video_containers{container_type="mkv",library_id="lib-video-01",tdarr_instance="tdarr.localdomain"} 920
+tdarr_library_video_containers{container_type="mp4",library_id="lib-audio-01",tdarr_instance="tdarr.localdomain"} 10
+tdarr_library_video_containers{container_type="mp4",library_id="lib-video-01",tdarr_instance="tdarr.localdomain"} 80
 # HELP tdarr_library_video_resolutions Tdarr video resolutions for library by type
 # TYPE tdarr_library_video_resolutions gauge
-tdarr_library_video_resolutions{library_id="lib-audio-01",library_name="Music",resolution="1080p",tdarr_instance="tdarr.localdomain"} 450
-tdarr_library_video_resolutions{library_id="lib-audio-01",library_name="Music",resolution="720p",tdarr_instance="tdarr.localdomain"} 50
-tdarr_library_video_resolutions{library_id="lib-video-01",library_name="Shows",resolution="1080p",tdarr_instance="tdarr.localdomain"} 700
-tdarr_library_video_resolutions{library_id="lib-video-01",library_name="Shows",resolution="4kuhd",tdarr_instance="tdarr.localdomain"} 200
-tdarr_library_video_resolutions{library_id="lib-video-01",library_name="Shows",resolution="720p",tdarr_instance="tdarr.localdomain"} 100
+tdarr_library_video_resolutions{library_id="lib-audio-01",resolution="1080p",tdarr_instance="tdarr.localdomain"} 450
+tdarr_library_video_resolutions{library_id="lib-audio-01",resolution="720p",tdarr_instance="tdarr.localdomain"} 50
+tdarr_library_video_resolutions{library_id="lib-video-01",resolution="1080p",tdarr_instance="tdarr.localdomain"} 700
+tdarr_library_video_resolutions{library_id="lib-video-01",resolution="4kuhd",tdarr_instance="tdarr.localdomain"} 200
+tdarr_library_video_resolutions{library_id="lib-video-01",resolution="720p",tdarr_instance="tdarr.localdomain"} 100
 # HELP tdarr_node_heap_total_bytes Tdarr node heap total in bytes
 # TYPE tdarr_node_heap_total_bytes gauge
 tdarr_node_heap_total_bytes{node_id="node-busy-1",node_name="BusyNode",tdarr_instance="tdarr.localdomain"} 1.34217728e+08


### PR DESCRIPTION
Part of the Prometheus best-practices breaking batch (3.0.0). Final code phase (P3.4) before migration notes + release. Stacked behind #88/#89/#90/#92/#93/#94 (all merged to `main`).

## Changes
- Removed the `library_name` label from every `tdarr_library_*` metric. Library metrics now key on the stable `library_id`.
- Added `tdarr_library_info{library_id, library_name}` (value always 1), emitted once per library — the id→name mapping to join against.
- Collector: stripped `library_name` from 11 desc label-sets + emit sites; `emitPieSlices` lost its `libName` param.
- Tests/golden: added the `tdarr_library_info` block, stripped `library_name` from value metrics, `wantCollectorDescs` 27 → 28.
- Dashboard (`examples/dashboard.json`):
  - `$library` template variable repointed to `label_values(tdarr_library_info, library_name)`.
  - 4 overview panels join `* on (library_id, tdarr_instance) group_left(library_name) tdarr_library_info` to display the name.
  - 13 per-library panels move the `$library` selector onto `and on (library_id, tdarr_instance) tdarr_library_info{library_name=~"$library"}`.
- Alerts (`examples/alerts.yaml`): `TdarrTranscodeFailed` expr joins `* on (library_id) group_left(library_name) tdarr_library_info` so the `{{ $labels.library_name }}` annotation still resolves.

## Motivation
A library rename churned every `library_name`-labeled series (id stable, name changes → new series, broken continuity). Moving the name to an info metric keyed on `library_id` makes the value series rename-stable and follows the Prometheus info-metric pattern (mirrors the worker `_info` split in #89).

## Decisions
- Joins use `on (library_id, tdarr_instance)` (both labels) for multi-instance safety — internally consistent across all P3.4 joins. The alert rule uses `on (library_id)` only (no `$tdarr_instance` template there).
- `node_name` on `tdarr_node_info` has the same churn pattern but is out of scope (node renames rare).

## Test plan
- `go test ./... -race`, `go vet`, `gofmt` — all green. Golden fixture updated by hand.
- Live-verified on Tdarr v2.77.01: 7 `tdarr_library_info` series, no `library_name` leak on other `tdarr_library_*`, `library_id` sets match between info and value metrics (every series joins to a name), `size_diff_bytes` sign/scale intact.
- Dashboard/alerts: JSON + YAML parse; join counts verified (4 group_left, 13 `and on`, 13 `library_name=~` all on the info side, 0 stale template refs).
- **Pending (manual):** Grafana visual import — PromQL render correctness of the joins can't be proven from a static `/metrics` dump.

## In-depth
Two join idioms, intentional: `* … group_left(library_name)` where the name must appear in output (multiplies the value by the info metric's `1`, preserving it incl. negative `size_diff`); `and on(...)` where `$library` is only a filter (set intersection, no value math, mirrors #89). Release-please PR stays gated until the whole batch + consolidated migration notes land on `main`.