### PR TITLE
chore: round-2 review build/CI hygiene (Taskfile drift, dead CI cruft, curated golangci-lint)

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -9,27 +9,22 @@ description: Creates a Docker image
 inputs:
   dockerhub_username:
     description: Dockerhub username
-    type: string
     required: false
     default: none
   dockerhub_token:
     description: Dockerhub token
-    type: string
     required: false
     default: none
   push:
     description: Push Images to docker hub
-    type: boolean
     required: false
     default: true
   latest:
     description: Update latest tag
-    type: boolean
     required: false
     default: true
   version:
     description: Semver version to tag, e.g. v2.2.0; empty for non-release builds
-    type: string
     required: false
     default: ""
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,5 +21,17 @@
       "groupSlug": "minor-patch"
     }
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Bump the Go base image tag in Taskfile.yml (kept in sync with Dockerfile's BASE_IMAGE_TAG build arg)",
+      "managerFilePatterns": ["/^Taskfile\\.yml$/"],
+      "matchStrings": [
+        "BASE_IMAGE_TAG:\\s*['\"]?(?<currentValue>[\\w.-]+)['\"]?"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "golang"
+    }
+  ],
   "timezone": "UTC"
 }

--- a/.github/workflows/on_pr_merged.yml
+++ b/.github/workflows/on_pr_merged.yml
@@ -1,5 +1,3 @@
-# needs: [tests]  # require tests to pass before deploy runs
-
 name: Create Current Main Image
 
 # on:
@@ -23,10 +21,6 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # strategy:
-    #   matrix:
-    #     go-version: ["1.21.5"]
-    #     golangci-version: ["v1.51.2"]
     steps:
     - name: Checkout
       uses: actions/checkout@v7

--- a/.github/workflows/on_pr_open.yml
+++ b/.github/workflows/on_pr_open.yml
@@ -11,11 +11,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # not working for some reason
-    # strategy:
-    #   matrix:
-    #     go-version: ["1.21.5"]
-    #     golangci-version: ["v1.51.2"]
     steps:
     - name: Checkout
       uses: actions/checkout@v7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+# Curated on top of golangci-lint's default (standard) linter set.
+linters:
+  enable:
+    - copyloopvar # flags obsolete per-iteration loop-variable copies (Go 1.22+)
+    - errorlint   # catches ==/type-assert on wrapped errors (use errors.Is/As)
+    - misspell    # catches common English misspellings in comments/strings
+    - nolintlint  # keeps //nolint directives honest (specific + explained)
+    - unconvert   # flags redundant type conversions

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,7 +7,9 @@ dotenv: ['.local/local.env']
 vars:
   # Build args for Dockerfile
   BASE_IMAGE: golang
-  BASE_IMAGE_TAG: 1.26.3-alpine
+  # keep in sync with Dockerfile BASE_IMAGE_TAG; renovate bumps this via the
+  # custom regex manager in .github/renovate.json
+  BASE_IMAGE_TAG: 1.26.5-alpine
   RUN_IMAGE: gcr.io/distroless/static
   RUN_IMAGE_TAG: nonroot
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,7 +37,7 @@ tasks:
       - air
 
   dev:docker:
-    desc: Build image, run detached, curl /metrics once, then tear down
+    desc: Build local image and run it in the foreground; Ctrl-C stops and removes the container
     deps:
       - task: docker:build:local
     cmds:
@@ -135,7 +135,7 @@ tasks:
           --no-cache .
 
   docker:build:latest:
