### PR TITLE
feat: remove tdarr_scrape_duration_seconds metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,6 @@ Run `task --list` to see all available tasks.
 ## Breaking Updates
 | Version | Target Version | Description |
 | ------- | -------------- | ----------- |
-| `v3.0.X` | `v3.1.0` | `v3.1.0` removes the `tdarr_scrape_duration_seconds` metric. It reported the *previous* scrape's duration (the value was set after the response was already written) and duplicated a built-in — use Prometheus's own [`scrape_duration_seconds`](https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series) instead. Removed as a minor because the metric was broken and undocumented; no other metric changes. |
+| `v3.0.X` | `v3.1.0` | Removes the broken `tdarr_scrape_duration_seconds` metric (it reported the *previous* scrape's duration) — use Prometheus's built-in [`scrape_duration_seconds`](https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series). The Grafana dashboard's Scrape Duration panel is updated to use it. |
 | `v2.X.X` | `v3.0.0` | `v3.0.0` aligns all metrics with Prometheus naming/typing best practice. Many metrics are renamed/retyped and the `library_name` label moves to `tdarr_library_info`. See the [`v3.0.0` release notes](https://github.com/homeylab/tdarr-exporter/releases/tag/v3.0.0) for the full migration guide. |
 | `v1.X.X` | `v2.0.0` | `v2.0.0` introduces a considerable refactor of behavior and metrics. See the [`v2.0.0` release notes](https://github.com/homeylab/tdarr-exporter/releases/tag/v2.0.0) for all information. |

--- a/README.md
+++ b/README.md
@@ -165,5 +165,6 @@ Run `task --list` to see all available tasks.
 ## Breaking Updates
 | Version | Target Version | Description |
 | ------- | -------------- | ----------- |
+| `v3.0.X` | `v3.1.0` | `v3.1.0` removes the `tdarr_scrape_duration_seconds` metric. It reported the *previous* scrape's duration (the value was set after the response was already written) and duplicated a built-in — use Prometheus's own [`scrape_duration_seconds`](https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series) instead. Removed as a minor because the metric was broken and undocumented; no other metric changes. |
 | `v2.X.X` | `v3.0.0` | `v3.0.0` aligns all metrics with Prometheus naming/typing best practice. Many metrics are renamed/retyped and the `library_name` label moves to `tdarr_library_info`. See the [`v3.0.0` release notes](https://github.com/homeylab/tdarr-exporter/releases/tag/v3.0.0) for the full migration guide. |
 | `v1.X.X` | `v2.0.0` | `v2.0.0` introduces a considerable refactor of behavior and metrics. See the [`v2.0.0` release notes](https://github.com/homeylab/tdarr-exporter/releases/tag/v2.0.0) for all information. |

--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -607,7 +607,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "tdarr_scrape_duration_seconds{tdarr_instance=~\"$tdarr_instance\"}",
+              "expr": "scrape_duration_seconds * on (instance, job) group_left (tdarr_instance) group by (instance, job, tdarr_instance) (tdarr_up{tdarr_instance=~\"$tdarr_instance\"})",
               "instant": false,
               "legendFormat": "scrape duration",
               "range": true,

--- a/internal/collector/tdarr_golden_test.go
+++ b/internal/collector/tdarr_golden_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 // collectorMetricNames is the exhaustive list of metric families emitted by
-// TdarrCollector.Collect.  Metrics that come from internal/handlers/metrics.go
-// (tdarr_scrape_duration_seconds) are intentionally excluded so they cannot
-// influence the comparison.
+// TdarrCollector.Collect. The comparison is scoped to this allowlist so that
+// handler-level series registered elsewhere (the promhttp_metric_handler_*
+// counters from internal/handlers/metrics.go) cannot influence it.
 var collectorMetricNames = []string{
 	"tdarr_avg_num_streams",
 	"tdarr_files",

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -103,9 +103,11 @@ func TestMetricsHandler(t *testing.T) {
 	}
 
 	// First scrape. The promhttp_metric_handler_requests_total counter is incremented
-	// inside promhttp's InstrumentMetricHandler after the body is written, so it is
-	// not visible until a later scrape. The scrape_duration gauge is registered
-	// eagerly, so it (and the const label) is present immediately.
+	// inside promhttp's InstrumentMetricHandler after the body is written, so its
+	// count is not visible until a later scrape. But the handler series are all
+	// registered eagerly and pre-seeded to 0 — requests_total/requests_in_flight by
+	// InstrumentMetricHandler, errors_total because opts.Registry is set — so they
+	// (and the const label) are present immediately.
 	rec := doGet()
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -117,13 +119,8 @@ func TestMetricsHandler(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	for _, want := range []string{
-		"tdarr_scrape_duration_seconds",
-		`tdarr_instance="` + instance + `"`,
-	} {
-		if !strings.Contains(body, want) {
-			t.Fatalf("metrics body missing %q\nbody:\n%s", want, body)
-		}
+	if !strings.Contains(body, `tdarr_instance="`+instance+`"`) {
+		t.Fatalf("metrics body missing %q\nbody:\n%s", `tdarr_instance="`+instance+`"`, body)
 	}
 
 	// Second scrape: now the counter from the first request is exposed.

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -2,14 +2,10 @@ package handlers
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
-
-const METRIC_NAMESPACE = "tdarr"
 
 // MetricsHandler returns the promhttp handler for the registry. The handler's
 // own instrumentation counters are labeled with tdarr_instance to match the
@@ -17,30 +13,8 @@ const METRIC_NAMESPACE = "tdarr"
 // gathers the real metrics); only the handler-internal counters are wrapped.
 // Setting opts.Registry routes promhttp_metric_handler_errors_total through
 // instReg too (it is registered only when opts.Registry != nil).
-//
-// NOTE: the scrapDuration timing wrapper is preserved verbatim from the gin
-// version (DEPRECATED, off-by-one — reports the previous scrape). It is removed
-// in v4 (pre-v4 plan B1); do not alter or "fix" it here.
 func MetricsHandler(reg *prometheus.Registry, opts promhttp.HandlerOpts, tdarrInstance string) http.Handler {
-	// static metrics always present
-	// use promAuto to auto register with existing registry
-	scrapDuration := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Namespace:   METRIC_NAMESPACE,
-		Name:        "scrape_duration_seconds",
-		Help:        "Duration of the last scrape of metrics from exporter.",
-		ConstLabels: prometheus.Labels{"tdarr_instance": tdarrInstance},
-	})
-
 	instReg := prometheus.WrapRegistererWith(prometheus.Labels{"tdarr_instance": tdarrInstance}, reg)
 	opts.Registry = instReg
-	h := promhttp.InstrumentMetricHandler(instReg, promhttp.HandlerFor(reg, opts))
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-		// defer keeps the original (broken) semantics: Set runs after ServeHTTP,
-		// so it reports the previous scrape. Preserved intentionally until v4-B1.
-		defer func() { scrapDuration.Set(time.Since(start).Seconds()) }()
-		// promhttp serves back response
-		h.ServeHTTP(w, r)
-	})
+	return promhttp.InstrumentMetricHandler(instReg, promhttp.HandlerFor(reg, opts))
 }


### PR DESCRIPTION
## Changes
- `internal/handlers/metrics.go`: remove the `tdarr_scrape_duration_seconds` gauge, the `METRIC_NAMESPACE` const, the timing wrapper closure, and the now-unused `time`/`promauto` imports. `MetricsHandler` returns the promhttp handler directly. The registry wrap (`tdarr_instance` const label on promhttp's own counters via `WrapRegistererWith` + `opts.Registry`) is unchanged.
- `internal/handlers/handlers_test.go`: drop the `tdarr_scrape_duration_seconds` assertion from `TestMetricsHandler`. The `tdarr_instance` assertion is kept — on the first scrape the const label is now carried by the eagerly-registered, pre-seeded promhttp handler series (`requests_total`/`requests_in_flight`/`errors_total`) instead of the deleted gauge (verified empirically). Comment updated to reflect this.
- `internal/collector/tdarr_golden_test.go`: reword the exclusion comment (the metric no longer exists).
- `examples/dashboard.json`: migrate the "Scrape Duration" stat panel from `tdarr_scrape_duration_seconds` to Prometheus's built-in, joined through `tdarr_up` to keep the `$tdarr_instance` dropdown.
- `README.md`: add a Breaking Updates row (v3.0.X → v3.1.0).

Shipped as a **minor (v3.1.0)**: `feat:` with no `!` and no `BREAKING CHANGE:` footer, so release-please cuts a minor, not a major. The loud README row is the compensating control.

## Motivation
The gauge was `Set` in a `defer` that ran *after* the promhttp handler had already written the response body, so each scrape reported the **previous** scrape's duration — an off-by-one that cannot be fixed in place (a scrape's own duration is not known until after its body is sent). It also duplicated Prometheus's built-in `scrape_duration_seconds`. Broken and undocumented, so it is removed rather than fixed.

Precedent for removing a broken metric in a minor: node_exporter removed the bcache metrics in 1.6.0 (minor, `[CHANGE]` entry).

## Migration
Use Prometheus's built-in `scrape_duration_seconds` (target labels `job`/`instance`). To retain a `tdarr_instance`-aware view (as the shipped dashboard now does), join through `tdarr_up`:

```promql
scrape_duration_seconds
  * on (instance, job) group_left (tdarr_instance)
    group by (instance, job, tdarr_instance) (tdarr_up{tdarr_instance=~"$tdarr_instance"})
```

## Test plan
- `go test ./... -race -count=1` — all 6 packages pass; `go vet`, `go fmt`, `go mod tidy` clean.
- End-to-end: built the binary, scraped `/metrics` — `tdarr_scrape_duration_seconds` absent, endpoint returns 200, `promhttp_metric_handler_requests_total{...,tdarr_instance="..."}` still present.
- Dashboard PromQL verified on a live Prometheus (container scraping a containerized exporter): the exact panel expr returns the scrape duration with `tdarr_instance` attached, filters correctly by the `$tdarr_instance` regex, and still resolves when `tdarr_up=0` (dead upstream).

## In-depth
- The migrated panel uses the `group()` aggregation (`group by (...) (tdarr_up)`) so the right-hand side is `1` per `(instance, job, tdarr_instance)`; the `* group_left` join therefore returns the duration unchanged with `tdarr_instance` copied on, rather than multiplying by `tdarr_up`'s value. Accepted caveat: if the exporter target is fully down (not scraped at all), `tdarr_up` is absent and the panel series is hidden — a scraped-but-upstream-down exporter (`tdarr_up=0`) still shows, since `group()` yields 1 regardless of value.
- `examples/archive/` snapshots are intentionally left untouched (historical).