### PR TITLE
feat: add response status to request log; harden Recovery middleware

### DIFF
--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -166,27 +166,6 @@ func counterValue(t *testing.T, body, instance string) float64 {
 	return -1
 }
 
-func TestRequestLoggerPassesThrough(t *testing.T) {
-	t.Parallel()
-
-	const wantBody = "logger-passthrough-body"
-	h := RequestLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusTeapot)
-		_, _ = w.Write([]byte(wantBody))
-	}))
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
-	h.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusTeapot {
-		t.Fatalf("status = %d, want %d (RequestLogger altered status)", rec.Code, http.StatusTeapot)
-	}
-	if rec.Body.String() != wantBody {
-		t.Fatalf("body = %q, want %q (RequestLogger altered body)", rec.Body.String(), wantBody)
-	}
-}
-
 // TestMetricsHandler_PromhttpInstrumented verifies P2.3: the standard
 // promhttp_metric_handler_* series are emitted and carry the tdarr_instance label
 // (injected via WrapRegistererWith). requests_total is incremented in a deferred
@@ -258,21 +237,5 @@ func TestMetricsHandler_ContinueOnError_Serves200OnGatherError(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (ContinueOnError must not 500 on a Gather error)", rec.Code)
-	}
-}
-
-// TestRecoveryConvertsPanicTo500 verifies the Recovery middleware converts a
-// handler panic into a 500 response instead of crashing the connection
-// (replaces gin.Recovery's equivalent behavior).
-func TestRecoveryConvertsPanicTo500(t *testing.T) {
-	t.Parallel()
-
-	h := Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		panic("boom")
-	}))
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("status: want 500, got %d", rec.Code)
 	}
 }

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -7,15 +7,61 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// RequestLogger debug-logs each request with method, URI, proto and duration.
+// responseRecorder wraps http.ResponseWriter to capture the status code and
+// whether anything was written. Unwrap exposes the underlying writer to
+// http.ResponseController (Go 1.20+) so Flush/Hijack/etc. still reach it; we
+// deliberately do NOT hand-implement Flusher/Hijacker/ReaderFrom, because faking
+// an interface the underlying writer may not support is a footgun and the
+// handlers here need none of them.
+type responseRecorder struct {
+	http.ResponseWriter
+	status int
+	wrote  bool
+}
+
+// newResponseRecorder seeds status with 200: net/http sends an implicit 200 when
+// a handler returns without ever calling WriteHeader, so that is the status the
+// client actually sees and the one the access log should report.
+func newResponseRecorder(w http.ResponseWriter) *responseRecorder {
+	return &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+}
+
+// WriteHeader and Write record the status/wrote state only AFTER forwarding
+// succeeds, so if the underlying writer panics (e.g. net/http rejecting an
+// out-of-range status code) nothing was committed, wrote stays false, and
+// Recovery still emits a clean 500 rather than a bare implicit 200.
+func (r *responseRecorder) WriteHeader(code int) {
+	r.ResponseWriter.WriteHeader(code)
+	if !r.wrote {
+		r.status = code
+		r.wrote = true
+	}
+}
+
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	n, err := r.ResponseWriter.Write(b)
+	if !r.wrote {
+		r.status = http.StatusOK
+		r.wrote = true
+	}
+	return n, err
+}
+
+func (r *responseRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}
+
+// RequestLogger debug-logs each request with method, URI, proto, status and duration.
 func RequestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := newResponseRecorder(w)
 		t := time.Now()
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(rec, r)
 		log.Debug().
 			Str("method", r.Method).
 			Str("request_uri", r.RequestURI).
 			Str("proto", r.Proto).
+			Int("status", rec.status).
 			Float64("duration_seconds", time.Since(t).Seconds()).
 			Msg("Incoming request")
 	})
