### PR TITLE
docs: GiB inference caveat; refactor: split prometheus_path validation

### DIFF
--- a/docs/metrics-internals.md
+++ b/docs/metrics-internals.md
@@ -150,6 +150,13 @@ Verified: transcoding a net-shrunk file moves the value up. Corroborated by
 plugin behavior — a pure stream-remover library trends positive, while a
 library that adds tracks (e.g. an AC3 5.1 audio add) trends negative.
 
+Note: `sizeDiff` arrives already converted to GB-scale (e.g. `225.95`), so we
+never see Tdarr's raw byte count. The exporter multiplies back by 1024³ (binary
+GiB), but Tdarr may use decimal GB (1000³) — a ~7% difference we cannot tell
+apart from the value alone. Tdarr's core is closed-source, so this is unverified
+from code; it could be settled by transcoding a file of known size and backing
+out the factor. Until then, treat `size_diff_bytes` as accurate to ~±7%.
+
 ## Stream stats and the bit-rate unit exception
 
 `tdarr_stream_stats_duration_seconds`, `tdarr_stream_stats_bit_rate`, and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,14 +209,15 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 	if !strings.HasPrefix(*promPath, "/") {
 		return Config{}, fmt.Errorf("prometheus_path must start with '/', got %q", *promPath)
 	}
-	// '{'/'}' are ServeMux wildcard metacharacters and whitespace splits the
-	// pattern string; any of them makes registration panic (e.g. "/metrics/{")
-	// or silently register a wildcard route (e.g. "/{id}"). None are valid in a
-	// metrics path, so reject them outright.
-	if strings.ContainsFunc(*promPath, func(r rune) bool {
-		return r == '{' || r == '}' || unicode.IsSpace(r)
-	}) {
-		return Config{}, fmt.Errorf("prometheus_path %q must not contain '{', '}', or whitespace", *promPath)
+	// '{' and '}' are ServeMux wildcard metacharacters: they make registration
+	// panic (e.g. "/metrics/{") or silently register a wildcard route (e.g.
+	// "/{id}"). Neither is valid in a metrics path.
+	if strings.ContainsAny(*promPath, "{}") {
+		return Config{}, fmt.Errorf("prometheus_path %q must not contain '{' or '}'", *promPath)
+	}
+	// Whitespace splits the "GET "+path pattern string, so registration panics.
+	if strings.ContainsFunc(*promPath, unicode.IsSpace) {
+		return Config{}, fmt.Errorf("prometheus_path %q must not contain whitespace", *promPath)
 	}
 	// ServeMux also panics on an unclean pattern path (".", ".." or "//"
 	// segments, e.g. "/metrics//foo" or "/foo/.."). Require a canonical path;


### PR DESCRIPTION
Two small, non-releasing changes (one commit each).

## Changes
- **`docs:`** — `docs/metrics-internals.md`, Size-diff sign convention section: note that `sizeDiff` arrives from Tdarr already converted to GB-scale, so the exporter never sees the raw byte count. It multiplies back by 1024³ (binary GiB), but Tdarr may use decimal GB (1000³) — a ~7% difference indistinguishable from the value alone. Tdarr's core is closed-source, so this is unverified from code (could be settled by transcoding a known-size file and backing out the factor); until then treat `size_diff_bytes` as accurate to ~±7%.
- **`refactor:`** — `internal/config/config.go`, `prometheus_path` validation: split the single `ContainsFunc` closure (which mixed explicit `{`/`}` comparison with a `unicode.IsSpace` predicate) into `strings.ContainsAny(*promPath, "{}")` for the brace set and `strings.ContainsFunc(*promPath, unicode.IsSpace)` for whitespace, each with its own targeted error message.

## Motivation
- The GiB note closes a documented-inference gap in the size-metric semantics writeup and tells the reader how to resolve it.
- The validation split reads more clearly (no mixed-style predicate) and gives the operator a specific error — `must not contain '{' or '}'` vs `must not contain whitespace` — instead of a lumped message. Follow-up polish on the T11 validation added in #111.

## Test plan
- `go test ./... -race -count=1` — all packages pass; `go vet`, `go fmt`, `go mod tidy` clean.
- Behavior of the refactor is unchanged (same inputs rejected). Verified end-to-end on the built binary: `-prometheus_path /{id}` → exit 1, `must not contain '{' or '}'`; `/met rics` → exit 1, `must not contain whitespace`; `/foo/..` → exit 1, clean-path error; all with zero panics.

## In-depth
- Both commits are intentionally kept separate (Conventional Commits): `docs:` and `refactor:` are both non-releasing, so this PR does not trigger a release-please version bump.
- No functional change to what `prometheus_path` accepts or rejects — this is purely message specificity and readability on top of the #111 crash fix.