### PR TITLE
fix: exit 128+signum on force-quit instead of 1

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -80,8 +80,9 @@ func run() int {
 	// yields a non-zero exit code.
 	exitCode := awaitShutdown(quitServer, errHttpChan)
 	go func() {
-		<-quitServer
-		log.Fatal().Msg("Killing app on 2nd forced interrupt...")
+		sig := <-quitServer
+		log.Error().Str("signal", sig.String()).Msg("Forcing immediate shutdown on signal")
+		os.Exit(forcedExitCode(sig))
 	}()
 	// Abort any in-flight scrape before tearing down the HTTP server.
 	cancelScrapes()
@@ -105,6 +106,19 @@ func buildRegistry(instanceName string, tdarrCollector prometheus.Collector) *pr
 		registry,
 	).MustRegister(versioncollector.NewCollector("tdarr_exporter"))
 	return registry
+}
+
+// forcedExitCode maps a signal to the conventional 128+signum exit code that
+// shells, Docker, and Kubernetes report for a signal-terminated process (SIGINT
+// -> 130, SIGTERM -> 143). This keeps a force-quit distinguishable from
+// awaitShutdown's exit 1, which means "HTTP server error". The fallback is
+// unreachable for the signals registered above on this unix build (all are
+// syscall.Signal); it exists only to keep the mapping total.
+func forcedExitCode(sig os.Signal) int {
+	if s, ok := sig.(syscall.Signal); ok {
+		return 128 + int(s)
+	}
+	return 1
 }
 
 // awaitShutdown blocks until either an OS signal or a fatal HTTP server error

--- a/cmd/exporter/main_test.go
+++ b/cmd/exporter/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -39,6 +40,54 @@ func TestAwaitShutdown(t *testing.T) {
 		}
 	})
 }
+
+// TestForcedExitCode verifies the force-quit path maps each shutdown signal to
+// its conventional 128+signum exit code, so a double-interrupt is reported as a
+// signal death (e.g. 130 for SIGINT) rather than colliding with awaitShutdown's
+// exit 1 (HTTP server error). The os.Exit call itself is inherently untestable;
+// this guards the arithmetic it feeds.
+func TestForcedExitCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sig  os.Signal
+		want int
+	}{
+		{"SIGINT", syscall.SIGINT, 130},
+		{"SIGTERM", syscall.SIGTERM, 143},
+		{"SIGHUP", syscall.SIGHUP, 129},
+		{"SIGQUIT", syscall.SIGQUIT, 131},
+		{"os.Interrupt", os.Interrupt, 130},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := forcedExitCode(tc.sig); got != tc.want {
+				t.Errorf("forcedExitCode(%v) = %d, want %d", tc.sig, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestForcedExitCode_NonSyscallSignalFallsBack verifies a signal that is not a
+// syscall.Signal falls back to 1. Unreachable for the registered signals on this
+// unix build, but the mapping must stay total.
+func TestForcedExitCode_NonSyscallSignalFallsBack(t *testing.T) {
+	t.Parallel()
+
+	if got := forcedExitCode(fakeSignal{}); got != 1 {
+		t.Errorf("forcedExitCode(non-syscall signal) = %d, want 1", got)
+	}
+}
+
+// fakeSignal is an os.Signal that is not a syscall.Signal, used to exercise the
+// forcedExitCode fallback branch.
+type fakeSignal struct{}
+
+func (fakeSignal) String() string { return "fake" }
+func (fakeSignal) Signal()        {}
 
 // TestBuildInfoCarriesInstanceLabel verifies tdarr_exporter_build_info is
 // registered through the tdarr_instance-labeled registerer (mirroring run()),


### PR DESCRIPTION
## Changes

- Force-quit (second-interrupt) path now exits with `128+signum` (SIGINT → 130, SIGTERM → 143, SIGHUP → 129, SIGQUIT → 131) instead of `os.Exit(1)` via `log.Fatal`.
- Extract `forcedExitCode(os.Signal) int` as a testable seam with a table test. The `os.Exit` call itself is inherently untestable; the test guards the arithmetic feeding it.
- Reword the force-quit log line from "Killing app on 2nd forced interrupt..." to "Forcing immediate shutdown on signal". The old wording was inaccurate on the error-shutdown path, where `awaitShutdown` returns via the server-error channel and the parked goroutine's `<-quitServer` is satisfied by the *first* signal.

## Motivation

`awaitShutdown` documents a contract: exit `0` = signal shutdown, exit `1` = HTTP server error. The old force-quit path used `log.Fatal` (`os.Exit(1)`), so a double Ctrl-C was reported identically to a server crash. `128+signum` is the conventional signal-death code and restores the distinction.

## In-depth

- **Precedent**: this is byte-for-byte moby/dockerd's `Trap` pattern (`os.Exit(128 + int(sig.(syscall.Signal)))`) — the closest analogue (long-running daemon, commonly PID 1 in a container). The ecosystem splits three ways: no force path (prometheus, node_exporter, containerd, etcd), `os.Exit(1)` (k8s, nomad), and `128+signum` (dockerd).
- **Why not re-raise-to-self** (etcd `pkg/osutil` style, `signal.Reset` + `syscall.Kill(getpid, sig)`): at PID 1 (this exporter's normal distroless deployment) the kernel discards a self-signal with no handler installed, so it degenerates to `os.Exit(128+signum)` plus dead machinery. The observed exit code is identical either way — runc's `ExitStatus` collapses `WIFSIGNALED` and a plain `os.Exit(128+n)` to the same number for Docker/k8s, and bash reports `128+N` for both.
- **`forcedExitCode` fallback** (`return 1`) is unreachable for the registered signals on this unix-only build (all are `syscall.Signal`); kept to keep the mapping total, and covered by a test.

## Test plan

- `task ci` gates pass locally: `gofmt` clean, `go vet` clean, `go test ./... -race`, golangci-lint 0 issues.
- New `TestForcedExitCode` table test: SIGINT→130, SIGTERM→143, SIGHUP→129, SIGQUIT→131, os.Interrupt→130; plus a non-`syscall.Signal` fallback→1 case.
- Manual e2e: booted the binary and sent interrupts. Normal graceful shutdown still exits `0` (no regression). The force path (exit `130`) is a safety net for a pathological hung shutdown and can't be triggered deterministically from outside — shutdown intentionally aborts in-flight scrapes (`cancelScrapes()` before teardown), so graceful shutdown always completes before the force goroutine's `<-quitServer` can win. Its arithmetic is unit-tested; the wiring is `os.Exit(forcedExitCode(sig))`.