### PR TITLE
fix: link landing page and 404 hint to configured prometheus_path

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -81,7 +81,7 @@ func run() int {
 	exitCode := awaitShutdown(quitServer, errHttpChan)
 	go func() {
 		sig := <-quitServer
-		log.Error().Str("signal", sig.String()).Msg("Forcing immediate shutdown on signal")
+		log.Warn().Str("signal", sig.String()).Msg("Forcing immediate shutdown on signal")
 		os.Exit(forcedExitCode(sig))
 	}()
 	// Abort any in-flight scrape before tearing down the HTTP server.
@@ -114,6 +114,11 @@ func buildRegistry(instanceName string, tdarrCollector prometheus.Collector) *pr
 // awaitShutdown's exit 1, which means "HTTP server error". The fallback is
 // unreachable for the signals registered above on this unix build (all are
 // syscall.Signal); it exists only to keep the mapping total.
+//
+// These codes (129-143) intentionally exceed os.Exit's documented portable
+// range [0, 125]: mimicking signal death is the whole point, and on the only
+// shipped platforms (linux/amd64, linux/arm64) exit status is 8-bit, so no
+// registered signal wraps mod 256 (max 143).
 func forcedExitCode(sig os.Signal) int {
 	if s, ok := sig.(syscall.Signal); ok {
 		return 128 + int(s)

--- a/internal/handlers/index.go
+++ b/internal/handlers/index.go
@@ -2,13 +2,19 @@ package handlers
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 )
 
-// IndexHandler serves the landing page at '/'.
-func IndexHandler() http.Handler {
+// IndexHandler serves the landing page at '/', linking to the metrics endpoint
+// at its configured path (metricsPath) rather than a hardcoded '/metrics', so
+// the link stays correct when prometheus_path is customized. The path is
+// html-escaped defensively before interpolation into the anchor.
+func IndexHandler(metricsPath string) http.Handler {
+	link := html.EscapeString(metricsPath)
+	body := fmt.Sprintf(`<h1>tdarr-exporter</h1><p><a href='%s'>metrics</a></p>`, link)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprint(w, `<h1>tdarr-exporter</h1><p><a href='/metrics'>metrics</a></p>`)
+		_, _ = fmt.Fprint(w, body)
 	})
 }

--- a/internal/handlers/index_test.go
+++ b/internal/handlers/index_test.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestIndexHandler verifies the landing page links to the configured metrics
+// path (not a hardcoded '/metrics') and html-escapes it before interpolation.
+func TestIndexHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		metricsPath string
+		wantLink    string
+	}{
+		{"default path", "/metrics", `href='/metrics'`},
+		{"custom path", "/custom-metrics", `href='/custom-metrics'`},
+		{"path with html-significant char is escaped", "/a'b", `href='/a&#39;b'`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			IndexHandler(tc.metricsPath).ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+			}
+			body := rec.Body.String()
+			if !strings.Contains(body, tc.wantLink) {
+				t.Errorf("body = %q, want it to contain %q", body, tc.wantLink)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,7 +31,7 @@ func newMux(runConfig HttpServerConfig, registry *prometheus.Registry) http.Hand
 	mux.Handle("GET "+runConfig.PrometheusPath, handlers.MetricsHandler(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}, runConfig.TdarrInstance))
 	// These hardcoded routes are the "reserved" set that config.go rejects for
 	// prometheus_path; keep the two in sync.
-	mux.Handle("GET /{$}", handlers.IndexHandler())
+	mux.Handle("GET /{$}", handlers.IndexHandler(runConfig.PrometheusPath))
 	mux.Handle("GET /healthz", handlers.HealthzHandler())
 	// Fallback for everything else (gin's old NoRoute behavior).
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +40,7 @@ func newMux(runConfig HttpServerConfig, registry *prometheus.Registry) http.Hand
 			Msg("Route Not Found")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "Route Not Found: Try /metrics"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "Route Not Found: Try " + runConfig.PrometheusPath})
 	})
 	return handlers.Recovery(handlers.RequestLogger(mux))
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -260,6 +260,43 @@ func TestStaticHandlers(t *testing.T) {
 	}
 }
 
+// TestCustomPrometheusPathReflectedInRoutes verifies that when prometheus_path
+// is customized, both the landing-page link and the 404 fallback hint point at
+// the configured path rather than a hardcoded '/metrics'.
+func TestCustomPrometheusPathReflectedInRoutes(t *testing.T) {
+	t.Parallel()
+
+	const customPath = "/custom-metrics"
+	mux := newMux(HttpServerConfig{TdarrInstance: "test-instance", PrometheusPath: customPath}, prometheus.NewRegistry())
+
+	tests := []struct {
+		name         string
+		path         string
+		wantStatus   int
+		wantContains string
+	}{
+		{"landing page links to custom path", "/", http.StatusOK, `href='/custom-metrics'`},
+		{"404 hint names custom path", "/does-not-exist", http.StatusNotFound, `"error":"Route Not Found: Try /custom-metrics"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if !strings.Contains(rec.Body.String(), tc.wantContains) {
+				t.Fatalf("body = %q, want it to contain %q", rec.Body.String(), tc.wantContains)
+			}
+		})
+	}
+}
+
 func TestMetricsHandler(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Changes

- `IndexHandler` now takes the configured metrics path and renders `<a href='<prometheus_path>'>` instead of a hardcoded `/metrics`. The path is html-escaped before interpolation into the anchor.
- The catch-all 404 fallback hint (`Route Not Found: Try ...`) now names the configured path instead of a hardcoded `/metrics`.
- Tests: `TestIndexHandler` (handlers) asserts the link tracks the configured path and is escaped; `TestCustomPrometheusPathReflectedInRoutes` (server) asserts both the landing link and the 404 hint reflect a custom path.
- Unrelated force-quit polish carried in a second commit (`refactor:`): the force-quit log line drops from error to warn level (a double-interrupt is an operator action; the graceful path already logs the same interrupt at info), and a comment documents why `forcedExitCode`'s 129-143 codes knowingly exceed `os.Exit`'s documented portable range [0, 125].

## Motivation

When `prometheus_path` is customized, the landing page's metrics link and the 404 hint both pointed at `/metrics`, which no longer exists — a dead link and a misleading hint. Both now track the configured path.

## Test plan

- `task ci` passes locally (gofmt, go mod tidy, golangci-lint, `go test ./... -race`).
- `IndexHandler` at 100% coverage; new tests cover default path, custom path, and html-escaping of a path containing a quote.

## In-depth

The path is operator-controlled and already validated at config time (metacharacters, whitespace, and unclean paths are rejected), but that validation does not cover HTML-significant characters. The html-escape is defense in depth for the anchor attribute.