@@ -26,12 +72,20 @@ func RequestLogger(next http.Handler) http.Handler {
 // its own scrape-path recover that degrades to tdarr_up=0).
 func Recovery(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorder := newResponseRecorder(w)
 		defer func() {
 			if rec := recover(); rec != nil {
+				if rec == http.ErrAbortHandler {
+					// stdlib's sanctioned connection-abort signal; net/http
+					// handles it, so let it continue unwinding.
+					panic(rec)
+				}
 				log.Error().Interface("panic", rec).Str("request_uri", r.RequestURI).Msg("Panic in HTTP handler")
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				if !recorder.wrote {
+					http.Error(recorder, "Internal Server Error", http.StatusInternalServerError)
+				}
 			}
 		}()
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(recorder, r)
 	})
 }

--- a/internal/handlers/middleware_test.go
+++ b/internal/handlers/middleware_test.go
@@ -1,0 +1,263 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestRequestLogger_ForwardsResponseUnchanged verifies RequestLogger is
+// transparent: it must not alter the status or body the wrapped handler
+// produces, for both a default 200 and an explicit non-200 status.
+func TestRequestLogger_ForwardsResponseUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name: "implicit 200",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("ok-body"))
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   "ok-body",
+		},
+		{
+			name: "explicit 404",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte("not-found-body"))
+			},
+			wantStatus: http.StatusNotFound,
+			wantBody:   "not-found-body",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := RequestLogger(http.HandlerFunc(tc.handler))
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if rec.Body.String() != tc.wantBody {
+				t.Fatalf("body = %q, want %q", rec.Body.String(), tc.wantBody)
+			}
+		})
+	}
+}
+
+// TestResponseRecorder_ImplicitStatusOnWrite verifies that calling Write
+// without a prior WriteHeader records an implicit 200 and flips wrote to true.
+func TestResponseRecorder_ImplicitStatusOnWrite(t *testing.T) {
+	t.Parallel()
+
+	underlying := httptest.NewRecorder()
+	rec := &responseRecorder{ResponseWriter: underlying}
+
+	if rec.wrote {
+		t.Fatalf("wrote = true before any write, want false")
+	}
+
+	const body = "hello"
+	n, err := rec.Write([]byte(body))
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if n != len(body) {
+		t.Fatalf("Write returned n = %d, want %d", n, len(body))
+	}
+	if !rec.wrote {
+		t.Fatalf("wrote = false after Write, want true")
+	}
+	if rec.status != http.StatusOK {
+		t.Fatalf("status = %d, want %d (implicit 200)", rec.status, http.StatusOK)
+	}
+	if underlying.Body.String() != body {
+		t.Fatalf("underlying body = %q, want %q (Write not forwarded)", underlying.Body.String(), body)
+	}
+}
+
+// TestResponseRecorder_DefaultStatusIsOK verifies a recorder from
+// newResponseRecorder reports 200 before any write, matching net/http's implicit
+// 200 for a handler that returns without calling WriteHeader.
+func TestResponseRecorder_DefaultStatusIsOK(t *testing.T) {
+	t.Parallel()
+
+	rec := newResponseRecorder(httptest.NewRecorder())
+	if rec.status != http.StatusOK {
+		t.Fatalf("default status = %d, want %d", rec.status, http.StatusOK)
+	}
+	if rec.wrote {
+		t.Fatalf("wrote = true before any write, want false")
+	}
+}
+
+// TestResponseRecorder_ExplicitWriteHeader verifies WriteHeader records the
+// given code, flips wrote to true, and forwards the call to the underlying
+// writer.
+func TestResponseRecorder_ExplicitWriteHeader(t *testing.T) {
+	t.Parallel()
+
+	underlying := httptest.NewRecorder()
+	rec := &responseRecorder{ResponseWriter: underlying}
+
+	rec.WriteHeader(http.StatusTeapot)
+
+	if !rec.wrote {
+		t.Fatalf("wrote = false after WriteHeader, want true")
+	}
+	if rec.status != http.StatusTeapot {
+		t.Fatalf("status = %d, want %d", rec.status, http.StatusTeapot)
+	}
+	if underlying.Code != http.StatusTeapot {
+		t.Fatalf("underlying recorder code = %d, want %d (WriteHeader not forwarded)", underlying.Code, http.StatusTeapot)
+	}
+}
+
+// TestResponseRecorder_FirstStatusWins verifies that a second WriteHeader
+// call does not overwrite the recorded status (mirrors stdlib's own
+// superfluous-WriteHeader semantics, which the recorder must not suppress).
+func TestResponseRecorder_FirstStatusWins(t *testing.T) {
+	t.Parallel()
+
+	underlying := httptest.NewRecorder()
+	rec := &responseRecorder{ResponseWriter: underlying}
+
+	rec.WriteHeader(http.StatusTeapot)
+	rec.WriteHeader(http.StatusInternalServerError)
+
+	if rec.status != http.StatusTeapot {
+		t.Fatalf("status = %d, want %d (first WriteHeader call should win)", rec.status, http.StatusTeapot)
+	}
+}
+
+// TestResponseRecorder_Unwrap verifies Unwrap returns the exact underlying
+// writer instance, so http.ResponseController can reach Flush/Hijack/etc.
+func TestResponseRecorder_Unwrap(t *testing.T) {
+	t.Parallel()
+
+	underlying := httptest.NewRecorder()
+	rec := &responseRecorder{ResponseWriter: underlying}
+
+	if got := rec.Unwrap(); got != http.ResponseWriter(underlying) {
+		t.Fatalf("Unwrap() = %v, want the underlying writer %v", got, underlying)
+	}
+}
+
+// TestRecovery_PanicWithoutWrite_Returns500 verifies a handler that panics
+// before writing anything is converted into a 500 with an explanatory body.
+func TestRecovery_PanicWithoutWrite_Returns500(t *testing.T) {
+	t.Parallel()
+
+	h := Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	if !strings.Contains(rec.Body.String(), "Internal Server Error") {
+		t.Fatalf("body = %q, want it to contain %q", rec.Body.String(), "Internal Server Error")
+	}
+}
+
+// TestRecovery_PanicAfterWrite_DoesNotAppend500 verifies that once a handler
+// has already started a response (status + body written), a subsequent panic
+// must not append a 500 on top of it.
+func TestRecovery_PanicAfterWrite_DoesNotAppend500(t *testing.T) {
+	t.Parallel()
+
+	const wantBody = "partial-body"
+	h := Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(wantBody))
+		panic("boom-after-write")
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (500 must not be appended after the response started)", rec.Code, http.StatusOK)
+	}
+	if rec.Body.String() != wantBody {
+		t.Fatalf("body = %q, want %q (unchanged)", rec.Body.String(), wantBody)
+	}
+	if strings.Contains(rec.Body.String(), "Internal Server Error") {
+		t.Fatalf("body = %q, must not contain %q", rec.Body.String(), "Internal Server Error")
+	}
+}
+
+// TestRecovery_PanicAfterWrite_ThroughRequestLogger exercises the real
+// production composition Recovery(RequestLogger(h)): the inner RequestLogger
+// recorder must forward the handler's write through to the outer Recovery
+// recorder so Recovery sees wrote=true and suppresses the 500 append.
+func TestRecovery_PanicAfterWrite_ThroughRequestLogger(t *testing.T) {
+	t.Parallel()
+
+	const wantBody = "partial-body"
+	h := Recovery(RequestLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(wantBody))
+		panic("boom-after-write")
+	})))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (500 must not be appended through the double wrap)", rec.Code, http.StatusOK)
+	}
+	if rec.Body.String() != wantBody {
+		t.Fatalf("body = %q, want %q (unchanged)", rec.Body.String(), wantBody)
+	}
+	if strings.Contains(rec.Body.String(), "Internal Server Error") {
+		t.Fatalf("body = %q, must not contain %q", rec.Body.String(), "Internal Server Error")
+	}
+}
+
+// TestRecovery_ErrAbortHandlerRePanics verifies http.ErrAbortHandler is
+// re-panicked rather than converted to a 500 — it is stdlib's sanctioned
+// connection-abort signal and net/http itself handles it.
+func TestRecovery_ErrAbortHandlerRePanics(t *testing.T) {
+	t.Parallel()
+
+	h := Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	rePanicked := false
+	func() {
+		defer func() {
+			p := recover()
+			if p == nil {
+				return
+			}
+			if p == http.ErrAbortHandler { //nolint:errorlint // sentinel identity check, matches middleware.go
+				rePanicked = true
+				return
+			}
+			t.Fatalf("recovered unexpected value: %v", p)
+		}()
+		h.ServeHTTP(rec, req)
+	}()
+
+	if !rePanicked {
+		t.Fatalf("Recovery did not re-panic http.ErrAbortHandler")
+	}
+}


