### PR TITLE
fix: exit codes, config validation, and dead-code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ $ ./tdarr-exporter -h
         valid url for tdarr instance, ex: https://tdarr.somedomain.com
   -verify_ssl
         verify ssl certificates from tdarr (default true)
+  -version
+        print version information and exit
 ```
 
 A valid URL for the tdarr instance must be provided and can include protocol (`http/https`) and port if needed.
@@ -101,6 +103,7 @@ A valid URL for the tdarr instance must be provided and can include protocol (`h
 | `verify_ssl`      | `VERIFY_SSL`          | `true`     | Whether or not to verify ssl certificates. |
 | `prometheus_port` | `PROMETHEUS_PORT`     | `9090`     | Which port for server to use to serve metrics |
 | `prometheus_path` | `PROMETHEUS_PATH`     | `/metrics` | Which path to serve metrics on. |
+| `version`         | —                     | `false`    | Print version information and exit. Flag only (`-version`), no environment variable. |
 
 If the URL is a valid URL, the hostname inside the URL will be used to identify the instance in the metrics as `tdarr_instance` label, i.e. `https://tdarr.example.com` will be shown as `tdarr.example.com` in the metrics (if using version `v1.2.0` or later).
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -84,16 +84,9 @@ func run() int {
 		syscall.SIGQUIT,
 		syscall.SIGTERM,
 	)
