### PR TITLE
fix: bracket IPv6 listen_address with net.JoinHostPort

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,7 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -44,7 +44,7 @@ func ServeHttp(wg *sync.WaitGroup, registry *prometheus.Registry, runConfig Http
 		Msg("Starting HTTP Server")
 
 	srv := http.Server{
-		Addr:    fmt.Sprintf("%s:%s", runConfig.ListenAddress, runConfig.PrometheusPort),
+		Addr:    net.JoinHostPort(runConfig.ListenAddress, runConfig.PrometheusPort),
 		Handler: handlers.Recovery(handlers.RequestLogger(mux)),
 		// Bound header read time so idle half-open connections cannot pin
 		// goroutines indefinitely (slowloris; gosec G112).

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -42,6 +43,43 @@ func waitForServer(t *testing.T, addr string, deadline time.Duration) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("server at %s did not become reachable within %s", addr, deadline)
+}
+
+// TestListenAddressJoinHostPort pins the contract ServeHttp relies on when it
+// builds http.Server.Addr with net.JoinHostPort: the result is accepted by
+// net.Listen for IPv4, IPv6, and the common defaults. It documents why the
+// naive fmt.Sprintf("%s:%s", host, port) is wrong — that form yields an
+// unparseable "too many colons" address for IPv6 hosts like "::".
+// (ServeHttp's own use of the address is exercised by TestServeHttpLifecycle.)
+func TestListenAddressJoinHostPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		wantAddr string
+	}{
+		{name: "ipv4 loopback", host: "127.0.0.1", wantAddr: "127.0.0.1:0"},
+		{name: "ipv4 unspecified", host: "0.0.0.0", wantAddr: "0.0.0.0:0"},
+		{name: "ipv6 unspecified", host: "::", wantAddr: "[::]:0"},
+		{name: "ipv6 loopback", host: "::1", wantAddr: "[::1]:0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr := net.JoinHostPort(tt.host, "0")
+			if addr != tt.wantAddr {
+				t.Fatalf("net.JoinHostPort(%q, \"0\") = %q, want %q", tt.host, addr, tt.wantAddr)
+			}
+
+			ln, err := net.Listen("tcp", addr)
+			if err != nil {
+				if strings.Contains(tt.host, ":") {
+					t.Skipf("skipping IPv6 bind: environment appears to lack IPv6 support: %v", err)
+				}
+				t.Fatalf("net.Listen(%q) failed: %v", addr, err)
+			}
+			defer func() { _ = ln.Close() }()
+		})
+	}
 }
 
 func TestServeHttpLifecycle(t *testing.T) {


### PR DESCRIPTION
## Changes
- `internal/server/server.go`: build `http.Server.Addr` with `net.JoinHostPort` instead of `fmt.Sprintf("%s:%s", host, port)`. Drops `fmt` import, adds `net`.
- `internal/server/server_test.go`: add `TestListenAddressJoinHostPort` — table-driven, binds real listeners for IPv4 loopback/unspecified and IPv6 `::`/`::1`; `t.Skip` where the host lacks IPv6.

## Motivation
`listen_address` / `LISTEN_ADDRESS` accepts IPv6 per the flag help (`config.go`) and README, but `fmt.Sprintf("%s:%s", ...)` produced `":::9090"` for `"::"` (and `"::1:9090"` for `"::1"`), which `net.Listen` rejects with `too many colons in address`. The advertised IPv6 forms never bound. `net.JoinHostPort` is the stdlib function for exactly this: it brackets IPv6 literals (`[::]:9090`) and leaves IPv4, hostnames, and the empty (all-interfaces) form byte-for-byte identical to the old output — so IPv4/hostname behavior is unchanged and only the broken IPv6 path is fixed.

Scope: address construction only. No config-time `listen_address` validation added (deliberate — `net.Listen` already accepts hostnames and empty-string that `net.ParseIP` would wrongly reject; the bind-error path stays covered and exits non-zero). No README/flag-help wording changes needed — they already document `::`.

## Test plan
- `go test ./... -race -count=1` — all packages pass.
- `go vet ./...`, `go fmt ./...` (clean), `go build ./...`.
- End-to-end: ran the built binary with `-listen_address ::1`; it bound and served `/healthz` (`{"status":"ok"}`) and `/` over IPv6 (`curl -6 http://[::1]:PORT/...`). The same invocation fails on `main` with `too many colons in address`.

## In-depth
- Behavior delta limited to IPv6: for any host without a colon, `JoinHostPort` returns `host:port` identically to the old `Sprintf`. Already-bracketed input (e.g. `[::1]`) would now double-bracket, but that form is undocumented and unrealistic (help/README document unbracketed `::`; default is `0.0.0.0`); net effect is strictly an improvement.
- `TestListenAddressJoinHostPort` asserts the `JoinHostPort` output equality unconditionally before attempting the bind, so the IPv6 `t.Skip` gate cannot mask a construction regression — it only tolerates hosts without IPv6. `ServeHttp`'s use of the address is exercised by the existing `TestServeHttpLifecycle`.