### PR TITLE
fix: reject malformed prometheus_path before ServeMux registration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -198,13 +200,33 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 	if port, err := strconv.ParseUint(*promPort, 10, 16); err != nil || port == 0 {
 		return Config{}, fmt.Errorf("prometheus_port must be an integer between 1 and 65535, got %q", *promPort)
 	}
-	// The http.ServeMux (internal/server/server.go) registers PrometheusPath,
-	// "/{$}" (index) and "/healthz". A PrometheusPath of "/" collides with the
-	// index pattern and "/healthz" duplicates that route; ServeMux panics at
-	// registration on a duplicate pattern. Reject at startup instead.
+	// PrometheusPath is spliced into an http.ServeMux pattern ("GET "+path) at
+	// registration (internal/server/server.go, which also hardcodes "/{$}" for
+	// the index and "/healthz"). ServeMux panics at registration on several
+	// malformed patterns, so validate here to fail cleanly at startup instead
+	// of crashing the ServeHttp goroutine. Keep the reserved list below in sync
+	// with those hardcoded routes.
 	if !strings.HasPrefix(*promPath, "/") {
 		return Config{}, fmt.Errorf("prometheus_path must start with '/', got %q", *promPath)
 	}
+	// '{'/'}' are ServeMux wildcard metacharacters and whitespace splits the
+	// pattern string; any of them makes registration panic (e.g. "/metrics/{")
+	// or silently register a wildcard route (e.g. "/{id}"). None are valid in a
+	// metrics path, so reject them outright.
+	if strings.ContainsFunc(*promPath, func(r rune) bool {
+		return r == '{' || r == '}' || unicode.IsSpace(r)
+	}) {
+		return Config{}, fmt.Errorf("prometheus_path %q must not contain '{', '}', or whitespace", *promPath)
+	}
+	// ServeMux also panics on an unclean pattern path (".", ".." or "//"
+	// segments, e.g. "/metrics//foo" or "/foo/.."). Require a canonical path;
+	// path.Clean also strips a trailing slash, so "/metrics/" is rejected in
+	// favor of "/metrics".
+	if *promPath != path.Clean(*promPath) {
+		return Config{}, fmt.Errorf("prometheus_path %q must be a clean path (no '.', '..', '//', or trailing slash)", *promPath)
+	}
+	// Each built-in route (index at "/", "/healthz") already claims its path; a
+	// PrometheusPath equal to one collides and panics ServeMux at registration.
 	if *promPath == "/" || *promPath == "/healthz" {
 		return Config{}, fmt.Errorf("prometheus_path %q conflicts with a reserved exporter route", *promPath)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -338,9 +338,18 @@ func TestPrometheusPathValidation(t *testing.T) {
 	}{
 		{"default ok", "/metrics", false},
 		{"custom ok", "/prom", false},
+		{"nested path ok", "/foo/bar", false},
 		{"no leading slash", "metrics", true},
 		{"root conflicts with index route", "/", true},
 		{"healthz conflicts with reserved route", "/healthz", true},
+		{"malformed wildcard open brace", "/metrics/{", true},
+		{"wildcard segment", "/{id}", true},
+		{"anchor pattern", "/{$}", true},
+		{"whitespace in path", "/met rics", true},
+		{"double slash", "/metrics//foo", true},
+		{"dot-dot segment", "/foo/..", true},
+		{"dot segment", "/./", true},
+		{"trailing slash", "/metrics/", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,8 @@ func ServeHttp(wg *sync.WaitGroup, registry *prometheus.Registry, runConfig Http
 	defer wg.Done()
 	mux := http.NewServeMux()
 	mux.Handle("GET "+runConfig.PrometheusPath, handlers.MetricsHandler(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}, runConfig.TdarrInstance))
+	// These hardcoded routes are the "reserved" set that config.go rejects for
+	// prometheus_path; keep the two in sync.
 	mux.Handle("GET /{$}", handlers.IndexHandler())
 	mux.Handle("GET /healthz", handlers.HealthzHandler())
 	// Fallback for everything else (gin's old NoRoute behavior).


### PR DESCRIPTION
## Changes
- `internal/config/config.go`: validate `prometheus_path` at config load. In addition to the existing leading-slash and reserved-route (`/`, `/healthz`) checks, reject:
  - `{`, `}` (Go 1.22+ ServeMux wildcard metacharacters) and any whitespace (splits the pattern string).
  - Unclean paths — `*promPath != path.Clean(*promPath)`, which covers `//`, `.`/`..` segments, and (as a side effect of `path.Clean`) a trailing slash.
- `internal/config/config_test.go`: add cases to `TestPrometheusPathValidation` — `/metrics/{`, `/{id}`, `/{$}`, `/met rics`, `/metrics//foo`, `/foo/..`, `/./`, `/metrics/` (all rejected), plus `/foo/bar` (allowed).
- `internal/server/server.go`: comment only — a cross-reference noting the hardcoded `/{$}` and `/healthz` routes are the reserved set `config.go` rejects, so the two stay in sync.

## Motivation
`prometheus_path` (operator config: `-prometheus_path` flag / `PROMETHEUS_PATH` env) is spliced into an `http.ServeMux` pattern at registration: `mux.Handle("GET "+PrometheusPath, ...)`. On Go 1.22+ several values crash the exporter at startup:

- `/metrics/{`, `/{$}` → `mux.Handle` **panics** (malformed pattern).
- `/{id}` → silently registers a **wildcard route**, so `/metrics` stops working with no error.
- `/metrics//foo`, `/foo/..`, `/./`, `//` → **panic** (`ServeMux` rejects unclean pattern paths).

The panic fires inside the `ServeHttp` goroutine, which has no `recover`, so the whole process crashes with a stack trace at boot — unlike every other config field (port, url, path-prefix), which fails with a clean startup error. This makes `prometheus_path` validation consistent with the rest of config.

Not remotely reachable — it requires an operator to supply the bad value; no HTTP request can trigger it.

## Test plan
- `go test ./... -race -count=1` — all packages pass; `go vet`, `go fmt`, `go mod tidy` clean.
- End-to-end on the built binary: `-prometheus_path` values `/metrics/{`, `/{id}`, `/{$}`, `/met rics`, `/metrics//foo`, `/foo/..`, `/./`, `//` all now exit 1 with a clear config error and **zero panics** (pre-fix, the `{`/unclean cases panicked the process). Reserved `/` and `/healthz` still rejected. A valid custom path (`/custommetrics`) serves 200; `/healthz`, `/` (index), and unknown→404 all still route correctly.

## In-depth
- Validation is the whole fix — no attempt to `recover` around registration. Failing at config load is consistent with the other fields and gives the operator an actionable message.
- Percent-encoded (`/metrics%`, `/foo/%2e%2e`) and non-ASCII (`/naïve`) paths are intentionally **allowed** — `ServeMux` treats them as opaque literal segments and registers them without panic, so they are not rejected.
- Check order is leading-slash → metacharacter/whitespace → unclean → reserved, so each bad input gets the most specific error (e.g. a braced path reports the metacharacter rule, not a generic "unclean").
- The reserved-route list stays inlined in both `config.go` and `server.go` with reciprocal cross-reference comments. A shared `internal/routes` package was prototyped and dropped as over-engineering for two string literals (only `/healthz` is truly shared; the index is a `/{$}`-pattern-vs-`/`-path pairing).