-    desc: Build multi-arch image (linux/amd64,linux/arm64) and PUSH to registry with :test and :latest tags
+    desc: Build multi-arch image (linux/amd64,linux/arm64) with :test and :latest tags, without pushing
     cmds:
       - task: docker:buildx-setup
       - docker buildx build

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -191,7 +191,6 @@ func TestNewRequestClient_ConcurrentConstruction(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
 	for i := 0; i < goroutines; i++ {
-		i := i
 		go func() {
 			defer wg.Done()
 			verifySsl := i%2 == 0 // alternate true/false for variety

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -75,6 +75,7 @@ func Recovery(next http.Handler) http.Handler {
 		recorder := newResponseRecorder(w)
 		defer func() {
 			if rec := recover(); rec != nil {
+				//nolint:errorlint // recover() returns the exact value panicked with; net/http panics with this sentinel unwrapped, so == is the idiom (net/http itself compares this way).
 				if rec == http.ErrAbortHandler {
 					// stdlib's sanctioned connection-abort signal; net/http
 					// handles it, so let it continue unwinding.

--- a/internal/handlers/middleware_test.go
+++ b/internal/handlers/middleware_test.go
@@ -41,7 +41,7 @@ func TestRequestLogger_ForwardsResponseUnchanged(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			h := RequestLogger(http.HandlerFunc(tc.handler))
+			h := RequestLogger(tc.handler)
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/probe", nil)
 			h.ServeHTTP(rec, req)


### PR DESCRIPTION
Build/CI/docs hygiene batch from the round-2 holistic review. All commits are non-releasing types (`chore`/`ci`/`test`) — no runtime behavior change, no effect on the queued v3.1.0 release PR.

## Changes

- **Taskfile Go base image aligned with Dockerfile** — `BASE_IMAGE_TAG` was stuck at `1.26.3-alpine` while the Dockerfile default (renovate-managed, last bumped in #108) is `1.26.5-alpine`, so local docker builds used an older toolchain. Bumped, and a renovate custom regex manager now tracks the Taskfile value (docker datasource, `golang` dep) so it lands in the same grouped minor-patch PRs as the Dockerfile — the drift can't recur.
- **Stale task descriptions fixed** — `dev:docker` claimed "run detached, curl /metrics once, then tear down" but actually runs foreground `docker run -it --rm`; `docker:build:latest` claimed it pushes to a registry but hardcodes `push=false`. Descriptions now match the commands.
- **Dead CI comments and ignored fields removed** — commented-out `strategy.matrix` blocks (pinning long-gone Go 1.21.5 / golangci-lint v1.51.2, marked "not working for some reason") in `on_pr_open.yml`/`on_pr_merged.yml`; stray `# needs: [tests]` line; and `type:` fields on the composite action's inputs, which GitHub silently ignores (`type` is a reusable-workflow-only field). All callers consume the inputs as strings (via `fromJSON` for the boolean-flavored ones), so removal is behavior-neutral.
- **Curated `.golangci.yml`** (v2 format for the pinned golangci-lint v2.12.2) — default linter set plus `copyloopvar`, `errorlint`, `misspell`, `nolintlint`, `unconvert`. Two trivial test cleanups the new linters flagged: an identity `http.HandlerFunc` conversion and an obsolete Go-1.22 `i := i` loopvar copy. One `//nolint:errorlint` (with explanation) on the `rec == http.ErrAbortHandler` recover-sentinel compare in `Recovery` — net/http panics with that sentinel unwrapped and compares it with `==`/`!=` itself, so `errors.Is` would be wrong there.

## Motivation

Round-2 review findings: local docker builds silently drifting behind CI's toolchain; task descriptions describing behavior the commands don't have; CI cruft; and lint running defaults only — `errorlint` would have caught the wrapped-error comparison fixed in #119.

## Verification

- `task ci` green (fmt clean, tidy clean, lint 0 issues, race+coverage tests pass) on Go 1.26.5.
- `task lint` 0 issues with the new config committed — also confirms `nolintlint` accepts the one directive (specific + explained) and that it's not unused.
- `.github/renovate.json` validated with `renovate-config-validator` (pass); regex confirmed to match only the `BASE_IMAGE_TAG:` vars line (build-arg lines use `=`, not `:`).
- All YAML/JSON files parse-checked.
- Adversarial review of the full diff: every factual claim independently verified (composite-action `type:` ignored; errorlint suppression a genuine false positive per net/http semantics; descriptions accurate; no load-bearing comments deleted). Two questions raised and both closed: lint run performed with the final config, and Dockerfile ARG confirmed renovate-tracked (bumped by renovate in #108 itself).

## In-depth

- The renovate custom manager intentionally covers only `Taskfile.yml`; the Dockerfile is already handled by renovate's stock dockerfile manager (empirically: #108 bumped it). Both feed the same `minor & patch updates` group.
- `PUSH` variable wiring into the buildx tasks was considered and skipped — CI pushes via the composite action, not the Taskfile, so making the description honest was the smaller correct change.
- `errorlint`, `unconvert`, `copyloopvar` each flagged exactly one existing occurrence; all were resolved (one suppressed as a stdlib-idiom false positive, two fixed) rather than dropping the linters.
