### PR TITLE
docs: link Tdarr API docs and OpenAPI spec

### DIFF
--- a/docs/metrics-internals.md
+++ b/docs/metrics-internals.md
@@ -16,6 +16,23 @@ re-verify against the raw API before relying on a claim here.
 Every metric is derived from one of these Tdarr endpoints. When a Tdarr upgrade
 changes behavior, re-verify against the raw response from the relevant call.
 
+Tdarr publishes API docs at <https://docs.tdarr.io/docs/api/> (also bundled with
+your installation). Each instance also serves a **Swagger 2.0** spec — Swagger UI
+at `<your-tdarr-instance>/#/tools/api-docs`, raw JSON at
+`<your-tdarr-instance>/api/v2/public/api-docs/json`.
+
+Response-schema coverage is **uneven** (verified against a running instance), and
+it is thinnest exactly where this doc needs it. `/api/v2/status` is fully typed
+(`status`, `os`, `version`, `uptime`, … — the fields behind `tdarr_server_*`),
+but the stats endpoints are skeletons: `cruddb` responds with a bare
+`additionalProperties: true` object (no field names), `get-pies` types only the
+outer `pieStats` wrapper and leaves its contents free-form, and `get-nodes` is an
+untyped object. So for the `StatisticsJSONDB.*`, `pieStats.*`, and node/worker
+fields mapped above, the ground truth is a **captured live response** plus the Go
+models in `internal/collector/tdarr_models.go`. Request bodies, by contrast, are
+typed with field-level detail — use the spec for request shapes and endpoint
+discovery.
+
 | Endpoint | Source | Feeds |
 | --- | --- | --- |
 | `POST /api/v2/cruddb` (collection `StatisticsJSONDB`) | global stats document (`TdarrMetric`) | global `tdarr_*` |


### PR DESCRIPTION
Follow-up to #97. Points maintainers at the Tdarr API documentation, with a verified, honest note on what it does and does not cover.

## Changes
- In the "Tdarr API sources" section, link:
  - the official Tdarr API docs (<https://docs.tdarr.io/docs/api/>, also bundled with an install), and
  - the per-instance **Swagger 2.0** spec — Swagger UI at `<your-tdarr-instance>/#/tools/api-docs`, raw JSON at `<your-tdarr-instance>/api/v2/public/api-docs/json`.
- Document the spec's uneven response coverage (checked per endpoint against a running instance): `/api/v2/status` is fully typed, but the stats endpoints the exporter relies on are skeletons — `cruddb` returns a bare `additionalProperties: true` object, `get-pies` types only the outer `pieStats` wrapper, and `get-nodes` is untyped. So the `StatisticsJSONDB.*`, `pieStats.*`, and node/worker response fields are confirmed from a captured live response plus the Go models in `internal/collector/tdarr_models.go`. Request bodies are typed — use the spec for request shapes and endpoint discovery.

## Motivation
The doc maps Tdarr source fields to metrics but did not say where to confirm them. Tdarr is closed-source; pointing at the API docs — and being explicit about which response fields the spec does and does not cover — tells maintainers exactly where each kind of field can be verified.

## Test plan
Documentation only — no code changes. Spec coverage was checked against the live JSON per endpoint. Uses a generic instance placeholder; no real instance URL.