### PR TITLE
feat: configurable listen_address and instance_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ $ ./tdarr-exporter -h
         api token for tdarr instance if authentication is enabled
   -http_max_concurrency int
         maximum number of concurrent http requests to make when requesting per Library stats (default 3)
+  -instance_name string
+        set to customize the tdarr_instance label (defaults to the url hostname); helpful when running multiple exporters and/or multiple tdarr instances on one host
+  -listen_address string
+        network interface address for the exporter's http server to listen on, ex: 127.0.0.1 or :: (default "0.0.0.0")
   -log_level string
         log level to use, see link for possible values: https://pkg.go.dev/github.com/rs/zerolog#Level (default "info")
   -prometheus_path string
@@ -101,11 +105,13 @@ A valid URL for the tdarr instance must be provided and can include protocol (`h
 | `http_max_concurrency` | `HTTP_MAX_CONCURRENCY` | `3`     | Maximum number of concurrent http requests to make when requesting per Library stats. For more information on caching and concurrency see this [section](#caching-and-concurrency) for more. |
 | `log_level`       | `LOG_LEVEL`           | `info`     | Log level to use: `debug`, `info`, `warn`, `error`. |
 | `verify_ssl`      | `VERIFY_SSL`          | `true`     | Whether or not to verify ssl certificates. |
+| `listen_address`  | `LISTEN_ADDRESS`      | `0.0.0.0`  | Network interface address for the exporter's http server to bind. Set to `127.0.0.1` to only accept local connections (e.g. behind a reverse proxy), or an IPv6 address such as `::`. |
 | `prometheus_port` | `PROMETHEUS_PORT`     | `9090`     | Which port for server to use to serve metrics |
 | `prometheus_path` | `PROMETHEUS_PATH`     | `/metrics` | Which path to serve metrics on. |
+| `instance_name`   | `INSTANCE_NAME`       | url hostname | Overrides the `tdarr_instance` label carried by the exporter's own metrics (`tdarr_*`, `tdarr_exporter_build_info`, and the `promhttp_*` handler counters); the generic `go_*` and `process_*` runtime metrics are unlabeled. Defaults to the url hostname; set it to disambiguate multiple exporters and/or multiple Tdarr instances running on the same host. |
 | `version`         | —                     | `false`    | Print version information and exit. Flag only (`-version`), no environment variable. |
 
-If the URL is a valid URL, the hostname inside the URL will be used to identify the instance in the metrics as `tdarr_instance` label, i.e. `https://tdarr.example.com` will be shown as `tdarr.example.com` in the metrics (if using version `v1.2.0` or later).
+If the URL is a valid URL, the hostname inside the URL will be used to identify the instance in the metrics as `tdarr_instance` label, i.e. `https://tdarr.example.com` will be shown as `tdarr.example.com` in the metrics (if using version `v1.2.0` or later). To override this (for example when two Tdarr instances share a hostname on different ports, or you run multiple exporters), set `instance_name` / `INSTANCE_NAME`.
 
 If using authentication with Tdarr, an API key must be provided. Follow instructions [here](https://docs.tdarr.io/docs/other/authentication) to generate or use an existing API key.
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -67,7 +67,7 @@ func run() int {
 		TdarrInstance:   userConfig.InstanceName,
 		PrometheusPort:  userConfig.PrometheusPort,
 		PrometheusPath:  userConfig.PrometheusPath,
-		ListenAddress:   "0.0.0.0",
+		ListenAddress:   userConfig.ListenAddress,
 		GracefulTimeout: 30 * time.Second,
 	}
 	httpWg.Add(1)

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -54,8 +54,13 @@ func run() int {
 	// standard Go runtime + process metrics (go_*, process_*)
 	registry.MustRegister(collectors.NewGoCollector())
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	// build info metric (tdarr_exporter_build_info)
-	registry.MustRegister(versioncollector.NewCollector("tdarr_exporter"))
+	// build info metric (tdarr_exporter_build_info). Registered through an
+	// instance-labeled registerer so it carries tdarr_instance like the rest of
+	// the exporter's own metrics (go_*/process_* stay unlabeled — generic runtime).
+	prometheus.WrapRegistererWith(
+		prometheus.Labels{"tdarr_instance": userConfig.InstanceName},
+		registry,
+	).MustRegister(versioncollector.NewCollector("tdarr_exporter"))
 
 	// http server
 	stopHttpChan := make(chan bool)

--- a/cmd/exporter/main_test.go
+++ b/cmd/exporter/main_test.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"os"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 )
 
 // TestAwaitShutdown verifies the exit-code contract: an OS signal yields 0, a
@@ -29,4 +32,52 @@ func TestAwaitShutdown(t *testing.T) {
 			t.Errorf("awaitShutdown on server error = %d, want 1", got)
 		}
 	})