-	// Shut down on either an OS signal or a fatal server error. A server error
-	// triggers the same graceful-shutdown path but yields a non-zero exit code.
-	exitCode := 0
-	select {
-	case <-quitServer:
-		log.Info().Msg("Received Interrupt - shutting down...")
-	case err := <-errHttpChan:
-		log.Error().Err(err).Msg("HTTP server error - shutting down...")
-		exitCode = 1
-	}
+	// Shut down on either an OS signal or a fatal server error; the latter
+	// yields a non-zero exit code.
+	exitCode := awaitShutdown(quitServer, errHttpChan)
 	go func() {
 		<-quitServer
 		log.Fatal().Msg("Killing app on 2nd forced interrupt...")
@@ -104,6 +97,20 @@ func run() int {
 	httpWg.Wait()
 	log.Info().Msg("Gracefully shutdown tdarr exporter")
 	return exitCode
+}
+
+// awaitShutdown blocks until either an OS signal or a fatal HTTP server error
+// arrives, logs the reason, and returns the process exit code: 0 for a
+// signal-triggered shutdown, 1 when a server error triggered it.
+func awaitShutdown(quit <-chan os.Signal, errCh <-chan error) int {
+	select {
+	case <-quit:
+		log.Info().Msg("Received Interrupt - shutting down...")
+		return 0
+	case err := <-errCh:
+		log.Error().Err(err).Msg("HTTP server error - shutting down...")
+		return 1
+	}
 }
 
 func init() {

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -22,14 +22,6 @@ import (
 )
 
 func main() {
-	// Handle --version before config parsing so it doesn't interfere with
-	// config.NewConfig's own flag set.
-	for _, arg := range os.Args[1:] {
-		if arg == "--version" || arg == "-version" {
-			fmt.Println(version.Print("tdarr_exporter"))
-			os.Exit(0)
-		}
-	}
 	os.Exit(run())
 }
 
@@ -38,6 +30,10 @@ func main() {
 // error. Split out of main so os.Exit does not skip deferred cleanup.
 func run() int {
 	userConfig := config.NewConfig()
+	if userConfig.Version {
+		fmt.Println(version.Print("tdarr_exporter"))
+		return 0
+	}
 	log.Debug().Interface("config", userConfig).Msg("Using generated configuration")
 	log.Info().Str("version", version.Version).Str("revision", version.Revision).Str("buildDate", version.BuildDate).Str("goVersion", version.GoVersion).Msg("Starting tdarr-exporter")
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -30,8 +30,13 @@ func main() {
 			os.Exit(0)
 		}
 	}
+	os.Exit(run())
+}
 
-	defer os.Exit(0)
+// run holds the real main body and returns the process exit code: 0 for a
+// signal-triggered shutdown, 1 when shutdown was caused by an HTTP server
+// error. Split out of main so os.Exit does not skip deferred cleanup.
+func run() int {
 	userConfig := config.NewConfig()
 	log.Debug().Interface("config", userConfig).Msg("Using generated configuration")
 	log.Info().Str("version", version.Version).Str("revision", version.Revision).Str("buildDate", version.BuildDate).Str("goVersion", version.GoVersion).Msg("Starting tdarr-exporter")
@@ -45,7 +50,8 @@ func main() {
 	// prometheus set up
 	tdarrCollector, err := collector.NewTdarrCollector(scrapeCtx, userConfig)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to create Tdarr collector")
+		log.Error().Err(err).Msg("Failed to create Tdarr collector")
+		return 1
 	}
 	registry := prometheus.NewRegistry()
 	// registering a collector uses JIT and first scrape will be slower
@@ -83,12 +89,14 @@ func main() {
 		syscall.SIGTERM,
 	)
 	// Shut down on either an OS signal or a fatal server error. A server error
-	// triggers the same graceful-shutdown path instead of hanging silently.
+	// triggers the same graceful-shutdown path but yields a non-zero exit code.
+	exitCode := 0
 	select {
 	case <-quitServer:
 		log.Info().Msg("Received Interrupt - shutting down...")
 	case err := <-errHttpChan:
 		log.Error().Err(err).Msg("HTTP server error - shutting down...")
+		exitCode = 1
 	}
 	go func() {
 		<-quitServer
@@ -99,6 +107,7 @@ func main() {
 	stopHttpChan <- true
 	httpWg.Wait()
 	log.Info().Msg("Gracefully shutdown tdarr exporter")
+	return exitCode
 }
 
 func init() {

--- a/cmd/exporter/main_test.go
+++ b/cmd/exporter/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+// TestAwaitShutdown verifies the exit-code contract: an OS signal yields 0, a
+// fatal HTTP server error yields 1. This guards the regression fixed by
+// splitting main into run() int (previously defer os.Exit(0) forced 0).
+func TestAwaitShutdown(t *testing.T) {
+	t.Parallel()
+
+	t.Run("signal shutdown exits 0", func(t *testing.T) {
+		t.Parallel()
+		quit := make(chan os.Signal, 1)
+		quit <- os.Interrupt
+		if got := awaitShutdown(quit, make(chan error)); got != 0 {
+			t.Errorf("awaitShutdown on signal = %d, want 0", got)
+		}
+	})
+
+	t.Run("server error shutdown exits 1", func(t *testing.T) {
+		t.Parallel()
+		errCh := make(chan error, 1)
+		errCh <- errors.New("listen: address already in use")
+		if got := awaitShutdown(make(chan os.Signal), errCh); got != 1 {
+			t.Errorf("awaitShutdown on server error = %d, want 1", got)
+		}
+	})
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -56,27 +55,14 @@ func NewRequestClient(parsedUrl *url.URL, verifySsl bool, timeoutSeconds int, ap
 	}, nil
 }
 
-func (c *RequestClient) unmarshalBody(body io.Reader, target any) (err error) {
-	// return error instead of panic
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("recovered from panic: %s", r)
-			// if debug, log body
-			if c.logger.GetLevel() == zerolog.DebugLevel {
-				// try to copy io.Reader to string for troubleshooting
-				s := new(strings.Builder)
-				_, copyErr := io.Copy(s, body)
-				if copyErr != nil {
-					c.logger.Error().Err(copyErr).Interface("recover", r).Msg("Failed to copy body to string in recover for troubleshooting")
-				}
-				c.logger.Error().Str("body", s.String()).Msg("Problem body")
-			}
-			c.logger.Error().Err(err).Interface("recover", r).Msg("Recovered while unmarshalling response")
-		}
-	}()
-	// read body into target
-	err = json.NewDecoder(body).Decode(target)
-	return
+// unmarshalBody decodes a JSON response body into target. A panic inside a
+// scrape (e.g. from a pathological reader) is already converted to tdarr_up=0
+// by the collector's Collect recover, so no recover is needed here.
+func (c *RequestClient) unmarshalBody(body io.Reader, target any) error {
+	if err := json.NewDecoder(body).Decode(target); err != nil {
+		return fmt.Errorf("failed to decode response body: %w", err)
+	}
+	return nil
 }
 
 // DoRequest - Take a HTTP Request and return Unmarshaled data. The ctx is

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -11,23 +11,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// panicReader is an io.Reader whose Read method panics, used to drive the
-// defer/recover branch in unmarshalBody.
-type panicReader struct{}
-
-func (panicReader) Read([]byte) (int, error) {
-	panic("boom from Read")
-}
-
-// TestUnmarshalBody exercises unmarshalBody's three branches: a successful
-// decode, a malformed-JSON decode error, and the panic-recover path where the
-// body's Read panics and must be converted into an error rather than crashing.
+// TestUnmarshalBody exercises unmarshalBody's two branches: a successful decode
+// and a malformed-JSON decode error.
 func TestUnmarshalBody(t *testing.T) {
 	t.Parallel()
 
-	// Explicit logger so the test does not depend on ambient log level. Nop()
-	// keeps the debug-only body-copy branch (which would re-read the panicking
-	// body) disabled; the recover-into-error behavior is what this test asserts.
 	c := &RequestClient{logger: zerolog.Nop()}
 
 	tests := []struct {
@@ -47,13 +35,7 @@ func TestUnmarshalBody(t *testing.T) {
 			name:      "malformed json returns error",
 			body:      strings.NewReader(`{not-json`),
 			wantErr:   true,
-			errSubstr: "", // any decode error is acceptable
-		},
-		{
-			name:      "panicking reader is recovered into an error",
-			body:      panicReader{},
-			wantErr:   true,
-			errSubstr: "recovered",
+			errSubstr: "failed to decode response body",
 		},
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -180,10 +180,10 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 	if *httpTimeoutSeconds <= 0 {
 		return Config{}, fmt.Errorf("http_timeout_seconds must be at least 1")
 	}
-	// strconv.Itoa(port) == *promPort rejects non-canonical spellings that Atoi
-	// accepts but net rejects at listen time (a leading '+' or '0', e.g.
-	// "+9090"/"09090"), so a bad port fails fast here rather than at ListenAndServe.
-	if port, err := strconv.Atoi(*promPort); err != nil || port < 1 || port > 65535 || strconv.Itoa(port) != *promPort {
+	// ParseUint with bitSize 16 rejects out-of-range and signed ports for free;
+	// port 0 is a valid uint16 but means "pick a random port", so reject it
+	// explicitly. Fails fast here rather than later at ListenAndServe.
+	if port, err := strconv.ParseUint(*promPort, 10, 16); err != nil || port == 0 {
 		return Config{}, fmt.Errorf("prometheus_port must be an integer between 1 and 65535, got %q", *promPort)
 	}
 	// The Gin router (internal/server/server.go) registers PrometheusPath, "/"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -180,12 +180,16 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 	if *httpTimeoutSeconds <= 0 {
 		return Config{}, fmt.Errorf("http_timeout_seconds must be at least 1")
 	}
-	if port, err := strconv.Atoi(*promPort); err != nil || port < 1 || port > 65535 {
+	// strconv.Itoa(port) == *promPort rejects non-canonical spellings that Atoi
+	// accepts but net rejects at listen time (a leading '+' or '0', e.g.
+	// "+9090"/"09090"), so a bad port fails fast here rather than at ListenAndServe.
+	if port, err := strconv.Atoi(*promPort); err != nil || port < 1 || port > 65535 || strconv.Itoa(port) != *promPort {
 		return Config{}, fmt.Errorf("prometheus_port must be an integer between 1 and 65535, got %q", *promPort)
 	}
-	// The exporter's mux (internal/server/server.go) registers "/" (index) and
-	// "/healthz"; a PrometheusPath equal to a reserved route would panic at mux
-	// registration ("/healthz") or shadow the index ("/"). Reject at startup.
+	// The Gin router (internal/server/server.go) registers PrometheusPath, "/"
+	// (index) and "/healthz". A PrometheusPath equal to "/" or "/healthz" collides
+	// with those routes and panics at registration ("handlers are already
+	// registered for path"). Reject at startup instead.
 	if !strings.HasPrefix(*promPath, "/") {
 		return Config{}, fmt.Errorf("prometheus_path must start with '/', got %q", *promPath)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ const (
 )
 
 type Config struct {
+	Version            bool
 	LogLevel           string
 	url                string
 	UrlParsed          *url.URL
@@ -159,9 +160,15 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 	logLevel := fs.String("log_level", defaults.LogLevel, "log level to use, see link for possible values: https://pkg.go.dev/github.com/rs/zerolog#Level")
 	httpMaxConcurrency := fs.Int("http_max_concurrency", defaults.HttpMaxConcurrency, "maximum number of concurrent http requests to make when requesting per Library stats")
 	httpTimeoutSeconds := fs.Int("http_timeout_seconds", defaults.HttpTimeoutSeconds, "timeout in seconds for http requests to the tdarr instance")
+	versionFlag := fs.Bool("version", false, "print version information and exit")
 
 	if err := fs.Parse(args); err != nil {
 		return Config{}, err
+	}
+
+	if *versionFlag {
+		// Short-circuit: -version must work without any other config present.
+		return Config{Version: true}, nil
 	}
 
 	if *url == "" {
@@ -172,6 +179,18 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 	}
 	if *httpTimeoutSeconds <= 0 {
 		return Config{}, fmt.Errorf("http_timeout_seconds must be at least 1")
+	}
+	if port, err := strconv.Atoi(*promPort); err != nil || port < 1 || port > 65535 {
+		return Config{}, fmt.Errorf("prometheus_port must be an integer between 1 and 65535, got %q", *promPort)
+	}
+	// The exporter's mux (internal/server/server.go) registers "/" (index) and
+	// "/healthz"; a PrometheusPath equal to a reserved route would panic at mux
+	// registration ("/healthz") or shadow the index ("/"). Reject at startup.
+	if !strings.HasPrefix(*promPath, "/") {
+		return Config{}, fmt.Errorf("prometheus_path must start with '/', got %q", *promPath)
+	}
+	if *promPath == "/" || *promPath == "/healthz" {
+		return Config{}, fmt.Errorf("prometheus_path %q conflicts with a reserved exporter route", *promPath)
 	}
 
 	// validate the log level here (without mutating global state).
@@ -212,6 +231,10 @@ func NewConfig() Config {
 	cfg, err := parseConfig(fs, os.Args[1:], os.Getenv)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to load configuration")
+	}
+
+	if cfg.Version {
+		return cfg
 	}
 
 	// parseConfig already validated the log level; apply it globally here.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -318,6 +318,8 @@ func TestPrometheusPortValidation(t *testing.T) {
 		{"non-numeric", "abc", true},
 		{"zero", "0", true},
 		{"too large", "70000", true},
+		{"leading plus", "+9090", true},
+		{"leading zero", "09090", true},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -319,7 +319,7 @@ func TestPrometheusPortValidation(t *testing.T) {
 		{"zero", "0", true},
 		{"too large", "70000", true},
 		{"leading plus", "+9090", true},
-		{"leading zero", "09090", true},
+		{"leading zero accepted (net accepts it too)", "09090", false},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -306,3 +306,64 @@ func TestParseLogLevel(t *testing.T) {
 		}
 	})
 }
+
+func TestPrometheusPortValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		port    string
+		wantErr bool
+	}{
+		{"valid", "9090", false},
+		{"non-numeric", "abc", true},
+		{"zero", "0", true},
+		{"too large", "70000", true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseConfig(newFS(), []string{"-url", "http://tdarr.test", "-prometheus_port", tt.port}, envFunc(nil))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("port %q: wantErr=%v, got err=%v", tt.port, tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestPrometheusPathValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"default ok", "/metrics", false},
+		{"custom ok", "/prom", false},
+		{"no leading slash", "metrics", true},
+		{"root conflicts with index route", "/", true},
+		{"healthz conflicts with reserved route", "/healthz", true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseConfig(newFS(), []string{"-url", "http://tdarr.test", "-prometheus_path", tt.path}, envFunc(nil))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("path %q: wantErr=%v, got err=%v", tt.path, tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestVersionFlagShortCircuits(t *testing.T) {
+	t.Parallel()
+	// no -url: version requests must not require or validate other config
+	cfg, err := parseConfig(newFS(), []string{"-version"}, envFunc(nil))
+	if err != nil {
+		t.Fatalf("parseConfig with -version: %v", err)
+	}
+	if !cfg.Version {
+		t.Error("cfg.Version: want true")
+	}
+}


### PR DESCRIPTION
## Changes

Three low-risk fixes from the holistic review backlog, batched:

- **Non-zero exit on server-error shutdown.** `main` restructured into `run() int` (`main` is now `os.Exit(run())`). Removes `defer os.Exit(0)`, which forced exit code 0 on every path and could skip other deferred cleanup. A signal-triggered shutdown returns 0; a shutdown caused by an HTTP server error returns 1. The signal-vs-error select is extracted into `awaitShutdown` and unit-tested.
- **Remove dead panic-recover in `unmarshalBody`.** `json.Decoder.Decode` returns errors rather than panicking, and the collector's `Collect` recover already degrades any scrape-path panic to `tdarr_up=0`. The debug body-copy branch also read an already-consumed reader, so it logged nothing useful. Now a plain decode-or-wrap-error. The `panicReader` test and the unused `strings` import are removed.
- **Validate `prometheus_port`/`prometheus_path`; register `-version` as a real flag.** Port typos now fail at startup with a clear message instead of surfacing later at `ListenAndServe`. A `prometheus_path` that would collide with the reserved `/` (index) or `/healthz` routes — a mux-registration panic — is rejected at startup. `-version` is now a registered flag (appears in `-h`) routed through config, replacing the raw `os.Args` scan that also matched flag *values*.

## Motivation

Correctness and operability cleanups: honest process exit codes for supervisors/orchestrators, fail-fast config validation, and removal of a dead defensive branch that could never fire.

## Test plan

- `task ci` green: `go fmt` clean, `go mod tidy` clean, golangci-lint, `go test ./... -race`.
- New tests: `awaitShutdown` exit-code contract (signal → 0, server error → 1); `prometheus_port`/`prometheus_path` validation tables; `-version` short-circuit returns `Config{Version: true}` without requiring other config.
- Manual: `go run ./cmd/exporter -version` prints the version block and exits 0; `-prometheus_port 70000` exits 1; `-version` appears in `-h` output.

## In-depth

- `run()` returns an exit code rather than calling `os.Exit` directly so deferred cleanup (`cancelScrapes`) always runs. `NewTdarrCollector` failure switches from `log.Fatal` to `log.Error` + `return 1` for the same reason (same exit code either way). `config.NewConfig` still `log.Fatal`s on bad config — exit 1, nothing to clean up yet.
- `-version` short-circuits inside `parseConfig` (returns `Config{Version: true}` before URL/port/path validation) and `NewConfig` returns early before dereferencing the nil `UrlParsed`, so `-version` works with no other config present.
- Scope note: these are non-breaking. The `path` validation assumes the current mux route set (`/`, `/healthz`); if those change (e.g. the planned gin→stdlib migration), revisit the reserved-route list.
