### PR TITLE
docs: note README tracks main, point to release tags for versioned docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # tdarr-exporter
+
+> [!NOTE]
+> This documentation tracks the `main` branch and may describe unreleased changes.
+> For docs matching your installed version, use the branch/tag dropdown to switch to your release tag. See [Releases](https://github.com/homeylab/tdarr-exporter/releases) for the list of published versions.
+
 - [tdarr-exporter](#tdarr-exporter)
   - [Background](#background)
   - [Usage](#usage)


### PR DESCRIPTION
## Changes
Add a GitHub `> [!NOTE]` callout at the top of README.md stating the docs track `main` and may describe unreleased changes. Directs users to switch to their release tag via the branch/tag dropdown and links the Releases page for the list of official versions.

No version literal is hardcoded, so the banner needs no per-release maintenance.

## Motivation
README on `main` evolves continuously and drifts from the latest published release. Users landing on the default branch can mistake unreleased docs for their installed version. The banner sets expectations and points to the version-accurate source (immutable release tags).