+}
+
+// TestBuildInfoCarriesInstanceLabel verifies tdarr_exporter_build_info is
+// registered through the tdarr_instance-labeled registerer (mirroring run()),
+// so the exporter's build-info metric is labeled like the rest of its metrics.
+func TestBuildInfoCarriesInstanceLabel(t *testing.T) {
+	t.Parallel()
+
+	const wantInstance = "tdarr-4k"
+	registry := prometheus.NewRegistry()
+	prometheus.WrapRegistererWith(
+		prometheus.Labels{"tdarr_instance": wantInstance},
+		registry,
+	).MustRegister(versioncollector.NewCollector("tdarr_exporter"))
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("registry.Gather: %v", err)
+	}
+
+	var found bool
+	for _, fam := range families {
+		if fam.GetName() != "tdarr_exporter_build_info" {
+			continue
+		}
+		found = true
+		metrics := fam.GetMetric()
+		if len(metrics) != 1 {
+			t.Fatalf("tdarr_exporter_build_info: want 1 metric, got %d", len(metrics))
+		}
+		var gotInstance string
+		var hasLabel bool
+		for _, lp := range metrics[0].GetLabel() {
+			if lp.GetName() == "tdarr_instance" {
+				hasLabel = true
+				gotInstance = lp.GetValue()
+			}
+		}
+		if !hasLabel {
+			t.Errorf("tdarr_exporter_build_info: missing tdarr_instance label")
+		}
+		if gotInstance != wantInstance {
+			t.Errorf("tdarr_instance: want %q, got %q", wantInstance, gotInstance)
+		}
+	}
+	if !found {
+		t.Fatal("tdarr_exporter_build_info family not found in gathered metrics")
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ const (
 	envHttpMaxConcurrency = "HTTP_MAX_CONCURRENCY"
 	envHttpTimeoutSeconds = "HTTP_TIMEOUT_SECONDS"
 	envListenAddress      = "LISTEN_ADDRESS"
+	envInstanceName       = "INSTANCE_NAME"
 )
 
 type Config struct {
@@ -128,6 +129,9 @@ func applyEnvDefaults(getenv func(string) string) (Config, error) {
 	if v := getenv(envListenAddress); v != "" {
 		defaults.ListenAddress = v
 	}
+	if v := getenv(envInstanceName); v != "" {
+		defaults.InstanceName = v
+	}
 	return defaults, nil
 }
 
@@ -168,6 +172,7 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 	httpTimeoutSeconds := fs.Int("http_timeout_seconds", defaults.HttpTimeoutSeconds, "timeout in seconds for http requests to the tdarr instance")
 	versionFlag := fs.Bool("version", false, "print version information and exit")
 	listenAddress := fs.String("listen_address", defaults.ListenAddress, "network interface address for the exporter's http server to listen on, ex: 127.0.0.1 or ::")
+	instanceName := fs.String("instance_name", defaults.InstanceName, "set to customize the tdarr_instance label (defaults to the url hostname); helpful when running multiple exporters and/or multiple tdarr instances on one host")
 
 	if err := fs.Parse(args); err != nil {
 		return Config{}, err
@@ -214,10 +219,15 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 		return Config{}, err
 	}
 
+	name := *instanceName
+	if name == "" {
+		name = urlParsed.Hostname()
+	}
+
 	return Config{
 		url:                *url,
 		UrlParsed:          urlParsed,
-		InstanceName:       urlParsed.Hostname(),
+		InstanceName:       name,
 		ApiKey:             *apiKeyAuth,
 		VerifySsl:          *sslVerify,
 		PrometheusPort:     *promPort,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ const (
 	envLogLevel           = "LOG_LEVEL"
 	envHttpMaxConcurrency = "HTTP_MAX_CONCURRENCY"
 	envHttpTimeoutSeconds = "HTTP_TIMEOUT_SECONDS"
+	envListenAddress      = "LISTEN_ADDRESS"
 )
 
 type Config struct {
@@ -39,6 +40,7 @@ type Config struct {
 	TdarrNodePath      string
 	TdarrStatusPath    string
 	HttpMaxConcurrency int
+	ListenAddress      string
 }
 
 // parseLogLevel maps a string log level to a zerolog.Level. It returns an error
@@ -79,6 +81,7 @@ func getDefaults() Config {
 		TdarrPieStatsPath:  "/api/v2/stats/get-pies",
 		TdarrStatusPath:    "/api/v2/status",
 		HttpMaxConcurrency: 3,
+		ListenAddress:      "0.0.0.0",
 	}
 }
 
@@ -122,6 +125,9 @@ func applyEnvDefaults(getenv func(string) string) (Config, error) {
 		}
 		defaults.HttpTimeoutSeconds = intValue
 	}
+	if v := getenv(envListenAddress); v != "" {
+		defaults.ListenAddress = v
+	}
 	return defaults, nil
 }
 
@@ -161,6 +167,7 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 	httpMaxConcurrency := fs.Int("http_max_concurrency", defaults.HttpMaxConcurrency, "maximum number of concurrent http requests to make when requesting per Library stats")
 	httpTimeoutSeconds := fs.Int("http_timeout_seconds", defaults.HttpTimeoutSeconds, "timeout in seconds for http requests to the tdarr instance")
 	versionFlag := fs.Bool("version", false, "print version information and exit")
+	listenAddress := fs.String("listen_address", defaults.ListenAddress, "network interface address for the exporter's http server to listen on, ex: 127.0.0.1 or ::")
 
 	if err := fs.Parse(args); err != nil {
 		return Config{}, err
@@ -223,6 +230,7 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 		TdarrPieStatsPath:  defaults.TdarrPieStatsPath,
 		TdarrStatusPath:    defaults.TdarrStatusPath,
 		HttpMaxConcurrency: *httpMaxConcurrency,
+		ListenAddress:      *listenAddress,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -202,7 +202,6 @@ func TestParseConfigErrors(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := parseConfig(newFS(), tc.args, envFunc(tc.env))
@@ -248,7 +247,6 @@ func TestParseConfigUrlSchemeDefaulting(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			env := map[string]string{envTdarrUrl: tc.url}
@@ -286,7 +284,6 @@ func TestParseLogLevel(t *testing.T) {
 		{"INFO", zerolog.InfoLevel}, // case-insensitive
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
 			got, err := parseLogLevel(tc.input)
@@ -322,7 +319,6 @@ func TestPrometheusPortValidation(t *testing.T) {
 		{"leading zero accepted (net accepts it too)", "09090", false},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := parseConfig(newFS(), []string{"-url", "http://tdarr.test", "-prometheus_port", tt.port}, envFunc(nil))
@@ -347,7 +343,6 @@ func TestPrometheusPathValidation(t *testing.T) {
 		{"healthz conflicts with reserved route", "/healthz", true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := parseConfig(newFS(), []string{"-url", "http://tdarr.test", "-prometheus_path", tt.path}, envFunc(nil))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -369,3 +369,29 @@ func TestVersionFlagShortCircuits(t *testing.T) {
 		t.Error("cfg.Version: want true")
 	}
 }
+
+func TestListenAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		env  map[string]string
+		want string
+	}{
+		{"default", nil, nil, "0.0.0.0"},
+		{"env override", nil, map[string]string{"LISTEN_ADDRESS": "127.0.0.1"}, "127.0.0.1"},
+		{"flag override", []string{"-listen_address", "::1"}, nil, "::1"},
+		{"flag beats env", []string{"-listen_address", "127.0.0.1"}, map[string]string{"LISTEN_ADDRESS": "0.0.0.0"}, "127.0.0.1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"-url", "http://tdarr.test"}, tt.args...)
+			cfg, err := parseConfig(newFS(), args, envFunc(tt.env))
+			if err != nil {
+				t.Fatalf("parseConfig: %v", err)
+			}
+			if cfg.ListenAddress != tt.want {
+				t.Errorf("ListenAddress: want %q, got %q", tt.want, cfg.ListenAddress)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -395,3 +395,29 @@ func TestListenAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestInstanceNameOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		env  map[string]string
+		want string
+	}{
+		{"default is url hostname", nil, nil, "tdarr.test"},
+		{"env override", nil, map[string]string{"INSTANCE_NAME": "tdarr-4k"}, "tdarr-4k"},
+		{"flag override", []string{"-instance_name", "tdarr-anime"}, nil, "tdarr-anime"},
+		{"flag beats env", []string{"-instance_name", "tdarr-anime"}, map[string]string{"INSTANCE_NAME": "tdarr-4k"}, "tdarr-anime"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"-url", "http://tdarr.test:8265"}, tt.args...)
+			cfg, err := parseConfig(newFS(), args, envFunc(tt.env))
+			if err != nil {
+				t.Fatalf("parseConfig: %v", err)
+			}
+			if cfg.InstanceName != tt.want {
+				t.Errorf("InstanceName: want %q, got %q", tt.want, cfg.InstanceName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes

Two additive configuration options for the exporter's HTTP server, a related metric-labeling fix, plus a test-file cleanup and docs.

- **`listen_address` flag / `LISTEN_ADDRESS` env** — binds the HTTP server to a specific interface. Default stays `0.0.0.0` (unchanged behavior). `cmd/exporter/main.go` now consumes `userConfig.ListenAddress` instead of a hardcoded literal.
- **`instance_name` flag / `INSTANCE_NAME` env** — optional override for the `tdarr_instance` label. Default stays the URL hostname, so existing setups are unaffected. An empty override falls back to the hostname; a non-empty env value survives (is not overwritten by the hostname fallback).
- **`tdarr_exporter_build_info` now carries `tdarr_instance`** — the build-info collector is registered through an instance-labeled registerer, so it matches the rest of the exporter's own metrics (`tdarr_*` and the `promhttp_*` handler counters). The generic `go_*`/`process_*` runtime metrics stay unlabeled. Honors the `instance_name` override.
- **chore** — removed 5 redundant `tc := tc` / `tt := tt` loop-variable copies in `config_test.go`. Dead since Go 1.22 (per-iteration loop variables); the repo is on Go 1.26.
- **docs** — both flags added to the README `-help` usage block and configuration table; the `instance_name` row documents exactly which metrics carry the label.

Precedence follows the existing config model: defaults → env → flags.

## Motivation

- `listen_address`: allows binding to `127.0.0.1` behind a reverse proxy, or to an IPv6 address, instead of always exposing on all interfaces.
- `instance_name`: two Tdarr instances on one host (different ports) previously collapsed to the same `tdarr_instance` label (both share the hostname). The override disambiguates them.
- `build_info` labeling: the exporter's own build-info metric was the odd one out — every other exporter-emitted series carries `tdarr_instance`, so joining build/version info by instance in dashboards now works consistently.

## Test plan

- `internal/config/config_test.go`: `TestListenAddress` and `TestInstanceNameOverride` cover the full precedence matrix for both options — default, env override, flag override, and flag-beats-env.
- `cmd/exporter/main_test.go`: `TestBuildInfoCarriesInstanceLabel` gathers the registry and asserts `tdarr_exporter_build_info` carries the expected `tdarr_instance` value.
- `task ci` green: `go fmt` clean, `go mod tidy` clean, `golangci-lint` 0 issues, `go test ./... -race` passing.

## In-depth

- `listen_address` is not validated at parse time; an invalid address surfaces at `ListenAndServe`, which logs, pushes to the error channel, and exits non-zero — it fails loudly. This diverges slightly from `prometheus_port` (validated early with a fast-fail). Left as-is to keep this change additive; early validation could be a follow-up for symmetry.
- Adding `tdarr_instance` to `build_info` is an additive label change: existing queries that don't reference the label are unaffected, and Prometheus already distinguishes targets by its own `instance` label.
