### PR TITLE
fix: do not serve partial pie results from cache; scope partial-failure to one scrape

### DIFF
--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -98,7 +98,6 @@ type TdarrCollector struct {
 	// collector at construction. Injected so tests can silence or capture logs.
 	logger                zerolog.Logger
 	statsCache            *TdarrLibStatsCache
-	partialFailure        atomic.Bool // set by getLibStats workers on per-library fetch error
 	unknownStatusMu       sync.Mutex
 	unknownStatusCounts   map[unknownStatusKey]float64 // monotonic counter for enum drift detection
 	totalFilesMetric      typedDesc
@@ -439,7 +438,7 @@ func (c *TdarrCollector) bumpUnknownStatus(kind, status string) {
 }
 
 // support concurrency
-func (c *TdarrCollector) getLibStats(ctx context.Context, wg *sync.WaitGroup, inChan <-chan TdarrPieDataRequest, outChan chan<- *TdarrPieStats) {
+func (c *TdarrCollector) getLibStats(ctx context.Context, wg *sync.WaitGroup, inChan <-chan TdarrPieDataRequest, outChan chan<- *TdarrPieStats, partial *atomic.Bool) {
 	defer wg.Done()
 	for piePayload := range inChan {
 		pieMetric := &TdarrPieStats{}
@@ -450,7 +449,7 @@ func (c *TdarrCollector) getLibStats(ctx context.Context, wg *sync.WaitGroup, in
 			// Signal partial failure so Collect() sets tdarr_up=0 and collect()
 			// skips the cache write (partial results are never cached; the next
 			// scrape re-fetches). This scrape emits only the libraries that succeeded.
-			c.partialFailure.Store(true)
+			partial.Store(true)
 			continue
 		}
 		pieMetric.libraryName = piePayload.Data.libraryName
@@ -477,10 +476,12 @@ func (c *TdarrCollector) getLibStats(ctx context.Context, wg *sync.WaitGroup, in
 
 // fetchPies fans the per-library pie requests across HttpMaxConcurrency workers and
 // fans the results back in. Per-library fetch failures are handled inside getLibStats
-// (it sets partialFailure and skips that library), so this returns only the gathered
-// pie stats — the same set collect() previously assembled inline before caching.
-func (c *TdarrCollector) fetchPies(ctx context.Context, allLibs []TdarrLibraryInfo) []*TdarrPieStats {
+// (it stores true into the per-scrape partial flag and skips that library), so this returns
+// the gathered pie stats alongside whether any library failed — the same set collect()
+// previously assembled inline before caching.
+func (c *TdarrCollector) fetchPies(ctx context.Context, allLibs []TdarrLibraryInfo) ([]*TdarrPieStats, bool) {
 	var pieData []*TdarrPieStats
+	var partial atomic.Bool
 
 	dataWg := &sync.WaitGroup{}
 	inChan := make(chan TdarrPieDataRequest, len(allLibs))
@@ -488,7 +489,7 @@ func (c *TdarrCollector) fetchPies(ctx context.Context, allLibs []TdarrLibraryIn
 	// start workers
 	for i := 0; i < c.maxConcurrency; i++ {
 		dataWg.Add(1)
-		go c.getLibStats(ctx, dataWg, inChan, outChan)
+		go c.getLibStats(ctx, dataWg, inChan, outChan, &partial)
 	}
 
 	// send data to workers
@@ -525,7 +526,7 @@ func (c *TdarrCollector) fetchPies(ctx context.Context, allLibs []TdarrLibraryIn
 
 	// wait for results to be collected
 	resultWg.Wait()
-	return pieData
+	return pieData, partial.Load()
 }
 
 func (c *TdarrCollector) Collect(ch chan<- prometheus.Metric) {
@@ -536,21 +537,17 @@ func (c *TdarrCollector) Collect(ch chan<- prometheus.Metric) {
 	defer cancel()
 	// Recover from any panic in the scrape path so a single bad scrape degrades to
 	// tdarr_up=0 instead of crashing the process (client_golang's collectWorker has
-	// no recover of its own). Reset partialFailure here too: the normal Swap below is
-	// skipped on panic, so without this the flag would leak into the next scrape.
+	// no recover of its own).
 	defer func() {
 		if r := recover(); r != nil {
-			c.partialFailure.Store(false)
 			c.logger.Error().Interface("panic", r).Msg("Panic during collection; emitting tdarr_up=0")
 			ch <- c.upMetric.mustNewConstMetric(0.0)
 		}
 	}()
-	err := c.collect(ctx, ch)
+	partial, err := c.collect(ctx, ch)
 	if err != nil {
 		c.logger.Error().Err(err).Msg("Collection cycle failed")
 	}
-	// Always reset partialFailure flag — must NOT short-circuit via OR or the flag leaks across scrapes.
-	partial := c.partialFailure.Swap(false)
 	v := 1.0
 	if err != nil || partial {
 		v = 0.0
@@ -584,13 +581,14 @@ func shouldRefetch(cached tdarrCacheTotals, libStatsNil bool, metric *TdarrMetri
 	return libStatsNil || cached != totalsFromMetric(metric)
 }
 
-func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) (bool, error) {
+	partialFail := false
 	// Fetch server status (/api/v2/status) first. Cheapest call and a liveness/version
 	// probe, so fail fast here before the heavier stats/pie/node work. Required: a failure
 	// returns an error like every other upstream fetch, flipping tdarr_up=0 via Collect().
 	serverStatus := &TdarrServerStatus{}
 	if err := c.api.DoRequest(ctx, c.statusPath, serverStatus); err != nil {
-		return fmt.Errorf("get server status: %w: %w", ErrUpstream, err)
+		return false, fmt.Errorf("get server status: %w: %w", ErrUpstream, err)
 	}
 	if !isHealthyServerStatus(serverStatus.Status) {
 		c.logger.Warn().Str("status", serverStatus.Status).
@@ -603,7 +601,7 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 	metric := &TdarrMetric{}
 	err := c.httpReqHelper(ctx, c.statsPath, metricReqBody, &metric)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	c.logger.Debug().Int("totalFiles", metric.TotalFileCount).
@@ -621,11 +619,11 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 
 	score, floatConvertErr = strconv.ParseFloat(metric.TdarrScore, 64)
 	if floatConvertErr != nil {
-		return fmt.Errorf("parse tdarr score %q: %w: %w", metric.TdarrScore, ErrParse, floatConvertErr)
+		return false, fmt.Errorf("parse tdarr score %q: %w: %w", metric.TdarrScore, ErrParse, floatConvertErr)
 	}
 	healthScore, floatConvertErr = strconv.ParseFloat(metric.HealthCheckScore, 64)
 	if floatConvertErr != nil {
-		return fmt.Errorf("parse health score %q: %w: %w", metric.HealthCheckScore, ErrParse, floatConvertErr)
+		return false, fmt.Errorf("parse health score %q: %w: %w", metric.HealthCheckScore, ErrParse, floatConvertErr)
 	}
 
 	// supports only api versions: v2.24.01+
@@ -653,17 +651,17 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 		allLibs := []TdarrLibraryInfo{}
 		err := c.httpReqHelper(ctx, c.statsPath, getLibsPayload, &allLibs)
 		if err != nil {
-			return fmt.Errorf("get library details: %w", err)
+			return false, fmt.Errorf("get library details: %w", err)
 		}
 
-		pieData = c.fetchPies(ctx, allLibs)
+		pieData, partialFail = c.fetchPies(ctx, allLibs)
 		// Cache invariant: only a fully successful pie sweep may be cached.
 		// Caching a partial result would let the next scrape serve incomplete
-		// data from cache with tdarr_up=1 (the partialFailure flag resets each
-		// scrape), silently dropping the failed library's series until the
+		// data from cache with tdarr_up=1 (partial failure is scoped to this
+		// scrape only), silently dropping the failed library's series until the
 		// totals next change. Skipping both writes keeps the cache stale/nil,
 		// so shouldRefetch() triggers a full refetch on the next scrape.
-		if c.partialFailure.Load() {
+		if partialFail {
 			c.logger.Warn().Msg("Partial library pie fetch failure - cache not updated, will re-fetch next scrape")
 		} else {
 			c.logger.Debug().Msg("All library stats gathered - setting cache")
@@ -689,11 +687,11 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 	// get all node metrics
 	nodeData, err := c.nodeCollector.GetNodeData(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 	// get worker data for each node
 	c.emitNodeMetrics(ch, nodeData)
-	return nil
+	return partialFail, nil
 }
 
 // emitServerMetrics emits the /api/v2/status-derived series: uptime gauge plus the

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -151,27 +151,24 @@ func NewTdarrLibStatsCache() *TdarrLibStatsCache {
 	}
 }
 
-func (c *TdarrLibStatsCache) GetTotals() tdarrCacheTotals {
+// Read returns the cached totals and library stats as a consistent pair under a
+// single lock. libraryStats is nil until the first fully-successful sweep is
+// cached (callers treat nil as "cache empty" and refetch). Returning both
+// together prevents a torn read where totals and stats come from different
+// scrapes.
+func (c *TdarrLibStatsCache) Read() (tdarrCacheTotals, []*TdarrPieStats) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.totals
+	return c.totals, c.libraryStats
 }
 
-func (c *TdarrLibStatsCache) SetTotals(totals tdarrCacheTotals) {
+// Write stores the totals and library stats together under a single lock, so
+// the two fields — which must correspond — are never observed as a torn pair by
+// a concurrent Read. Only a fully-successful pie sweep is written (see collect()).
+func (c *TdarrLibStatsCache) Write(totals tdarrCacheTotals, stats []*TdarrPieStats) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.totals = totals
-}
-
-func (c *TdarrLibStatsCache) GetLibStats() []*TdarrPieStats {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.libraryStats
-}
-
-func (c *TdarrLibStatsCache) SetLibStats(stats []*TdarrPieStats) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.libraryStats = stats
 }
 
@@ -631,21 +628,21 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 	// already have total file count from general stats (`metric.TotalFileCount`)
 	// check cache for all libraries data
 	// this won't block other reads when checking
-	cacheTotals := c.statsCache.GetTotals()
+	cacheTotals, cachedStats := c.statsCache.Read()
 	// Refetch if the cache is empty (first run) or any of the 10 totals changed.
 	// Beyond the three top-level counts, the seven per-bucket queue fields
 	// (holdQueue/transcodeQueue/… on TdarrMetric) catch state transitions the totals miss
 	// (e.g. files queued but not yet transcoded). Their Tdarr JSON source (table0Count–table6Count)
 	// and bucket meanings are documented on TdarrMetric in tdarr_models.go. Older Tdarr versions
 	// omit those fields; they decode to 0, so 0==0 never triggers a spurious refetch.
-	shouldCollect := shouldRefetch(cacheTotals, c.statsCache.GetLibStats() == nil, metric)
+	shouldCollect := shouldRefetch(cacheTotals, cachedStats == nil, metric)
 	if shouldCollect {
 		c.logger.Debug().Msg("Stats totals mismatch - re-fetching library pie stats")
 	}
 	// if counts are the same use cache
 	if !shouldCollect {
 		c.logger.Debug().Msg("Using cached library stats - api totals matches cached values")
-		pieData = c.statsCache.GetLibStats()
+		pieData = cachedStats
 	} else { // fetch new data and update cache
 		getLibsPayload := getGeneralReqPayload("library")
 		allLibs := []TdarrLibraryInfo{}
@@ -665,9 +662,8 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 			c.logger.Warn().Msg("Partial library pie fetch failure - cache not updated, will re-fetch next scrape")
 		} else {
 			c.logger.Debug().Msg("All library stats gathered - setting cache")
-			c.statsCache.SetLibStats(pieData)
-			// set totals here after all data is collected
-			c.statsCache.SetTotals(totalsFromMetric(metric))
+			// Store totals and stats together so a concurrent scrape never reads a torn pair.
+			c.statsCache.Write(totalsFromMetric(metric), pieData)
 		}
 	}
 

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -447,9 +447,9 @@ func (c *TdarrCollector) getLibStats(ctx context.Context, wg *sync.WaitGroup, in
 		err := c.httpReqHelper(ctx, c.pieStatsPath, piePayload, pieMetric)
 		if err != nil {
 			c.logger.Error().Interface("payload", piePayload).Err(err).Msg("Failed to get Lib stats pie data")
-			// Signal partial failure so Collect() can set tdarr_up=0.
-			// Previously-cached normalized data for this library is preserved (acceptable:
-			// last-known zero-padded series keep emitting while tdarr_up signals the issue).
+			// Signal partial failure so Collect() sets tdarr_up=0 and collect()
+			// skips the cache write (partial results are never cached; the next
+			// scrape re-fetches). This scrape emits only the libraries that succeeded.
 			c.partialFailure.Store(true)
 			continue
 		}
@@ -657,11 +657,20 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 		}
 
 		pieData = c.fetchPies(ctx, allLibs)
-		c.logger.Debug().Msg("All library stats gathered - setting cache")
-		c.statsCache.SetLibStats(pieData)
-
-		// set totals here after all data is collected
-		c.statsCache.SetTotals(totalsFromMetric(metric))
+		// Cache invariant: only a fully successful pie sweep may be cached.
+		// Caching a partial result would let the next scrape serve incomplete
+		// data from cache with tdarr_up=1 (the partialFailure flag resets each
+		// scrape), silently dropping the failed library's series until the
+		// totals next change. Skipping both writes keeps the cache stale/nil,
+		// so shouldRefetch() triggers a full refetch on the next scrape.
+		if c.partialFailure.Load() {
+			c.logger.Warn().Msg("Partial library pie fetch failure - cache not updated, will re-fetch next scrape")
+		} else {
+			c.logger.Debug().Msg("All library stats gathered - setting cache")
+			c.statsCache.SetLibStats(pieData)
+			// set totals here after all data is collected
+			c.statsCache.SetTotals(totalsFromMetric(metric))
+		}
 	}
 
 	// add metrics to collector

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -574,6 +574,18 @@ func totalsFromMetric(metric *TdarrMetric) tdarrCacheTotals {
 // true when the cache is empty (libStatsNil) or any of the 10 cached totals differs
 // from the current metric. tdarrCacheTotals is all-int and thus comparable, so the
 // struct != comparison is equivalent to the prior field-by-field OR chain.
+//
+// Invalidation is deliberately GLOBAL (all-or-nothing across every library), not
+// per-library, and this is forced by the Tdarr API's shape — do not "optimize" it
+// to a per-library cache. The only cheap signal Tdarr exposes is the general-stats
+// document (StatisticsJSONDB, ~ms), and it is aggregate-only: it carries no
+// per-library breakdown. Per-library data lives solely in the get-pies call, which
+// is the expensive per-library fan-out the cache exists to skip (seconds across all
+// libraries). So there is no cheap "did library X change?" probe: checking one
+// library would cost the same fetch the cache is trying to avoid. A per-library
+// cache is therefore not viable, and with it the sync.Map that concurrent
+// per-library cache writes would need is moot — the whole-slice cache guarded by a
+// single RWMutex, written by one drain goroutine, is the correct shape here.
 func shouldRefetch(cached tdarrCacheTotals, libStatsNil bool, metric *TdarrMetric) bool {
 	return libStatsNil || cached != totalsFromMetric(metric)
 }

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -338,11 +338,10 @@ func TestCollect_ConsecutiveScrapes_PartialFlagResets(t *testing.T) {
 		t.Errorf("scrape 1 tdarr_up: want 0.0, got %v", up1)
 	}
 
-	// Flip to success mode for scrape 2.
+	// Flip to success mode for scrape 2. No manual cache reset needed: the
+	// partial failure in scrape 1 already left the cache unwritten (see the
+	// cache-write guard in collect()), so the collector re-fetches on its own.
 	delete(api.errors, pieKey)
-	// Reset the stats cache so the collector re-fetches library pie stats
-	// (cache hit avoids pie calls entirely, which would skip the test's purpose).
-	c.statsCache = NewTdarrLibStatsCache()
 
 	// Scrape 2: all endpoints succeed → tdarr_up must be 1, not 0.
 	reg2 := prometheus.NewRegistry()
@@ -634,4 +633,75 @@ func TestDescribe_EmitsAllDescs(t *testing.T) {
 			t.Errorf("Describe missing expected desc %q", name)
 		}
 	}
+}
+
+// TestCollect_PartialPieFailure_DoesNotPoisonCache verifies that a partial
+// per-library pie fetch failure does not write incomplete data into the stats
+// cache. Regression test: previously the partial result was cached together
+// with the current totals, so the NEXT scrape hit the cache, served incomplete
+// data (lib2's series missing), and reported tdarr_up=1 — masking the gap
+// until the totals next changed.
+//
+// Two libraries are required: lib1 succeeds, lib2 fails. With a single library
+// the partial result is empty (nil), nothing meaningful is cached, and the bug
+// cannot be observed.
+func TestCollect_PartialPieFailure_DoesNotPoisonCache(t *testing.T) {
+	cfg := newTestConfig(t)
+	api := newSuccessFakeAPI(cfg)
+	twoLibs, _ := json.Marshal([]TdarrLibraryInfo{
+		{LibraryId: "lib1", Name: "Library One"},
+		{LibraryId: "lib2", Name: "Library Two"},
+	})
+	api.setResponse(fakeKey{path: cfg.TdarrStatsPath, disc: "LibrarySettingsJSONDB"}, twoLibs)
+	// Register lib2's success response up front; the error registered next takes
+	// precedence (see fakeTdarrAPI.setError), and deleting the error later
+	// reveals the response for scrape 2.
+	pieKey2 := fakeKey{path: cfg.TdarrPieStatsPath, disc: "lib2"}
+	api.setResponse(pieKey2, validPieBody())
+	api.setError(pieKey2, statErr{"pie fetch failed"})
+	c := newTdarrCollectorWithAPI(cfg, api)
+
+	// Scrape 1: lib1 ok, lib2 fails → up=0 and, critically, cache stays empty.
+	reg1 := prometheus.NewRegistry()
+	reg1.MustRegister(c)
+	mfs1, err := reg1.Gather()
+	if err != nil {
+		t.Fatalf("scrape 1 gather: %v", err)
+	}
+	if up := upValueFromFamilies(mfs1); up != 0.0 {
+		t.Errorf("scrape 1 tdarr_up: want 0.0, got %v", up)
+	}
+	if c.statsCache.GetLibStats() != nil {
+		t.Fatal("cache was written despite partial pie failure; partial data must not be cached")
+	}
+
+	// Scrape 2: lib2 recovers. NO manual cache reset — the collector must
+	// refetch on its own because the cache was never written.
+	delete(api.errors, pieKey2)
+	reg2 := prometheus.NewRegistry()
+	reg2.MustRegister(c)
+	mfs2, err := reg2.Gather()
+	if err != nil {
+		t.Fatalf("scrape 2 gather: %v", err)
+	}
+	if up := upValueFromFamilies(mfs2); up != 1.0 {
+		t.Errorf("scrape 2 tdarr_up: want 1.0, got %v", up)
+	}
+	if got := libraryFilesSeriesCount(mfs2); got != 2 {
+		t.Errorf("scrape 2 tdarr_library_files series: want 2 (lib1+lib2), got %d", got)
+	}
+	if c.statsCache.GetLibStats() == nil {
+		t.Error("cache not written after fully successful scrape")
+	}
+}
+
+// libraryFilesSeriesCount returns the number of series in the
+// tdarr_library_files family (one per library emitted).
+func libraryFilesSeriesCount(mfs []*dto.MetricFamily) int {
+	for _, mf := range mfs {
+		if mf.GetName() == "tdarr_library_files" {
+			return len(mf.GetMetric())
+		}
+	}
+	return 0
 }

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/homeylab/tdarr-exporter/internal/config"
@@ -672,7 +674,7 @@ func TestCollect_PartialPieFailure_DoesNotPoisonCache(t *testing.T) {
 	if up := upValueFromFamilies(mfs1); up != 0.0 {
 		t.Errorf("scrape 1 tdarr_up: want 0.0, got %v", up)
 	}
-	if c.statsCache.GetLibStats() != nil {
+	if _, stats := c.statsCache.Read(); stats != nil {
 		t.Fatal("cache was written despite partial pie failure; partial data must not be cached")
 	}
 
@@ -691,7 +693,7 @@ func TestCollect_PartialPieFailure_DoesNotPoisonCache(t *testing.T) {
 	if got := libraryFilesSeriesCount(mfs2); got != 2 {
 		t.Errorf("scrape 2 tdarr_library_files series: want 2 (lib1+lib2), got %d", got)
 	}
-	if c.statsCache.GetLibStats() == nil {
+	if _, stats := c.statsCache.Read(); stats == nil {
 		t.Error("cache not written after fully successful scrape")
 	}
 }
@@ -705,4 +707,64 @@ func libraryFilesSeriesCount(mfs []*dto.MetricFamily) int {
 		}
 	}
 	return 0
+}
+
+// TestLibStatsCache_ReadWritePairing verifies Read always returns the exact
+// totals/stats pair the last Write stored, sequentially. This is the baseline
+// invariant check for the single-lock Read/Write API replacing the four
+// separately-locked getters/setters.
+func TestLibStatsCache_ReadWritePairing(t *testing.T) {
+	c := NewTdarrLibStatsCache()
+	// empty cache: stats nil (refetch signal), zero totals
+	if tot, stats := c.Read(); stats != nil || tot != (tdarrCacheTotals{}) {
+		t.Fatalf("empty cache: want zero totals + nil stats, got %+v / %v", tot, stats)
+	}
+	totals := tdarrCacheTotals{totalFileCount: 42}
+	stats := []*TdarrPieStats{{libraryId: "lib1"}}
+	c.Write(totals, stats)
+	gotT, gotS := c.Read()
+	if gotT != totals {
+		t.Errorf("totals: want %+v, got %+v", totals, gotT)
+	}
+	if len(gotS) != 1 || gotS[0].libraryId != "lib1" {
+		t.Errorf("stats: want [lib1], got %v", gotS)
+	}
+}
+
+// TestLibStatsCache_ReadWritePairing_Concurrent races N writers against N
+// readers under -race. Each writer stores a totals/stats pair whose values
+// are derived from the same index, so any Read that observed a torn pair
+// (totals from one Write, stats from another) would show a mismatched index.
+func TestLibStatsCache_ReadWritePairing_Concurrent(t *testing.T) {
+	c := NewTdarrLibStatsCache()
+	const n = 100
+
+	var wg sync.WaitGroup
+	wg.Add(2 * n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			c.Write(
+				tdarrCacheTotals{totalFileCount: i},
+				[]*TdarrPieStats{{libraryId: fmt.Sprintf("lib%d", i)}},
+			)
+		}()
+		go func() {
+			defer wg.Done()
+			tot, stats := c.Read()
+			if stats == nil {
+				return // cache not yet written; not a torn pair
+			}
+			id := strings.TrimPrefix(stats[0].libraryId, "lib")
+			want, err := strconv.Atoi(id)
+			if err != nil {
+				t.Errorf("unexpected libraryId format %q: %v", stats[0].libraryId, err)
+				return
+			}
+			if tot.totalFileCount != want {
+				t.Errorf("torn pair: totals.totalFileCount=%d does not match stats libraryId=%q", tot.totalFileCount, stats[0].libraryId)
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -291,8 +291,8 @@ func TestCollect_NodeFetchFails_UpEquals0(t *testing.T) {
 }
 
 // TestCollect_PartialPieFailure_UpEquals0 verifies tdarr_up == 0 when the get-pies call fails
-// (the worker records a partial failure via c.partialFailure.Store(true)), while general stats
-// emitted before the pie fetch are still present.
+// (the worker records the failure on the per-scrape partial flag returned by collect()),
+// while general stats emitted before the pie fetch are still present.
 func TestCollect_PartialPieFailure_UpEquals0(t *testing.T) {
 	cfg := newTestConfig(t)
 	api := newSuccessFakeAPI(cfg)
@@ -311,13 +311,14 @@ func TestCollect_PartialPieFailure_UpEquals0(t *testing.T) {
 	}
 }
 
-// TestCollect_ConsecutiveScrapes_PartialFlagResets is a critical regression test for the
-// partialFailure.Swap(false) fix in Collect(). It verifies that a stale partialFailure flag
-// from a failed scrape does not contaminate the following successful scrape.
+// TestCollect_ConsecutiveScrapes_PartialFlagResets is a critical regression test verifying
+// that the partial-failure signal is scoped to a single scrape. Since collect() returns a
+// local partial-failure bool per call (rather than storing it on a shared collector field),
+// a failed scrape cannot leak its partial flag into the next scrape's result.
 //
-// If the flag were reset via short-circuit OR (e.g. `err != nil || partial` before Swap), the
-// flag would leak across scrapes: scrape 2 would still report tdarr_up == 0 even when all
-// endpoints succeed.
+// If partial failure were instead tracked via a shared field across concurrent/consecutive
+// scrapes, a stale true from a failed scrape could contaminate a later successful one:
+// scrape 2 would still report tdarr_up == 0 even when all endpoints succeed.
 func TestCollect_ConsecutiveScrapes_PartialFlagResets(t *testing.T) {
 	cfg := newTestConfig(t)
 	api := newSuccessFakeAPI(cfg)
@@ -440,7 +441,7 @@ func TestCollect_ErrorCause(t *testing.T) {
 
 			// Drain emissions into a buffered channel so collect() never blocks.
 			ch := make(chan prometheus.Metric, 512)
-			err := c.collect(context.Background(), ch)
+			_, err := c.collect(context.Background(), ch)
 			close(ch)
 
 			if err == nil {
@@ -492,7 +493,7 @@ func TestCollect_ContextCancelled_Aborts(t *testing.T) {
 	c.baseCtx = ctx
 
 	ch := make(chan prometheus.Metric, 512)
-	err := c.collect(ctx, ch)
+	_, err := c.collect(ctx, ch)
 	close(ch)
 
 	if err == nil {


### PR DESCRIPTION
## Changes

Three related correctness fixes in the collector's per-library pie-stats handling. All three are concurrent-`Collect()` / cache correctness; single-scrape behavior and emitted output are unchanged (golden test intact).

1. **Do not cache partial pie results.** `collect()` wrote the stats cache (`SetLibStats` + `SetTotals`) even when a per-library pie fetch failed. Because the totals then matched on the next scrape, the cache hit and served incomplete data with `tdarr_up=1` — silently dropping the failed library's series until the totals next changed. Partial sweeps now skip the cache write entirely; the cache only ever holds a fully-successful snapshot, so `shouldRefetch()` forces a refetch on the next scrape.

2. **Scope the partial-failure signal to a single scrape.** `partialFailure` was a collector-wide `atomic.Bool`. Two concurrent `Collect()` calls (two Prometheus servers, or overlapping `/metrics` requests — promhttp does not serialize scrapes) shared it, so one scrape could observe another's failure or clear another's real failure — which also made change (1)'s cache-write gate unsound under concurrency. The signal is now a per-scrape value: `fetchPies` owns a local `atomic.Bool`, passes it to its workers, and returns whether any library failed; `collect()` returns `(bool, error)` and `Collect()` reads it. The shared field, its `Swap(false)` reset, and the panic-path reset are removed (net-simplifying).

3. **Store cache totals and stats as one atomic pair.** The cache exposed `totals` and `libraryStats` through four separately-locked methods, so concurrent scrapes could read or write a torn pair (stats from one scrape paired with totals from another). Collapsed to `Read()`/`Write()` that lock once and return/set both fields together, making a torn pair structurally impossible; `collect()` now takes a single snapshot per scrape.

No metric semantics change.

## Motivation

(1) is a silent-data-loss bug: a transient per-library fetch failure could pin the exporter to a stale, incomplete cache with `tdarr_up=1`, masking the gap indefinitely. It affects even a single-Prometheus deployment. An existing test (`TestCollect_ConsecutiveScrapes_PartialFlagResets`) had a manual cache-reset workaround for it; that workaround is removed.

(2) and (3) close concurrent-`Collect()` correctness gaps surfaced while fixing (1) — a Prometheus collector is expected to be safe for concurrent `Collect`, and (1)'s new cache-write gate added another reader of the shared flag. Both are net cleanups: (2) deletes shared mutable state, (3) reduces four cache methods to two and enforces the totals/stats consistency invariant by construction. These paths are only reachable under overlapping scrapes (HA Prometheus, federation, or a manual scrape racing Prometheus), not a single Prometheus.

## Test plan

- `go test ./... -race -count=1` — all packages pass, including:
  - `TestCollect_PartialPieFailure_DoesNotPoisonCache` (two libraries; lib1 succeeds, lib2 fails → scrape 1 `tdarr_up=0` and cache stays empty; scrape 2 recovers with no manual reset → `tdarr_up=1`, both libraries' series present).
  - `TestLibStatsCache_ReadWritePairing` and `TestLibStatsCache_ReadWritePairing_Concurrent` (100 writer/reader goroutines under `-race`, asserting totals and stats indices always match — a torn pair would fail).
- Golden test (`TestCollect_Golden_FullFixture`) unchanged — emitted output identical.
- `gofmt` / `go vet` clean; `golangci-lint` v2.12.2 — 0 issues.
- Live e2e against a real Tdarr instance: exporter builds and runs, `tdarr_up=1` across four scrapes including a concurrent pair, identical `tdarr_library_*` series set (7 libraries, 161 series) across all, graceful shutdown, no errors/panics.

## In-depth

- **Why a two-library fixture** for the regression test: with a single failing library, the partial pie result is empty (`nil`), so the buggy code cached `nil` and the poisoning was unobservable. The bug only reproduces when one library succeeds and one fails (non-empty partial cached alongside matching totals).
- **Not fixed (benign, pre-existing):** the read-decide-write in a refetch is not atomic as a whole, so two concurrent refetching scrapes may both fetch and both `Write`. This is benign last-writer-wins — each writes a self-consistent full snapshot — and fixing it would require holding the cache lock across network I/O.
