### PR TITLE
fix: startup validation and shutdown-path hardening

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -52,9 +52,10 @@ func run() int {
 
 	// http server
 	stopHttpChan := make(chan bool)
-	// Buffered so the server goroutine never blocks sending an error (e.g. a
-	// late Shutdown error after main has stopped selecting on errChan).
-	errHttpChan := make(chan error, 1)
+	// Buffered with one slot per potential sender (ListenAndServe error,
+	// Shutdown error) so the server goroutine never blocks sending, even if
+	// both fire after main has stopped selecting on errChan.
+	errHttpChan := make(chan error, 2)
 	httpWg := &sync.WaitGroup{}
 	httpServerConfig := server.HttpServerConfig{
 		TdarrInstance:   userConfig.InstanceName,

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -454,8 +454,9 @@ func (c *TdarrCollector) getLibStats(ctx context.Context, wg *sync.WaitGroup, in
 		// Defensive skip: never emit a library series with an empty id or name.
 		// The synthetic aggregate sentinel has been removed; use sum() across
 		// per-library series in dashboards/queries instead. Tdarr's cruddb
-		// response always populates _id and name for real libraries, so this
-		// branch should never fire — log loudly if it does, and flag the scrape
+		// response has populated _id and name in all observed responses, but
+		// nothing guarantees it (cruddb is a generic DB endpoint with no
+		// response schema), so log loudly if this fires and flag the scrape
 		// partial so the dropped series surfaces as tdarr_up=0 instead of
 		// silently vanishing.
 		if pieMetric.libraryId == "" || pieMetric.libraryName == "" {

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -455,12 +455,15 @@ func (c *TdarrCollector) getLibStats(ctx context.Context, wg *sync.WaitGroup, in
 		// The synthetic aggregate sentinel has been removed; use sum() across
 		// per-library series in dashboards/queries instead. Tdarr's cruddb
 		// response always populates _id and name for real libraries, so this
-		// branch should never fire — log loudly if it does.
+		// branch should never fire — log loudly if it does, and flag the scrape
+		// partial so the dropped series surfaces as tdarr_up=0 instead of
+		// silently vanishing.
 		if pieMetric.libraryId == "" || pieMetric.libraryName == "" {
 			c.logger.Warn().
 				Str("libraryId", pieMetric.libraryId).
 				Str("libraryName", pieMetric.libraryName).
 				Msg("Tdarr returned library with empty id or name; dropping series")
+			partial.Store(true)
 			continue
 		}
 		// Normalize status slices to cleaned-label maps covering the full known enum.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -13,6 +14,11 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
+
+// errFlagParse marks errors from flag parsing itself (unknown flag, bad value
+// syntax) as opposed to semantic validation errors. NewConfig maps it to exit
+// code 2, matching the stdlib flag package's ExitOnError behavior.
+var errFlagParse = errors.New("invalid command line arguments")
 
 const (
 	envTdarrUrl           = "TDARR_URL"
@@ -151,6 +157,12 @@ func parseUrl(urlString string) (*url.URL, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid url provided - failed to parse %q: %w", urlString, err)
 	}
+	// url.Parse accepts host-less URLs like "https://"; without a host every
+	// outbound request would fail at scrape time (and InstanceName would
+	// default to empty), so fail startup instead.
+	if parsed.Hostname() == "" {
+		return nil, fmt.Errorf("invalid url provided - missing host in %q", urlString)
+	}
 	return parsed, nil
 }
 
@@ -177,7 +189,12 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 	instanceName := fs.String("instance_name", defaults.InstanceName, "set to customize the tdarr_instance label (defaults to the url hostname); helpful when running multiple exporters and/or multiple tdarr instances on one host")
 
 	if err := fs.Parse(args); err != nil {
-		return Config{}, err
+		if errors.Is(err, flag.ErrHelp) {
+			return Config{}, err
+		}
+		// Tag flag syntax errors so NewConfig can exit 2 (the stdlib/GNU
+		// usage-error convention) instead of 1 like semantic config errors.
+		return Config{}, fmt.Errorf("%w: %w", errFlagParse, err)
 	}
 
 	if *versionFlag {
@@ -272,9 +289,23 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 // side effects (log level mutation, fatal on error, startup logging) that must
 // not live in the testable core.
 func NewConfig() Config {
-	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	// ContinueOnError (not ExitOnError) so parse outcomes surface here as
+	// errors and each maps to the right exit path below: help -> 0, flag
+	// syntax error -> 2 (stdlib convention), semantic config error -> 1.
+	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	cfg, err := parseConfig(fs, os.Args[1:], os.Getenv)
 	if err != nil {
+		// -h/-help: usage was already printed by fs.Parse; that's a successful
+		// outcome, not a config failure.
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		// Flag syntax errors: fs.Parse already printed the offending flag and
+		// usage to stderr, so don't log the same thing again — just exit 2
+		// like the stdlib's ExitOnError would.
+		if errors.Is(err, errFlagParse) {
+			os.Exit(2)
+		}
 		log.Fatal().Err(err).Msg("Failed to load configuration")
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"errors"
 	"flag"
+	"io"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -196,6 +198,12 @@ func TestParseConfigErrors(t *testing.T) {
 			env:  map[string]string{envTdarrUrl: "https://exa mple.com/\x7f"},
 		},
 		{
+			// url.Parse accepts "https://" but the host is empty; must fail at
+			// startup, not at scrape time.
+			name: "host-less url",
+			env:  map[string]string{envTdarrUrl: "https://"},
+		},
+		{
 			name: "unknown log level",
 			env:  map[string]string{envTdarrUrl: "https://x.com", envLogLevel: "verbose"},
 		},
@@ -210,6 +218,38 @@ func TestParseConfigErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseConfigFlagParseErrorTagging locks the error classification NewConfig
+// relies on for exit codes: flag syntax errors are tagged errFlagParse (exit 2),
+// -h/-help passes through as flag.ErrHelp untagged (exit 0).
+func TestParseConfigFlagParseErrorTagging(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{envTdarrUrl: "https://x.com"}
+
+	t.Run("unknown flag tagged errFlagParse", func(t *testing.T) {
+		t.Parallel()
+		fs := newFS()
+		fs.SetOutput(io.Discard) // silence stdlib's usage print in test output
+		_, err := parseConfig(fs, []string{"-definitely_not_a_flag"}, envFunc(env))
+		if !errors.Is(err, errFlagParse) {
+			t.Fatalf("err = %v, want errors.Is(err, errFlagParse)", err)
+		}
+	})
+
+	t.Run("help passes through as flag.ErrHelp untagged", func(t *testing.T) {
+		t.Parallel()
+		fs := newFS()
+		fs.SetOutput(io.Discard)
+		_, err := parseConfig(fs, []string{"-h"}, envFunc(env))
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("err = %v, want errors.Is(err, flag.ErrHelp)", err)
+		}
+		if errors.Is(err, errFlagParse) {
+			t.Fatalf("help must not be tagged as a flag syntax error: %v", err)
+		}
+	})
 }
 
 func TestParseConfigUrlSchemeDefaulting(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"sync"
@@ -59,10 +60,15 @@ func ServeHttp(wg *sync.WaitGroup, registry *prometheus.Registry, runConfig Http
 		// Bound header read time so idle half-open connections cannot pin
 		// goroutines indefinitely (slowloris; gosec G112).
 		ReadHeaderTimeout: 5 * time.Second,
+		// Reap idle keep-alive connections. WriteTimeout stays 0 (unlimited)
+		// on purpose: it would cap total response time, and scrape duration is
+		// unbounded by design (lazy per-scrape collection against a possibly
+		// slow Tdarr instance).
+		IdleTimeout: 120 * time.Second,
 	}
 
 	go func() {
-		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 			// Propagate to the caller instead of os.Exit so the graceful
 			// shutdown path in main can run.
 			log.Error().

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -197,6 +197,94 @@ func TestServeHttpListenErrorDeliveredOnChannel(t *testing.T) {
 	}
 }
 
+// blockingCollector parks Collect until release is closed, holding a /metrics
+// request active so srv.Shutdown cannot finish before its deadline. entered
+// signals that the scrape (and thus the request) is in flight.
+type blockingCollector struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingCollector) Describe(chan<- *prometheus.Desc) {}
+func (b *blockingCollector) Collect(chan<- prometheus.Metric) {
+	close(b.entered)
+	<-b.release
+}
+
+// TestServeHttpShutdownErrorSecondSendDoesNotBlock pins the errChan capacity
+// contract: with one slot per sender (cap 2, matching main's wiring), ServeHttp
+// must still return when a Shutdown error is sent while an earlier error
+// already sits undrained in the channel. With cap 1 the second send would
+// block forever and the WaitGroup would never complete.
+func TestServeHttpShutdownErrorSecondSendDoesNotBlock(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort("127.0.0.1", port)
+
+	wg := &sync.WaitGroup{}
+	stopChan := make(chan bool)
+	// Mirror production wiring (cmd/exporter/main.go) and pre-fill one slot to
+	// simulate an earlier undrained send.
+	errChan := make(chan error, 2)
+	errChan <- fmt.Errorf("simulated earlier undrained error")
+
+	bc := &blockingCollector{entered: make(chan struct{}), release: make(chan struct{})}
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(bc)
+
+	cfg := HttpServerConfig{
+		TdarrInstance:  "double-error",
+		ListenAddress:  "127.0.0.1",
+		PrometheusPort: port,
+		PrometheusPath: "/metrics",
+		// Short deadline so Shutdown gives up on the parked request quickly.
+		GracefulTimeout: 100 * time.Millisecond,
+	}
+
+	wg.Add(1)
+	go ServeHttp(wg, registry, cfg, stopChan, errChan)
+	waitForServer(t, addr, 2*time.Second)
+
+	// Park a scrape inside the handler so the connection stays active across
+	// Shutdown. Release it at the end so the client goroutine can exit.
+	scrapeDone := make(chan struct{})
+	go func() {
+		defer close(scrapeDone)
+		resp, err := http.Get(fmt.Sprintf("http://%s/metrics", addr))
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+	<-bc.entered
+
+	stopChan <- true
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeHttp did not return: Shutdown-error send blocked on an undrained errChan")
+	}
+
+	// Both errors must be present: the pre-filled one and the Shutdown
+	// deadline error.
+	<-errChan
+	select {
+	case err := <-errChan:
+		if err == nil {
+			t.Fatal("expected a non-nil Shutdown error as the second channel entry")
+		}
+	default:
+		t.Fatal("Shutdown error was not delivered as the second channel entry")
+	}
+
+	close(bc.release)
+	<-scrapeDone
+}
+
 func TestStaticHandlers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Changes

Hardening batch from the 2026-07-12 round-2 holistic review (PR1 of the recorded findings; every item was adversarially re-verified before implementation).

- **Reject host-less URLs at startup** (`internal/config`): `--url https://` previously passed config load (`url.Parse` succeeds with an empty host), producing an empty default `instance_name` and failing every outbound request at scrape time. Now fails startup with `missing host`.
- **Conventional exit codes for flag parsing** (`internal/config`): switched `NewConfig` from `flag.ExitOnError` to `flag.ContinueOnError` and mapped each outcome — `-h`/`-help` exits 0, flag syntax errors exit 2 (stdlib parity; error + usage printed once by the flag package, no duplicate fatal log), semantic config errors exit 1 via the standard fatal-log path. Syntax errors are classified with an `errFlagParse` sentinel in `parseConfig`.
- **Error-channel capacity matches sender count** (`cmd/exporter`, `internal/server`): `errHttpChan` had capacity 1 but two potential senders (`ListenAndServe` error, `Shutdown` error). If an undrained error was already buffered, the second send would block the server goroutine forever and hang `httpWg.Wait()`. Capacity is now 2 (one slot per sender).
- **`IdleTimeout: 120s`** on the HTTP server to reap idle keep-alive connections. `WriteTimeout` deliberately stays 0: it caps total response time, and scrape duration is unbounded by design (lazy per-scrape collection against a possibly slow Tdarr instance) — documented in code.
- **`errors.Is(err, http.ErrServerClosed)`** instead of raw sentinel comparison.
- **Empty library id/name drop now flags the scrape partial** (`internal/collector`): this defensive branch previously only warn-logged, silently dropping a series while `tdarr_up` stayed 1. It now sets the partial flag like every other incompleteness path, so drift surfaces as `tdarr_up=0`.

## Motivation

Round-2 holistic review found no criticals but a set of small hardening gaps: a validation hole that deferred failure from startup to scrape time, a theoretical shutdown deadlock, missing server timeouts, and one silent-data-loss path inconsistent with the collector's "partial ⇒ tdarr_up=0" contract.

## Test plan

- `task ci` green (go fmt / go mod tidy clean, golangci-lint, `go test ./... -race`).
- New `TestServeHttpShutdownErrorSecondSendDoesNotBlock` pins the channel-capacity contract: a Shutdown error sent while an earlier error sits undrained must not block `ServeHttp` (fails under cap 1). Passes 5/5 under `-race`.
- New `TestParseConfigFlagParseErrorTagging` locks the error classification behind the exit codes.
- New `host-less url` case in `TestParseConfigErrors`.
- Manually verified binary behavior: `-h` → usage, exit 0; `-badflag` → single error print + usage, exit 2; `--url https://` → fatal `missing host`, exit 1.

## In-depth

- Bad-flag exit code changes from stdlib `ExitOnError`'s 2 → briefly 1 during development → back to 2 in the final form; net behavior change vs `main` is only *where* the exit happens (after classification) — user-visible output and code are stdlib-identical except the error no longer double-prints.
- An independent reviewer pass on this diff confirmed the changes are idiomatic and match established exporter practice (exporter-toolkit/node_exporter posture on `WriteTimeout`=0 + `IdleTimeout`; fail-fast target validation; `tdarr_up=0` on partial matches this repo's documented collector contract). Verdict: ship.
- Remaining round-2 findings land separately: docs batch (SIGHUP intent note, stats-cache staleness, timeout help text), chore/ci hygiene, optional polish.