### PR TITLE
fix: invalidate stats cache when library list changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY . .
 RUN go build \
     # -trimpath: strip absolute build paths for reproducible builds
     -trimpath \
-    # ldlflags: `-w -s` disable debugging and `pprof` for minimal binary,
+    # ldflags: `-w -s` strip the DWARF debug info and symbol table for a smaller binary
     -ldflags "-w -s -X github.com/prometheus/common/version.Version=${VERSION} -X github.com/prometheus/common/version.Revision=${REVISION} -X github.com/prometheus/common/version.BuildDate=${BUILDTIME}" \
     -o exporter /build/cmd/exporter/.
 

--- a/README.md
+++ b/README.md
@@ -125,10 +125,11 @@ Caching and concurrency is only applicable if Tdarr instance is version `2.24.01
 
 The Tdarr library stats API introduced in that version calculates stats only when requested and an API call has to be made individually for each library. This can be a time consuming operation for some larger setups or certain hardware causing latency when requesting individual library statistics.
 
-To reduce number of API calls made, caching will be utilized if the below counts have not changed since the last scrape:
-- total file count
-- total transcode count (broken down by category: `success`, `error`)
-- total health check count
+To reduce number of API calls made, per-library stats are cached and reused when nothing has changed since the last scrape. Two cheap signals are checked on every scrape:
+- the general stats totals (total file count, transcode counts by `success`/`error`, health check count, and per-status queue sizes)
+- the library list itself — adding, removing, or renaming a library invalidates the cache
+
+If either signal changed, all per-library stats are re-fetched. See [docs/metrics-internals.md](docs/metrics-internals.md#stats-cache-invalidation) for the full mechanics and known edge cases.
 
 Consider increasing the `http_max_concurrency` property if you have a large number of libraries or want to speed up metrics collection. You can try increasing this number to be closer to your number of Tdarr libraries to reduce the time it takes to collect all the stats from different libraries. The max value of this property is `num of libraries + 1`. It is recommended to increase this cautiously and put use a reasonable value if you have a very large number of libraries. You can also consider increasing scrape interval time as well to make less API calls overall if needed.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Inspired by exportarr and qbittorrent-exporter projects. I wanted to have everyt
 2. Executable binary
 3. Helm chart (K8)
 
+`tdarr-exporter` shuts down gracefully on `SIGINT`, `SIGTERM`, `SIGQUIT`, and `SIGHUP` (a second signal forces an immediate exit). There is no config file to reload, so `SIGHUP` is treated the same as the others — a graceful shutdown, exit code 0 — rather than the reload-on-hangup convention some daemons use.
+
 ### Binary
 Each tagged release will include executable binaries under the `assets` section of the release notes. This can be downloaded and run directly, see [configuration](#configuration) section for more details on run options.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ $ ./tdarr-exporter -h
         api token for tdarr instance if authentication is enabled
   -http_max_concurrency int
         maximum number of concurrent http requests to make when requesting per Library stats (default 3)
+  -http_timeout_seconds int
+        total time budget in seconds for an http request to the tdarr instance, including transport-level retries and backoff (a low value can silently truncate retries) (default 15)
   -instance_name string
         set to customize the tdarr_instance label (defaults to the url hostname); helpful when running multiple exporters and/or multiple tdarr instances on one host
   -listen_address string
@@ -105,6 +107,7 @@ A valid URL for the tdarr instance must be provided and can include protocol (`h
 | `url`             | `TDARR_URL`           | `NONE`     | This is a required property and must be provided. If no protocol is provided (`http/https`), defaults to using `https`. Examples: `tdarr.example.com`, `http://tdarr.example.com`, `http://tdarr.localdomain:8266`. |
 | `api_key`         | `TDARR_API_KEY`       | `NONE`     | API token for tdarr instance if authentication is enabled. |
 | `http_max_concurrency` | `HTTP_MAX_CONCURRENCY` | `3`     | Maximum number of concurrent http requests to make when requesting per Library stats. For more information on caching and concurrency see this [section](#caching-and-concurrency) for more. |
+| `http_timeout_seconds` | `HTTP_TIMEOUT_SECONDS` | `15`     | Total time budget, in seconds, for a single http request to the tdarr instance — this is the whole exchange, including transport-level retries and their backoff (currently 1s then 3s, 2 retries). A value too low for your instance can silently truncate those retries rather than give up cleanly. |
 | `log_level`       | `LOG_LEVEL`           | `info`     | Log level to use: `debug`, `info`, `warn`, `error`. |
 | `verify_ssl`      | `VERIFY_SSL`          | `true`     | Whether or not to verify ssl certificates. |
 | `listen_address`  | `LISTEN_ADDRESS`      | `0.0.0.0`  | Network interface address for the exporter's http server to bind. Set to `127.0.0.1` to only accept local connections (e.g. behind a reverse proxy), or an IPv6 address such as `::`. |

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -69,6 +69,8 @@ func run() int {
 
 	// graceful shutdown
 	quitServer := make(chan os.Signal, 1)
+	// SIGHUP has nothing to reload here (no config file to re-read), so it is
+	// treated the same as the other signals below: a graceful shutdown, exit 0.
 	signal.Notify(
 		quitServer,
 		os.Interrupt,

--- a/docs/metrics-internals.md
+++ b/docs/metrics-internals.md
@@ -122,6 +122,72 @@ So the per-library sum exceeds the global total by exactly the lifetime events
 of files that have since been deleted: kept by the per-library pies, dropped
 from the global aggregate.
 
+## Stats cache invalidation
+
+Per-library pie stats (`tdarr_library_*`) are expensive to collect — one
+`get-pies` call per library, fanned out across `HTTP_MAX_CONCURRENCY` workers —
+so a scrape reuses the previous sweep's results (`TdarrLibStatsCache`) unless an
+invalidation signal says something changed. See `shouldRefetch` in
+`internal/collector/tdarr.go` for the code; this section covers the *why* and
+the trade-offs.
+
+### The two-part signal
+
+Invalidation compares two things against the cached sweep, on every scrape:
+
+- **10 numeric totals** from the general-stats document (`StatisticsJSONDB`):
+  the three top-level counts plus the seven `table0Count`–`table6Count` queue
+  buckets. Cheap (~ms), but aggregate-only — it carries no per-library
+  breakdown and cannot see a change that doesn't move any of the ten numbers.
+- **A library-list fingerprint**: a sorted-by-id copy of the library list
+  (`LibrarySettingsJSONDB`, id + name pairs), fetched fresh every scrape and
+  compared with the fingerprint stored alongside the totals at the last cache
+  write. This catches drift the totals miss entirely — a library rename, or a
+  newly added library with zero files (nothing to transcode yet, so none of
+  the ten totals move).
+
+Either signal differing triggers a full refetch of every library's pie stats,
+matching the cache's existing all-or-nothing (not per-library) invalidation —
+see the `shouldRefetch` doc comment for why a per-library cache isn't viable
+given the Tdarr API's shape.
+
+### Bandwidth cost
+
+The library-list call is cheap in latency but not in bandwidth: measured live
+against a 7-library Tdarr instance, the response was 104,532 bytes — roughly
+**15 KB per library**. Fetching it every scrape (rather than only on a cache
+miss) adds that payload to every scrape regardless of whether anything
+changed: ~102 KB/scrape for 7 libraries, which is ~590 MB/day at a 15s scrape
+interval. This is a deliberate trade against staleness — see below. The payload
+scales with library count (each library contributes its full settings document),
+not file count, so it stays flat as libraries fill up with media.
+
+### Residual staleness (still self-heals)
+
+The two-part signal closes the rename/new-library gap but is not exhaustive.
+The following changes move no numeric total and leave the library-list
+fingerprint identical (same ids, same names), so they do not trigger a refetch
+on their own:
+
+- **Cross-library file moves that stay in the same status bucket** — e.g.
+  moving a fully-transcoded file from one library's folder to another's. Both
+  libraries' `totalFiles` counts change, but that only reaches the *global*
+  totals (which are also unaffected here, since the file's overall status
+  bucket didn't change), not the fingerprint.
+- **Offsetting add+delete across libraries** — a file added to one library and
+  removed from another in the same window can leave every one of the 10
+  global totals net unchanged.
+- **Same-bucket rescans that shift codec/resolution distributions** — e.g. a
+  library rescan that reclassifies files' detected video codec without
+  changing transcode/health-check status counts moves the per-library pie
+  slices but none of the 10 totals.
+
+All three self-heal on the next scrape where a totals-visible event occurs
+(any transcode, health check, or file add/delete that moves one of the ten
+numbers) — the staleness window is bounded by how long an instance goes
+between such events, not unbounded. This is the same accepted trade-off as
+before the fingerprint was added, just narrowed to fewer cases.
+
 ## Counter vs gauge typing
 
 This divergence drives the metric typing, and the two scopes are typed

--- a/internal/collector/fake_api_test.go
+++ b/internal/collector/fake_api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/homeylab/tdarr-exporter/internal/client"
 )
@@ -30,6 +31,14 @@ type fakeTdarrAPI struct {
 	// errors maps a request key to an error that should be returned instead of a
 	// response, used to drive tdarr_up=0 / partial-failure paths.
 	errors map[fakeKey]error
+
+	// callsMu guards calls; fetchPies fans requests across worker goroutines, so
+	// call counting must be concurrency-safe even though most tests use
+	// HttpMaxConcurrency=1.
+	callsMu sync.Mutex
+	// calls counts requests per key, used by tests asserting a cache hit made
+	// no pie (or other) API calls on a given scrape.
+	calls map[fakeKey]int
 }
 
 // statErr is returned by the fake to mimic a non-2xx / transport failure from the
@@ -42,7 +51,29 @@ func newFakeTdarrAPI() *fakeTdarrAPI {
 	return &fakeTdarrAPI{
 		responses: make(map[fakeKey][]byte),
 		errors:    make(map[fakeKey]error),
+		calls:     make(map[fakeKey]int),
 	}
+}
+
+// callCount returns how many times key has been requested (POST or GET) so far.
+func (f *fakeTdarrAPI) callCount(key fakeKey) int {
+	f.callsMu.Lock()
+	defer f.callsMu.Unlock()
+	return f.calls[key]
+}
+
+// resetCalls clears the recorded call counts, e.g. between scrapes in a test
+// that asserts on calls made during a specific scrape only.
+func (f *fakeTdarrAPI) resetCalls() {
+	f.callsMu.Lock()
+	defer f.callsMu.Unlock()
+	f.calls = make(map[fakeKey]int)
+}
+
+func (f *fakeTdarrAPI) recordCall(key fakeKey) {
+	f.callsMu.Lock()
+	defer f.callsMu.Unlock()
+	f.calls[key]++
 }
 
 // setResponse registers fixture bytes for a request key.
@@ -82,6 +113,7 @@ func (f *fakeTdarrAPI) DoPostRequest(ctx context.Context, path string, target an
 	if err != nil {
 		return err
 	}
+	f.recordCall(key)
 	if e, ok := f.errors[key]; ok {
 		return e
 	}
@@ -97,6 +129,7 @@ func (f *fakeTdarrAPI) DoRequest(ctx context.Context, path string, target any, q
 		return err
 	}
 	key := fakeKey{path: path}
+	f.recordCall(key)
 	if e, ok := f.errors[key]; ok {
 		return e
 	}

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -135,41 +137,48 @@ type TdarrCollector struct {
 	descsList []typedDesc
 }
 
+// libStatsSnapshot bundles everything one fully-successful pie sweep caches.
+// The fields must all correspond to the same scrape; the cache reads and writes
+// a snapshot as one value under a single lock, so a concurrent scrape can never
+// observe a torn combination (e.g. totals from one sweep, stats from another).
+type libStatsSnapshot struct {
+	totals tdarrCacheTotals
+	// stats is nil until the first fully-successful sweep is cached; callers
+	// treat nil as "cache empty" and refetch.
+	stats []*TdarrPieStats
+	// fingerprint is a sorted-by-LibraryId snapshot of the library list at the
+	// time stats was cached, used alongside totals to decide whether a refetch
+	// is needed (see shouldRefetch). Sorted so two fetches of the same library
+	// set compare equal regardless of the order Tdarr returns them in.
+	fingerprint []TdarrLibraryInfo
+}
+
 // Cache to store library stats and reduce excessive API calls
 // Mutex added to reduce chance of running into errors (from race condition) from misconfiguration or manual testing
 // i.e getting scraped twice by two different prometheus instances
 type TdarrLibStatsCache struct {
-	mu           sync.RWMutex
-	totals       tdarrCacheTotals
-	libraryStats []*TdarrPieStats
+	mu   sync.RWMutex
+	snap libStatsSnapshot
 }
 
 func NewTdarrLibStatsCache() *TdarrLibStatsCache {
-	return &TdarrLibStatsCache{
-		totals:       tdarrCacheTotals{},
-		libraryStats: nil,
-	}
+	return &TdarrLibStatsCache{}
 }
 
-// Read returns the cached totals and library stats as a consistent pair under a
-// single lock. libraryStats is nil until the first fully-successful sweep is
-// cached (callers treat nil as "cache empty" and refetch). Returning both
-// together prevents a torn read where totals and stats come from different
-// scrapes.
-func (c *TdarrLibStatsCache) Read() (tdarrCacheTotals, []*TdarrPieStats) {
+// Read returns the cached snapshot under a single lock. snap.stats is nil until
+// the first fully-successful sweep is cached.
+func (c *TdarrLibStatsCache) Read() libStatsSnapshot {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.totals, c.libraryStats
+	return c.snap
 }
 
-// Write stores the totals and library stats together under a single lock, so
-// the two fields — which must correspond — are never observed as a torn pair by
-// a concurrent Read. Only a fully-successful pie sweep is written (see collect()).
-func (c *TdarrLibStatsCache) Write(totals tdarrCacheTotals, stats []*TdarrPieStats) {
+// Write stores a snapshot under a single lock. Only a fully-successful pie
+// sweep is written (see collect()).
+func (c *TdarrLibStatsCache) Write(snap libStatsSnapshot) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.totals = totals
-	c.libraryStats = stats
+	c.snap = snap
 }
 
 // collector
@@ -574,24 +583,42 @@ func totalsFromMetric(metric *TdarrMetric) tdarrCacheTotals {
 	}
 }
 
+// libraryFingerprint builds a sorted-by-LibraryId copy of libs for use as a cache
+// comparison key. It copies before sorting so the caller's slice — which fetchPies
+// also consumes, in the order Tdarr returned it — is never reordered as a side effect.
+func libraryFingerprint(libs []TdarrLibraryInfo) []TdarrLibraryInfo {
+	fp := make([]TdarrLibraryInfo, len(libs))
+	copy(fp, libs)
+	sort.Slice(fp, func(i, j int) bool { return fp[i].LibraryId < fp[j].LibraryId })
+	return fp
+}
+
 // shouldRefetch decides whether library pie stats must be re-fetched. It returns
-// true when the cache is empty (libStatsNil) or any of the 10 cached totals differs
-// from the current metric. tdarrCacheTotals is all-int and thus comparable, so the
+// true when the cache is empty (cached.stats nil), any of the 10 cached totals
+// differs from the current metric, or the cached library-list fingerprint differs
+// from the current one. tdarrCacheTotals is all-int and thus comparable, so the
 // struct != comparison is equivalent to the prior field-by-field OR chain.
 //
 // Invalidation is deliberately GLOBAL (all-or-nothing across every library), not
 // per-library, and this is forced by the Tdarr API's shape — do not "optimize" it
-// to a per-library cache. The only cheap signal Tdarr exposes is the general-stats
-// document (StatisticsJSONDB, ~ms), and it is aggregate-only: it carries no
-// per-library breakdown. Per-library data lives solely in the get-pies call, which
+// to a per-library cache. Per-library data lives solely in the get-pies call, which
 // is the expensive per-library fan-out the cache exists to skip (seconds across all
-// libraries). So there is no cheap "did library X change?" probe: checking one
+// libraries); there is no cheap "did library X change?" probe, since checking one
 // library would cost the same fetch the cache is trying to avoid. A per-library
 // cache is therefore not viable, and with it the sync.Map that concurrent
 // per-library cache writes would need is moot — the whole-slice cache guarded by a
 // single RWMutex, written by one drain goroutine, is the correct shape here.
-func shouldRefetch(cached tdarrCacheTotals, libStatsNil bool, metric *TdarrMetric) bool {
-	return libStatsNil || cached != totalsFromMetric(metric)
+//
+// The invalidation signal has two parts, both cheap relative to the get-pies
+// fan-out: the general-stats document (StatisticsJSONDB, ~ms) supplies the 10
+// totals, and the library-list document (LibrarySettingsJSONDB, ~ms in latency,
+// but non-trivial in bandwidth — ~15KB per library, see docs/metrics-internals.md)
+// supplies the fingerprint. The totals alone miss a library rename or a newly
+// added zero-file library (neither moves any of the 10 counts); the fingerprint
+// catches both, since it changes whenever a library's id/name set changes. Either
+// signal changing triggers a refetch — they cover different drift.
+func shouldRefetch(cached libStatsSnapshot, metric *TdarrMetric, currentFingerprint []TdarrLibraryInfo) bool {
+	return cached.stats == nil || cached.totals != totalsFromMetric(metric) || !slices.Equal(cached.fingerprint, currentFingerprint)
 }
 
 func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) (bool, error) {
@@ -641,45 +668,59 @@ func (c *TdarrCollector) collect(ctx context.Context, ch chan<- prometheus.Metri
 
 	// supports only api versions: v2.24.01+
 	c.logger.Debug().Str("path", c.pieStatsPath).Msg("Fetching library pie stats")
+	// Fetch the current library list on EVERY scrape, not just cache misses. This is
+	// a single cheap cruddb call (~ms in latency) used purely as an invalidation
+	// signal (see shouldRefetch); a failure here hard-fails the scrape exactly like
+	// the general-stats fetch above — there is no fallback, since a stale/partial
+	// library list would make both the cache decision and any resulting pie fetch
+	// unreliable.
+	getLibsPayload := getGeneralReqPayload("library")
+	allLibs := []TdarrLibraryInfo{}
+	if err := c.httpReqHelper(ctx, c.statsPath, getLibsPayload, &allLibs); err != nil {
+		return false, fmt.Errorf("get library details: %w", err)
+	}
+	fingerprint := libraryFingerprint(allLibs)
+
 	// already have total file count from general stats (`metric.TotalFileCount`)
 	// check cache for all libraries data
 	// this won't block other reads when checking
-	cacheTotals, cachedStats := c.statsCache.Read()
-	// Refetch if the cache is empty (first run) or any of the 10 totals changed.
-	// Beyond the three top-level counts, the seven per-bucket queue fields
-	// (holdQueue/transcodeQueue/… on TdarrMetric) catch state transitions the totals miss
-	// (e.g. files queued but not yet transcoded). Their Tdarr JSON source (table0Count–table6Count)
-	// and bucket meanings are documented on TdarrMetric in tdarr_models.go. Older Tdarr versions
-	// omit those fields; they decode to 0, so 0==0 never triggers a spurious refetch.
-	shouldCollect := shouldRefetch(cacheTotals, cachedStats == nil, metric)
+	cached := c.statsCache.Read()
+	// Refetch if the cache is empty (first run), any of the 10 totals changed, or the
+	// library-list fingerprint changed. Beyond the three top-level counts, the seven
+	// per-bucket queue fields (holdQueue/transcodeQueue/… on TdarrMetric) catch state
+	// transitions the totals miss (e.g. files queued but not yet transcoded). Their
+	// Tdarr JSON source (table0Count–table6Count) and bucket meanings are documented
+	// on TdarrMetric in tdarr_models.go. Older Tdarr versions omit those fields; they
+	// decode to 0, so 0==0 never triggers a spurious refetch. The fingerprint (sorted
+	// library id/name pairs) catches a library rename or a new zero-file library —
+	// drift the 10 totals alone cannot see, since neither moves any of them.
+	shouldCollect := shouldRefetch(cached, metric, fingerprint)
 	if shouldCollect {
-		c.logger.Debug().Msg("Stats totals mismatch - re-fetching library pie stats")
+		c.logger.Debug().Msg("Stats totals or library fingerprint mismatch - re-fetching library pie stats")
 	}
-	// if counts are the same use cache
+	// if counts and fingerprint are unchanged, use cache
 	if !shouldCollect {
-		c.logger.Debug().Msg("Using cached library stats - api totals matches cached values")
-		pieData = cachedStats
-	} else { // fetch new data and update cache
-		getLibsPayload := getGeneralReqPayload("library")
-		allLibs := []TdarrLibraryInfo{}
-		err := c.httpReqHelper(ctx, c.statsPath, getLibsPayload, &allLibs)
-		if err != nil {
-			return false, fmt.Errorf("get library details: %w", err)
-		}
-
+		c.logger.Debug().Msg("Using cached library stats - api totals and library fingerprint match cached values")
+		pieData = cached.stats
+	} else { // fetch new data and update cache; reuse the library list already fetched above
 		pieData, partialFail = c.fetchPies(ctx, allLibs)
 		// Cache invariant: only a fully successful pie sweep may be cached.
 		// Caching a partial result would let the next scrape serve incomplete
 		// data from cache with tdarr_up=1 (partial failure is scoped to this
 		// scrape only), silently dropping the failed library's series until the
-		// totals next change. Skipping both writes keeps the cache stale/nil,
-		// so shouldRefetch() triggers a full refetch on the next scrape.
+		// totals or fingerprint next change. Skipping the write keeps the cache
+		// stale/nil, so shouldRefetch() triggers a full refetch on the next scrape.
 		if partialFail {
 			c.logger.Warn().Msg("Partial library pie fetch failure - cache not updated, will re-fetch next scrape")
 		} else {
 			c.logger.Debug().Msg("All library stats gathered - setting cache")
-			// Store totals and stats together so a concurrent scrape never reads a torn pair.
-			c.statsCache.Write(totalsFromMetric(metric), pieData)
+			// Store the whole snapshot in one Write so a concurrent scrape never
+			// reads a torn combination of totals/stats/fingerprint.
+			c.statsCache.Write(libStatsSnapshot{
+				totals:      totalsFromMetric(metric),
+				stats:       pieData,
+				fingerprint: fingerprint,
+			})
 		}
 	}
 

--- a/internal/collector/tdarr_emit_test.go
+++ b/internal/collector/tdarr_emit_test.go
@@ -149,6 +149,15 @@ func TestShouldRefetch(t *testing.T) {
 	}
 	matchingCache := totalsFromMetric(base)
 
+	// matchingFingerprint/otherFingerprint model the library-list side of the
+	// invalidation signal: same set vs. a renamed/added library.
+	matchingFingerprint := []TdarrLibraryInfo{{LibraryId: "lib1", Name: "Library One"}}
+	renamedFingerprint := []TdarrLibraryInfo{{LibraryId: "lib1", Name: "Renamed Library"}}
+	newLibraryFingerprint := []TdarrLibraryInfo{
+		{LibraryId: "lib1", Name: "Library One"},
+		{LibraryId: "lib2", Name: "New Empty Library"},
+	}
+
 	// mutate returns a copy of base with one field changed, to prove every field
 	// participates in the refetch decision.
 	mutate := func(f func(m *TdarrMetric)) *TdarrMetric {
@@ -157,82 +166,114 @@ func TestShouldRefetch(t *testing.T) {
 		return &cp
 	}
 
+	// populatedStats marks the cache as non-empty; shouldRefetch only checks
+	// stats for nil-ness, never its contents.
+	populatedStats := []*TdarrPieStats{{libraryId: "lib1"}}
+	// matchingSnap is the "nothing changed" cached snapshot most cases start from.
+	matchingSnap := libStatsSnapshot{
+		totals:      matchingCache,
+		stats:       populatedStats,
+		fingerprint: matchingFingerprint,
+	}
+
 	tests := []struct {
-		name        string
-		cached      tdarrCacheTotals
-		libStatsNil bool
-		metric      *TdarrMetric
-		want        bool
+		name               string
+		cached             libStatsSnapshot
+		metric             *TdarrMetric
+		currentFingerprint []TdarrLibraryInfo
+		want               bool
 	}{
 		{
-			name:        "empty cache (libStatsNil) forces refetch even when totals match",
-			cached:      matchingCache,
-			libStatsNil: true,
-			metric:      base,
-			want:        true,
+			name: "empty cache (nil stats) forces refetch even when totals and fingerprint match",
+			cached: libStatsSnapshot{
+				totals:      matchingCache,
+				stats:       nil,
+				fingerprint: matchingFingerprint,
+			},
+			metric:             base,
+			currentFingerprint: matchingFingerprint,
+			want:               true,
 		},
 		{
-			name:        "totals match and cache populated -> no refetch",
-			cached:      matchingCache,
-			libStatsNil: false,
-			metric:      base,
-			want:        false,
+			name:               "totals and fingerprint match, cache populated -> no refetch",
+			cached:             matchingSnap,
+			metric:             base,
+			currentFingerprint: matchingFingerprint,
+			want:               false,
 		},
 		{
-			name:        "zero cache vs zero metric -> no refetch (graceful degradation)",
-			cached:      tdarrCacheTotals{},
-			libStatsNil: false,
-			metric:      &TdarrMetric{},
-			want:        false,
+			name: "zero totals vs zero metric, nil fingerprints -> no refetch (graceful degradation)",
+			cached: libStatsSnapshot{
+				totals:      tdarrCacheTotals{},
+				stats:       populatedStats,
+				fingerprint: nil,
+			},
+			metric:             &TdarrMetric{},
+			currentFingerprint: nil,
+			want:               false,
 		},
 		{
-			name:        "totalFileCount changed -> refetch",
-			cached:      matchingCache,
-			libStatsNil: false,
-			metric:      mutate(func(m *TdarrMetric) { m.TotalFileCount = 101 }),
-			want:        true,
+			name:               "totalFileCount changed -> refetch",
+			cached:             matchingSnap,
+			metric:             mutate(func(m *TdarrMetric) { m.TotalFileCount = 101 }),
+			currentFingerprint: matchingFingerprint,
+			want:               true,
 		},
 		{
-			name:        "totalTranscodeCount changed -> refetch",
-			cached:      matchingCache,
-			libStatsNil: false,
-			metric:      mutate(func(m *TdarrMetric) { m.TotalTranscodeCount = 41 }),
-			want:        true,
+			name:               "totalTranscodeCount changed -> refetch",
+			cached:             matchingSnap,
+			metric:             mutate(func(m *TdarrMetric) { m.TotalTranscodeCount = 41 }),
+			currentFingerprint: matchingFingerprint,
+			want:               true,
 		},
 		{
-			name:        "totalHealthCheckCount changed -> refetch",
-			cached:      matchingCache,
-			libStatsNil: false,
-			metric:      mutate(func(m *TdarrMetric) { m.TotalHealthCheckCount = 31 }),
-			want:        true,
+			name:               "totalHealthCheckCount changed -> refetch",
+			cached:             matchingSnap,
+			metric:             mutate(func(m *TdarrMetric) { m.TotalHealthCheckCount = 31 }),
+			currentFingerprint: matchingFingerprint,
+			want:               true,
 		},
 		{
-			name:        "table0Count (holdQueue) changed -> refetch",
-			cached:      matchingCache,
-			libStatsNil: false,
-			metric:      mutate(func(m *TdarrMetric) { m.HoldQueue = 99 }),
-			want:        true,
+			name:               "table0Count (holdQueue) changed -> refetch",
+			cached:             matchingSnap,
+			metric:             mutate(func(m *TdarrMetric) { m.HoldQueue = 99 }),
+			currentFingerprint: matchingFingerprint,
+			want:               true,
 		},
 		{
-			name:        "table1Count (transcodeQueue) changed -> refetch",
-			cached:      matchingCache,
-			libStatsNil: false,
-			metric:      mutate(func(m *TdarrMetric) { m.TranscodeQueue = 99 }),
-			want:        true,
+			name:               "table1Count (transcodeQueue) changed -> refetch",
+			cached:             matchingSnap,
+			metric:             mutate(func(m *TdarrMetric) { m.TranscodeQueue = 99 }),
+			currentFingerprint: matchingFingerprint,
+			want:               true,
 		},
 		{
-			name:        "table6Count (healthCheckFailed) changed -> refetch",
-			cached:      matchingCache,
-			libStatsNil: false,
-			metric:      mutate(func(m *TdarrMetric) { m.HealthCheckFailed = 99 }),
-			want:        true,
+			name:               "table6Count (healthCheckFailed) changed -> refetch",
+			cached:             matchingSnap,
+			metric:             mutate(func(m *TdarrMetric) { m.HealthCheckFailed = 99 }),
+			currentFingerprint: matchingFingerprint,
+			want:               true,
+		},
+		{
+			name:               "library renamed, totals unchanged -> refetch",
+			cached:             matchingSnap,
+			metric:             base,
+			currentFingerprint: renamedFingerprint,
+			want:               true,
+		},
+		{
+			name:               "new library appears, totals unchanged -> refetch",
+			cached:             matchingSnap,
+			metric:             base,
+			currentFingerprint: newLibraryFingerprint,
+			want:               true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := shouldRefetch(tc.cached, tc.libStatsNil, tc.metric); got != tc.want {
+			if got := shouldRefetch(tc.cached, tc.metric, tc.currentFingerprint); got != tc.want {
 				t.Errorf("shouldRefetch = %v, want %v", got, tc.want)
 			}
 		})
@@ -267,6 +308,45 @@ func TestTotalsFromMetric(t *testing.T) {
 	}
 	if got := totalsFromMetric(metric); got != want {
 		t.Errorf("totalsFromMetric mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// TestLibraryFingerprint verifies libraryFingerprint sorts by LibraryId (so two
+// fetches of the same library set compare equal via slices.Equal regardless of
+// API response order) and does not mutate the caller's slice — fetchPies consumes
+// that same slice afterward, in Tdarr's original order.
+func TestLibraryFingerprint(t *testing.T) {
+	t.Parallel()
+
+	libs := []TdarrLibraryInfo{
+		{LibraryId: "lib3", Name: "Three"},
+		{LibraryId: "lib1", Name: "One"},
+		{LibraryId: "lib2", Name: "Two"},
+	}
+	original := append([]TdarrLibraryInfo(nil), libs...)
+
+	got := libraryFingerprint(libs)
+
+	want := []TdarrLibraryInfo{
+		{LibraryId: "lib1", Name: "One"},
+		{LibraryId: "lib2", Name: "Two"},
+		{LibraryId: "lib3", Name: "Three"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("libraryFingerprint length = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("libraryFingerprint[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	// The input slice must be untouched (fetchPies iterates it next, in the
+	// original order Tdarr returned).
+	for i := range original {
+		if libs[i] != original[i] {
+			t.Errorf("libraryFingerprint mutated input at index %d: got %+v, want %+v", i, libs[i], original[i])
+		}
 	}
 }
 

--- a/internal/collector/tdarr_test.go
+++ b/internal/collector/tdarr_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -674,7 +675,7 @@ func TestCollect_PartialPieFailure_DoesNotPoisonCache(t *testing.T) {
 	if up := upValueFromFamilies(mfs1); up != 0.0 {
 		t.Errorf("scrape 1 tdarr_up: want 0.0, got %v", up)
 	}
-	if _, stats := c.statsCache.Read(); stats != nil {
+	if c.statsCache.Read().stats != nil {
 		t.Fatal("cache was written despite partial pie failure; partial data must not be cached")
 	}
 
@@ -693,7 +694,7 @@ func TestCollect_PartialPieFailure_DoesNotPoisonCache(t *testing.T) {
 	if got := libraryFilesSeriesCount(mfs2); got != 2 {
 		t.Errorf("scrape 2 tdarr_library_files series: want 2 (lib1+lib2), got %d", got)
 	}
-	if _, stats := c.statsCache.Read(); stats == nil {
+	if c.statsCache.Read().stats == nil {
 		t.Error("cache not written after fully successful scrape")
 	}
 }
@@ -709,32 +710,177 @@ func libraryFilesSeriesCount(mfs []*dto.MetricFamily) int {
 	return 0
 }
 
+// libraryInfoHasSeries returns true if tdarr_library_info carries a series with
+// the given library_id/library_name label pair.
+func libraryInfoHasSeries(mfs []*dto.MetricFamily, libID, libName string) bool {
+	for _, mf := range mfs {
+		if mf.GetName() != "tdarr_library_info" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["library_id"] == libID && labels["library_name"] == libName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestCollect_LibraryFingerprint_TriggersRefetch verifies that a library-list
+// change invisible to the 10 numeric totals — a rename, or a new zero-file
+// library — still triggers a pie refetch. Before the library-list fingerprint
+// was added to the cache invalidation signal, shouldRefetch keyed only on the
+// totals, so neither case would be observed until unrelated activity next
+// changed a total (see docs/metrics-internals.md).
+func TestCollect_LibraryFingerprint_TriggersRefetch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		newLibs     []TdarrLibraryInfo
+		wantLibID   string
+		wantLibName string
+	}{
+		{
+			name:        "library renamed, totals unchanged",
+			newLibs:     []TdarrLibraryInfo{{LibraryId: "lib1", Name: "Renamed Library"}},
+			wantLibID:   "lib1",
+			wantLibName: "Renamed Library",
+		},
+		{
+			name: "new zero-file library appears, totals unchanged",
+			newLibs: []TdarrLibraryInfo{
+				{LibraryId: "lib1", Name: "Library One"},
+				{LibraryId: "lib2", Name: "New Empty Library"},
+			},
+			wantLibID:   "lib2",
+			wantLibName: "New Empty Library",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := newTestConfig(t)
+			api := newSuccessFakeAPI(cfg)
+			c := newTdarrCollectorWithAPI(cfg, api)
+
+			// Scrape 1: populate the cache off the default single-library fixture
+			// (lib1 / "Library One"). The general-stats fixture (validStatsBody)
+			// is untouched throughout, so the 10 totals never change.
+			reg1 := prometheus.NewRegistry()
+			reg1.MustRegister(c)
+			if _, err := reg1.Gather(); err != nil {
+				t.Fatalf("scrape 1 gather: %v", err)
+			}
+
+			// Swap in the mutated library list and register a pie fixture for any
+			// library id introduced by this case.
+			libsBody, _ := json.Marshal(tc.newLibs)
+			api.setResponse(fakeKey{path: cfg.TdarrStatsPath, disc: "LibrarySettingsJSONDB"}, libsBody)
+			for _, lib := range tc.newLibs {
+				pieKey := fakeKey{path: cfg.TdarrPieStatsPath, disc: lib.LibraryId}
+				if _, ok := api.responses[pieKey]; !ok {
+					api.setResponse(pieKey, validPieBody())
+				}
+			}
+
+			// Scrape 2: totals unchanged, library list changed -> must refetch and
+			// emit the new/renamed series.
+			reg2 := prometheus.NewRegistry()
+			reg2.MustRegister(c)
+			mfs2, err := reg2.Gather()
+			if err != nil {
+				t.Fatalf("scrape 2 gather: %v", err)
+			}
+			if up := upValueFromFamilies(mfs2); up != 1.0 {
+				t.Errorf("scrape 2 tdarr_up: want 1.0, got %v", up)
+			}
+			if !libraryInfoHasSeries(mfs2, tc.wantLibID, tc.wantLibName) {
+				t.Errorf("scrape 2: tdarr_library_info missing series {library_id=%q, library_name=%q}", tc.wantLibID, tc.wantLibName)
+			}
+		})
+	}
+}
+
+// TestCollect_UnchangedLibraries_CacheHit_NoPieCalls verifies that when neither
+// the 10 totals nor the library list change between scrapes, the second scrape
+// serves pie stats entirely from cache and makes NO get-pies API calls.
+func TestCollect_UnchangedLibraries_CacheHit_NoPieCalls(t *testing.T) {
+	t.Parallel()
+	cfg := newTestConfig(t)
+	api := newSuccessFakeAPI(cfg)
+	c := newTdarrCollectorWithAPI(cfg, api)
+	pieKey := fakeKey{path: cfg.TdarrPieStatsPath, disc: "lib1"}
+
+	// Scrape 1: cache miss, populates the cache (and calls the pie endpoint once).
+	reg1 := prometheus.NewRegistry()
+	reg1.MustRegister(c)
+	if _, err := reg1.Gather(); err != nil {
+		t.Fatalf("scrape 1 gather: %v", err)
+	}
+	if got := api.callCount(pieKey); got != 1 {
+		t.Fatalf("scrape 1 pie calls: want 1, got %d", got)
+	}
+	api.resetCalls()
+
+	// Scrape 2: nothing changed (same totals, same library list) -> cache hit,
+	// so fetchPies must not run at all.
+	reg2 := prometheus.NewRegistry()
+	reg2.MustRegister(c)
+	mfs2, err := reg2.Gather()
+	if err != nil {
+		t.Fatalf("scrape 2 gather: %v", err)
+	}
+	if up := upValueFromFamilies(mfs2); up != 1.0 {
+		t.Errorf("scrape 2 tdarr_up: want 1.0, got %v", up)
+	}
+	if got := api.callCount(pieKey); got != 0 {
+		t.Errorf("scrape 2 pie calls: want 0 (cache hit), got %d", got)
+	}
+	// The library-list call itself is expected every scrape (it is the cheap
+	// invalidation signal) — only the expensive pie fan-out is skipped.
+	if got := api.callCount(fakeKey{path: cfg.TdarrStatsPath, disc: "LibrarySettingsJSONDB"}); got != 1 {
+		t.Errorf("scrape 2 library-list calls: want 1 (fetched every scrape), got %d", got)
+	}
+}
+
 // TestLibStatsCache_ReadWritePairing verifies Read always returns the exact
-// totals/stats pair the last Write stored, sequentially. This is the baseline
-// invariant check for the single-lock Read/Write API replacing the four
+// snapshot the last Write stored, sequentially. This is the baseline invariant
+// check for the single-lock snapshot Read/Write API replacing the four
 // separately-locked getters/setters.
 func TestLibStatsCache_ReadWritePairing(t *testing.T) {
 	c := NewTdarrLibStatsCache()
-	// empty cache: stats nil (refetch signal), zero totals
-	if tot, stats := c.Read(); stats != nil || tot != (tdarrCacheTotals{}) {
-		t.Fatalf("empty cache: want zero totals + nil stats, got %+v / %v", tot, stats)
+	// empty cache: stats nil (refetch signal), zero totals, nil fingerprint
+	if got := c.Read(); got.stats != nil || got.totals != (tdarrCacheTotals{}) || got.fingerprint != nil {
+		t.Fatalf("empty cache: want zero snapshot, got %+v", got)
 	}
-	totals := tdarrCacheTotals{totalFileCount: 42}
-	stats := []*TdarrPieStats{{libraryId: "lib1"}}
-	c.Write(totals, stats)
-	gotT, gotS := c.Read()
-	if gotT != totals {
-		t.Errorf("totals: want %+v, got %+v", totals, gotT)
+	snap := libStatsSnapshot{
+		totals:      tdarrCacheTotals{totalFileCount: 42},
+		stats:       []*TdarrPieStats{{libraryId: "lib1"}},
+		fingerprint: []TdarrLibraryInfo{{LibraryId: "lib1", Name: "Library One"}},
 	}
-	if len(gotS) != 1 || gotS[0].libraryId != "lib1" {
-		t.Errorf("stats: want [lib1], got %v", gotS)
+	c.Write(snap)
+	got := c.Read()
+	if got.totals != snap.totals {
+		t.Errorf("totals: want %+v, got %+v", snap.totals, got.totals)
+	}
+	if len(got.stats) != 1 || got.stats[0].libraryId != "lib1" {
+		t.Errorf("stats: want [lib1], got %v", got.stats)
+	}
+	if !slices.Equal(got.fingerprint, snap.fingerprint) {
+		t.Errorf("fingerprint: want %v, got %v", snap.fingerprint, got.fingerprint)
 	}
 }
 
 // TestLibStatsCache_ReadWritePairing_Concurrent races N writers against N
-// readers under -race. Each writer stores a totals/stats pair whose values
-// are derived from the same index, so any Read that observed a torn pair
-// (totals from one Write, stats from another) would show a mismatched index.
+// readers under -race. Each writer stores a snapshot whose field values are all
+// derived from the same index, so any Read that observed a torn snapshot
+// (fields from different Writes) would show a mismatched index.
 func TestLibStatsCache_ReadWritePairing_Concurrent(t *testing.T) {
 	c := NewTdarrLibStatsCache()
 	const n = 100
@@ -744,25 +890,30 @@ func TestLibStatsCache_ReadWritePairing_Concurrent(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() {
 			defer wg.Done()
-			c.Write(
-				tdarrCacheTotals{totalFileCount: i},
-				[]*TdarrPieStats{{libraryId: fmt.Sprintf("lib%d", i)}},
-			)
+			libId := fmt.Sprintf("lib%d", i)
+			c.Write(libStatsSnapshot{
+				totals:      tdarrCacheTotals{totalFileCount: i},
+				stats:       []*TdarrPieStats{{libraryId: libId}},
+				fingerprint: []TdarrLibraryInfo{{LibraryId: libId}},
+			})
 		}()
 		go func() {
 			defer wg.Done()
-			tot, stats := c.Read()
-			if stats == nil {
-				return // cache not yet written; not a torn pair
+			got := c.Read()
+			if got.stats == nil {
+				return // cache not yet written; not a torn snapshot
 			}
-			id := strings.TrimPrefix(stats[0].libraryId, "lib")
+			id := strings.TrimPrefix(got.stats[0].libraryId, "lib")
 			want, err := strconv.Atoi(id)
 			if err != nil {
-				t.Errorf("unexpected libraryId format %q: %v", stats[0].libraryId, err)
+				t.Errorf("unexpected libraryId format %q: %v", got.stats[0].libraryId, err)
 				return
 			}
-			if tot.totalFileCount != want {
-				t.Errorf("torn pair: totals.totalFileCount=%d does not match stats libraryId=%q", tot.totalFileCount, stats[0].libraryId)
+			if got.totals.totalFileCount != want {
+				t.Errorf("torn snapshot: totals.totalFileCount=%d does not match stats libraryId=%q", got.totals.totalFileCount, got.stats[0].libraryId)
+			}
+			if len(got.fingerprint) != 1 || got.fingerprint[0].LibraryId != got.stats[0].libraryId {
+				t.Errorf("torn snapshot: fingerprint=%v does not match stats libraryId=%q", got.fingerprint, got.stats[0].libraryId)
 			}
 		}()
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -183,7 +183,7 @@ func parseConfig(fs *flag.FlagSet, args []string, getenv func(string) string) (C
 	promPath := fs.String("prometheus_path", defaults.PrometheusPath, "path to use for prometheus exporter")
 	logLevel := fs.String("log_level", defaults.LogLevel, "log level to use, see link for possible values: https://pkg.go.dev/github.com/rs/zerolog#Level")
 	httpMaxConcurrency := fs.Int("http_max_concurrency", defaults.HttpMaxConcurrency, "maximum number of concurrent http requests to make when requesting per Library stats")
-	httpTimeoutSeconds := fs.Int("http_timeout_seconds", defaults.HttpTimeoutSeconds, "timeout in seconds for http requests to the tdarr instance")
+	httpTimeoutSeconds := fs.Int("http_timeout_seconds", defaults.HttpTimeoutSeconds, "total time budget in seconds for an http request to the tdarr instance, including transport-level retries and backoff (a low value can silently truncate retries)")
 	versionFlag := fs.Bool("version", false, "print version information and exit")
 	listenAddress := fs.String("listen_address", defaults.ListenAddress, "network interface address for the exporter's http server to listen on, ex: 127.0.0.1 or ::")
 	instanceName := fs.String("instance_name", defaults.InstanceName, "set to customize the tdarr_instance label (defaults to the url hostname); helpful when running multiple exporters and/or multiple tdarr instances on one host")


### PR DESCRIPTION
## Changes

**fix: invalidate stats cache when library list changes**
- The library list (`LibrarySettingsJSONDB` via `/api/v2/cruddb`) is now fetched on every scrape, not just cache misses. A sorted library id/name fingerprint is stored alongside the cached totals/stats — all three written under the same lock, so the torn-read guarantee extends to the new field.
- `shouldRefetch` now triggers on a mismatch in either the 10 numeric totals **or** the library fingerprint. The fingerprint catches drift the totals cannot see: a library rename, or a newly added zero-file library.
- A library-list fetch failure hard-fails the scrape (`tdarr_up=0`), consistent with the existing general-stats failure path. No fallback.
- The fetched list is reused on the refetch path, so net API calls go 3→4 on a cache-hit scrape and stay unchanged on a cache miss.

**docs:**
- SIGHUP: noted at the `signal.Notify` site + README — nothing to reload (no config file), treated as graceful shutdown, exit 0.
- `http_timeout_seconds`: flag help + README now describe it as the total request budget including transport-level retries and backoff (1s then 3s); the flag was previously absent from the README config table and `-h` example entirely — both added.
- Dockerfile: `-w -s` comment corrected — strips the symbol table and DWARF debug info; it does not disable pprof. Fixed "ldlflags" typo.
- `docs/metrics-internals.md`: new "Stats cache invalidation" section — the two-part signal, the bandwidth trade-off, and the residual staleness cases. README "Caching and Concurrency" section updated to match (it still described the pre-queue-buckets 3-count signal).

## Motivation

A library rename or a new zero-file library moves none of the 10 numeric totals the cache compared, so on an otherwise idle instance a stale `tdarr_library_info` name (or a missing new series) could persist indefinitely while `tdarr_up=1`. Measured live, the list call costs ~8ms and ~15KB per library — cheap enough in latency to check every scrape. The bandwidth cost (~102KB/scrape for 7 libraries) is a deliberate, documented trade against staleness.

## Verification

- `task ci` green: gofmt clean, `go mod tidy` clean, golangci-lint 0 issues, `go test ./... -race` all pass (collector coverage 94%).
- New tests (verified to fail without the fix): library rename and new-empty-library each trigger a refetch and emit the updated `tdarr_library_info` series; unchanged libraries → cache hit with **zero** pie calls on the second scrape (asserted via a call counter on the test fake); library-list failure → `tdarr_up=0`; `libraryFingerprint` sorts a copy without mutating the input slice; cache Read/Write triple consistency exercised under `-race`.
- Live e2e against a real Tdarr instance (7 libraries): scrape 1 cache miss → full fetch → cache set; scrape 2 logs "api totals and library fingerprint match" → cache hit; `tdarr_up=1` both scrapes, 7 `tdarr_library_info` series.
- Adversarial review of the full diff found no correctness, concurrency, test, or doc-accuracy issues; nil-vs-empty `slices.Equal` edge traced and confirmed unreachable (current fingerprint is never nil; cached-nil coincides with the empty-cache refetch path).

## In-depth

- Fingerprint is a sorted `[]TdarrLibraryInfo` compared with `slices.Equal`, not a joined `id:name` string — names are free-form user input, so any delimited-string form is collision-prone (`{a, b:c}` vs `{a:b, c}`).
- Invalidation stays global/all-or-nothing: per-library data only exists in the expensive per-library `get-pies` call, so no cheap per-library probe exists (see the `shouldRefetch` doc comment).
- Residual staleness that still won't trigger a refetch (cross-library moves within the same status bucket, offsetting add+delete across libraries, same-bucket rescans shifting codec/resolution distributions) is documented in `docs/metrics-internals.md`; all cases self-heal on the next totals-visible event.
