### PR TITLE
fix: abort retry backoff when request context is cancelled

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -40,7 +40,6 @@ func TestUnmarshalBody(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/client/request_test.go
+++ b/internal/client/request_test.go
@@ -114,7 +114,6 @@ func TestDoRequest_ApiKeyHeader(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -22,11 +22,11 @@ func WithBackoff(durations []time.Duration) ClientTransportOption {
 	}
 }
 
-// WithSleep injects a custom sleep function, replacing time.Sleep.
-// Intended for tests to avoid real wall-clock delays.
-func WithSleep(fn func(time.Duration)) ClientTransportOption {
+// WithAfter injects the timer function used for retry backoff, replacing
+// time.After. Intended for tests to avoid real wall-clock delays.
+func WithAfter(fn func(time.Duration) <-chan time.Time) ClientTransportOption {
 	return func(t *ClientTransport) {
-		t.sleep = fn
+		t.after = fn
 	}
 }
 
@@ -41,18 +41,18 @@ func WithLogger(logger zerolog.Logger) ClientTransportOption {
 type ClientTransport struct {
 	inner   http.RoundTripper
 	backoff []time.Duration
-	sleep   func(time.Duration)
+	after   func(time.Duration) <-chan time.Time
 	logger  zerolog.Logger
 }
 
 // NewClientTransport constructs a ClientTransport wrapping inner.
-// Default: 2 retries with backoff [1s, 3s], using time.Sleep.
+// Default: 2 retries with backoff [1s, 3s], using time.After.
 // The existing call site NewClientTransport(baseTransport) keeps working unchanged.
 func NewClientTransport(inner http.RoundTripper, opts ...ClientTransportOption) *ClientTransport {
 	t := &ClientTransport{
 		inner:   inner,
 		backoff: []time.Duration{1 * time.Second, 3 * time.Second},
-		sleep:   time.Sleep,
+		after:   time.After,
 		logger:  log.Logger,
 	}
 	for _, opt := range opts {
@@ -101,8 +101,15 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			// returns to the pool instead of leaking (nil-safe on the first
 			// iteration when the initial attempt errored with no response).
 			drainClose(resp)
-			// first try already failed so wait before retrying
-			t.sleep(backoffDur)
+			// first try already failed so wait before retrying — but abort the
+			// wait immediately if the request's context is cancelled (shutdown
+			// or Prometheus scrape timeout); retrying with a dead context is
+			// pointless and delays shutdown by the full backoff.
+			select {
+			case <-req.Context().Done():
+				return nil, fmt.Errorf("aborting retries - request context done: %w", req.Context().Err())
+			case <-t.after(backoffDur):
+			}
 			// re-add body to request
 			if req.Body != nil {
 				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))

--- a/internal/client/transport_leak_test.go
+++ b/internal/client/transport_leak_test.go
@@ -67,7 +67,7 @@ func TestRoundTrip_ClosesDiscardedBodies(t *testing.T) {
 			rt := &seqRoundTripper{statuses: tt.statuses}
 			transport := NewClientTransport(rt,
 				WithBackoff([]time.Duration{0}), // one retry, no real delay
-				WithSleep(func(time.Duration) {}),
+				WithAfter(immediateAfter),
 			)
 
 			req, err := http.NewRequest(http.MethodGet, "http://example.test", nil)

--- a/internal/client/transport_test.go
+++ b/internal/client/transport_test.go
@@ -1,12 +1,17 @@
 package client
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
 )
 
 // fakeRoundTripper records calls and returns pre-configured responses/errors.
@@ -44,13 +49,21 @@ func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}, nil
 }
 
-// noopSleep is a sleep func that never blocks and records nothing.
-func noopSleep(_ time.Duration) {}
+// immediateAfter is an after func that fires immediately without blocking.
+func immediateAfter(time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	ch <- time.Time{}
+	return ch
+}
 
-// collectingSleep returns a sleep func that appends durations to *out.
-func collectingSleep(out *[]time.Duration) func(time.Duration) {
-	return func(d time.Duration) {
-		*out = append(*out, d)
+// collectingAfter returns an after func that appends durations to *out and
+// fires immediately.
+func collectingAfter(sleeps *[]time.Duration) func(time.Duration) <-chan time.Time {
+	return func(d time.Duration) <-chan time.Time {
+		*sleeps = append(*sleeps, d)
+		ch := make(chan time.Time, 1)
+		ch <- time.Time{}
+		return ch
 	}
 }
 
@@ -200,7 +213,7 @@ func TestClientTransport_RetryBehavior(t *testing.T) {
 			t.Parallel()
 			var sleeps []time.Duration
 			inner := &fakeRoundTripper{responses: tc.responses}
-			tr := NewClientTransport(inner, WithBackoff(tc.backoff), WithSleep(collectingSleep(&sleeps)))
+			tr := NewClientTransport(inner, WithBackoff(tc.backoff), WithAfter(collectingAfter(&sleeps)))
 
 			req := newRequest(t, http.MethodGet, "http://example.com/test", "")
 			resp, err := tr.RoundTrip(req)
@@ -260,7 +273,7 @@ func TestClientTransport_PostBodyReusedAcrossRetries(t *testing.T) {
 	}
 	tr := NewClientTransport(inner,
 		WithBackoff([]time.Duration{0, 0}),
-		WithSleep(noopSleep),
+		WithAfter(immediateAfter),
 	)
 
 	req := newRequest(t, http.MethodPost, "http://example.com/post", `{"key":"value"}`)
@@ -286,8 +299,8 @@ func TestClientTransport_DefaultsArePreserved(t *testing.T) {
 	inner := &fakeRoundTripper{responses: []fakeResponse{{statusCode: 200}}}
 	tr := NewClientTransport(inner) // no options — use defaults
 
-	if tr.sleep == nil {
-		t.Error("default sleep should be non-nil")
+	if tr.after == nil {
+		t.Error("default after should be non-nil")
 	}
 	// Default backoff should be [1s, 3s].
 	want := []time.Duration{1 * time.Second, 3 * time.Second}
@@ -308,5 +321,49 @@ func TestClientTransport_DefaultsArePreserved(t *testing.T) {
 	}
 	if resp != nil {
 		_ = resp.Body.Close()
+	}
+}
+
+// roundTripFunc adapts a function to http.RoundTripper, for tests that need
+// full control over every attempt (fakeRoundTripper replays a fixed list).
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// TestClientTransport_ContextCancelDuringBackoff verifies that cancelling the
+// request context while the transport is waiting out a retry backoff aborts
+// the wait immediately (no further attempts, prompt ctx error) instead of
+// sleeping the full backoff and retrying with a dead context.
+func TestClientTransport_ContextCancelDuringBackoff(t *testing.T) {
+	attempts := 0
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return nil, errors.New("dial refused")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// after() that never fires and cancels the context instead: the only way
+	// RoundTrip can return is via the ctx.Done() select arm.
+	blockedAfter := func(time.Duration) <-chan time.Time {
+		cancel()
+		return make(chan time.Time) // never fires
+	}
+
+	tr := NewClientTransport(inner,
+		WithBackoff([]time.Duration{time.Hour, time.Hour}),
+		WithAfter(blockedAfter),
+		WithLogger(zerolog.Nop()),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://tdarr.test/api", nil).WithContext(ctx)
+	resp, err := tr.RoundTrip(req) //nolint:bodyclose // resp is nil on error
+	if resp != nil {
+		t.Fatalf("expected nil response, got %v", resp)
+	}
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled in error chain, got %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts: want 1 (no retry after cancel), got %d", attempts)
 	}
 }

--- a/internal/client/transport_test.go
+++ b/internal/client/transport_test.go
@@ -208,7 +208,6 @@ func TestClientTransport_RetryBehavior(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			var sleeps []time.Duration


### PR DESCRIPTION
## Changes

- Retry backoff in the custom `http.RoundTripper` (`internal/client/transport.go`) now selects on the request context during the backoff wait. A cancelled request (process shutdown or a Prometheus scrape timeout) aborts the wait immediately and returns the context error, instead of sleeping the full backoff and then retrying against a dead context.
- The injected `sleep func(time.Duration)` is replaced by `after func(time.Duration) <-chan time.Time`; the `WithSleep` option becomes `WithAfter` (internal package, no external API). Default remains `time.After`.
- Backoff sequence, attempt count, POST-body reuse, and discarded-body drain/close on the non-cancelled path are unchanged.
- Chore: removed now-redundant `x := x` loop-variable copies in the client test files (Go 1.22+ gives each iteration its own variable). Separate commit.

## Motivation

Worst case before this change: a request that gets cancelled mid-backoff still burned the full `[1s, 3s]` per endpoint before giving up, delaying shutdown and wasting a retry on an already-dead context. Making the backoff context-aware bounds shutdown/scrape-timeout latency to roughly the time already spent in the in-flight attempt.

## Test plan

- New `TestClientTransport_ContextCancelDuringBackoff`: cancels the context while the transport is waiting out a backoff (via an injected `after` that never fires), asserts the call returns promptly with `context.Canceled` in the error chain and makes exactly one attempt (no retry). Deterministic — no real sleeps.
- Existing `TestClientTransport_RetryBehavior`, `TestClientTransport_PostBodyReusedAcrossRetries`, `TestClientTransport_DefaultsArePreserved`, and the body-close leak test migrated to `WithAfter` with assertions unchanged.
- `task ci` green (go fmt, go mod tidy, golangci-lint, `go test ./... -race`).

## In-depth

- **Timer on the cancel path:** the abandoned `time.After` channel is GC-eligible on Go 1.23+ (repo is on Go 1.26), so aborting the wait leaks no goroutine.
- **Zero-backoff select tie:** if a backoff duration were `0` and the context were already cancelled, Go's `select` could pick the timer arm and drive one more attempt — but production backoffs are `[1s, 3s]` (never 0), and even in that tie the next attempt still respects the cancelled context and errors out. Not guarded, noted for completeness.
- **Follow-up:** a `rangeint` modernizer hint remains in `client_test.go` (a `for i:=0;i<n` loop that could use range-over-int); left for a separate repo-wide modernization sweep rather than expanding this PR.