### PR DESCRIPTION
## Changes

Batches two middleware improvements in `internal/handlers/middleware.go`, both built on one shared `responseRecorder` wrapper.

- **`responseRecorder`** — wraps `http.ResponseWriter`, capturing the first status code and whether anything was written. `Unwrap()` exposes the underlying writer to `http.ResponseController` (Go 1.20+) so `Flush`/`Hijack`/etc. still reach it. It deliberately does **not** hand-implement `Flusher`/`Hijacker`/`ReaderFrom`: promhttp detects those by direct type assertion and the metrics handler needs none of them, so faking an interface the underlying writer may not support would be a footgun. Status seeds to `200` (net/http's implicit status when a handler returns without calling `WriteHeader`).
- **T13 — `RequestLogger`** now includes the response `status` in its debug access log (alongside method, request_uri, proto, duration).
- **T16 — `Recovery` hardening:**
  - re-panics `http.ErrAbortHandler` instead of swallowing it into a 500 — it is the stdlib's sanctioned connection-abort signal that net/http itself handles;
  - writes the 500 **only if nothing has been written yet**, so a handler that panics mid-response no longer gets `Internal Server Error` appended to a partial body (and no `superfluous response.WriteHeader` log).

Each middleware wraps independently (two thin wraps compose in the `Recovery(RequestLogger(mux))` chain) so each stays self-contained and independently testable.

Removes two tests from `handlers_test.go` (`TestRequestLoggerPassesThrough`, `TestRecoveryConvertsPanicTo500`) now superseded by broader coverage in the new `middleware_test.go`.

## Motivation

- Response status is the single most useful field missing from the access log when debugging (distinguishing a 200 scrape from a 404/500 at a glance).
- The `Recovery` behaviors were latent bugs surfaced by the post-v3 review: swallowing `http.ErrAbortHandler` defeats the stdlib's abort contract, and appending a 500 after a partial write corrupts the response. Impact is low today (handlers are simple; promhttp uses `ContinueOnError` and does not panic), so this is hardening, not a live-incident fix.

## Test plan

New `internal/handlers/middleware_test.go` (all via `net/http/httptest`):
- `responseRecorder`: default-200 before any write; implicit-200 on `Write`; explicit code via `WriteHeader`; first-status-wins on double `WriteHeader`; `Unwrap` identity.
- `RequestLogger`: response passthrough unchanged for 200 and 404.
- `Recovery`: panic-without-write → 500 + body; panic-after-write → no 500 appended; panic-after-write through the real `Recovery(RequestLogger(...))` double wrap → no 500 appended; `http.ErrAbortHandler` → re-panics rather than converting to 500.

Verified: `gofmt` clean, `go mod tidy` clean, `go vet` ok, `golangci-lint` 0 issues, `go test ./... -race` all pass. Live smoke: ran the exporter with `LOG_LEVEL=debug`, hit `/healthz`, an unknown route, and `/` — access log correctly reported `status:200`, `status:404`, `status:200`.

## In-depth

The wrapper intentionally sheds `Flusher`/`Hijacker`/`ReaderFrom` rather than hand-forwarding them. promhttp's `newDelegator` selects a delegator by asserting the interfaces present on the writer it receives; since the metrics handler writes a single buffered response (gzip close flushes through `Write`, no streaming/hijack/sendfile), presenting as a plain `ResponseWriter` is correct and avoids advertising capabilities the wrapper can't honor. Future streaming/SSE/hijacking handlers placed behind these middlewares would lose those capabilities through promhttp-style assertions — worth noting if such a handler is ever added.
