### PR TITLE
fix: round-2 review polish (deferred access log, 404 log level, dead error plumbing)

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -43,11 +43,7 @@ func run() int {
 	defer cancelScrapes()
 
 	// prometheus set up
-	tdarrCollector, err := collector.NewTdarrCollector(scrapeCtx, userConfig)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to create Tdarr collector")
-		return 1
-	}
+	tdarrCollector := collector.NewTdarrCollector(scrapeCtx, userConfig)
 	registry := buildRegistry(userConfig.InstanceName, tdarrCollector)
 
 	// http server

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -47,7 +47,7 @@ func run() int {
 	registry := buildRegistry(userConfig.InstanceName, tdarrCollector)
 
 	// http server
-	stopHttpChan := make(chan bool)
+	stopHttpChan := make(chan struct{})
 	// Buffered with one slot per potential sender (ListenAndServe error,
 	// Shutdown error) so the server goroutine never blocks sending, even if
 	// both fire after main has stopped selecting on errChan.
@@ -85,7 +85,7 @@ func run() int {
 	}()
 	// Abort any in-flight scrape before tearing down the HTTP server.
 	cancelScrapes()
-	stopHttpChan <- true
+	stopHttpChan <- struct{}{}
 	httpWg.Wait()
 	log.Info().Msg("Gracefully shutdown tdarr exporter")
 	return exitCode

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -33,7 +33,7 @@ type QueryParams = url.Values
 //   - timeoutSeconds: HTTP client timeout; use config.HttpTimeoutSeconds (default 15).
 //
 // The global http.DefaultTransport is never mutated; a fresh clone is created per call.
-func NewRequestClient(parsedUrl *url.URL, verifySsl bool, timeoutSeconds int, apiKeyAuth string) (*RequestClient, error) {
+func NewRequestClient(parsedUrl *url.URL, verifySsl bool, timeoutSeconds int, apiKeyAuth string) *RequestClient {
 	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
 	baseTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: !verifySsl}
 
@@ -52,7 +52,7 @@ func NewRequestClient(parsedUrl *url.URL, verifySsl bool, timeoutSeconds int, ap
 		URL:    *parsedUrl,
 		apiKey: apiKeyAuth,
 		logger: log.Logger,
-	}, nil
+	}
 }
 
 // maxBodyHeadBytes bounds how much of a failed response body is captured for the

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -168,10 +168,7 @@ func TestNewRequestClient_DoesNotLeakInsecureIntoDefaultTransport(t *testing.T) 
 	u, _ := url.Parse("http://example.com")
 	// verifySsl=false means InsecureSkipVerify=true in the new client — the most
 	// aggressive change; old code would set the global to InsecureSkipVerify=true here.
-	_, err := NewRequestClient(u, false, 15, "")
-	if err != nil {
-		t.Fatalf("NewRequestClient: %v", err)
-	}
+	NewRequestClient(u, false, 15, "")
 
 	// The global transport must never end up with our insecure setting.
 	if cfg := http.DefaultTransport.(*http.Transport).TLSClientConfig; cfg != nil && cfg.InsecureSkipVerify {
@@ -194,11 +191,7 @@ func TestNewRequestClient_ConcurrentConstruction(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			verifySsl := i%2 == 0 // alternate true/false for variety
-			_, err := NewRequestClient(u, verifySsl, 15, "test-key")
-			if err != nil {
-				// t.Error is goroutine-safe; t.Fatal is not.
-				t.Error("NewRequestClient concurrent construction error:", err)
-			}
+			NewRequestClient(u, verifySsl, 15, "test-key")
 		}()
 	}
 	wg.Wait()

--- a/internal/client/request_test.go
+++ b/internal/client/request_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/rs/zerolog"
 )
 
 // payloadTarget is a small struct the request methods unmarshal JSON into.
@@ -160,6 +162,40 @@ func TestDoRequest_UnmarshalError(t *testing.T) {
 	var target payloadTarget
 	if err := c.DoRequest(context.Background(), "/api/v2/status", &target); err == nil {
 		t.Fatal("DoRequest: want error for invalid JSON, got nil")
+	}
+}
+
+// TestDoRequest_ConnectionFailure verifies that a network-level failure (the
+// server having gone away) surfaces as a non-nil error from DoRequest and
+// leaves target untouched, rather than a decode error or a zero-valued success.
+//
+// Built directly (bypassing NewRequestClient/NewClientTransport, matching the
+// direct-construction style already used in client_test.go) so the request
+// goes out over the plain http.DefaultTransport with no retry-with-backoff
+// wrapper: NewRequestClient's transport retries a failed dial with real
+// (1s, 3s) backoff and offers no seam to inject a fake timer through the
+// client package's public surface, which would make this test take ~4s of
+// real wall-clock time for no additional coverage (the retry/backoff behavior
+// itself is already covered deterministically in transport_test.go via
+// WithBackoff/WithAfter).
+func TestDoRequest_ConnectionFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // closed before any request is made: connection refused, deterministically
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", srv.URL, err)
+	}
+	c := &RequestClient{URL: *u, logger: zerolog.Nop()}
+
+	target := payloadTarget{Name: "unchanged", Count: -1}
+	if err := c.DoRequest(context.Background(), "/api/v2/status", &target); err == nil {
+		t.Fatal("DoRequest: want error for a closed server connection, got nil")
+	}
+	if target.Name != "unchanged" || target.Count != -1 {
+		t.Errorf("target: want unmodified {unchanged -1}, got %+v", target)
 	}
 }
 

--- a/internal/client/request_test.go
+++ b/internal/client/request_test.go
@@ -23,11 +23,7 @@ func newTestClient(t *testing.T, serverURL, apiKey string) *RequestClient {
 	if err != nil {
 		t.Fatalf("url.Parse(%q): %v", serverURL, err)
 	}
-	c, err := NewRequestClient(u, false, 5, apiKey)
-	if err != nil {
-		t.Fatalf("NewRequestClient: %v", err)
-	}
-	return c
+	return NewRequestClient(u, false, 5, apiKey)
 }
 
 // TestDoRequest_HappyPath verifies a GET to a path: the server sees method GET

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -185,20 +185,14 @@ func (c *TdarrLibStatsCache) Write(snap libStatsSnapshot) {
 //
 // NewTdarrCollector builds the shared HTTP client once from runConfig and wires it
 // into both the top-level collector and the embedded node collector. The client is
-// surfaced as a tdarrAPI; the error from client.NewRequestClient is propagated so the
-// composition root (main) can fail fast on a bad URL.
-func NewTdarrCollector(ctx context.Context, runConfig config.Config) (*TdarrCollector, error) {
-	api, err := client.NewRequestClient(runConfig.UrlParsed, runConfig.VerifySsl, runConfig.HttpTimeoutSeconds, runConfig.ApiKey)
-	if err != nil {
-		log.Error().
-			Err(err).Msg("Failed to create http request client for Tdarr, ensure proper URL is provided")
-		return nil, err
-	}
+// surfaced as a tdarrAPI.
+func NewTdarrCollector(ctx context.Context, runConfig config.Config) *TdarrCollector {
+	api := client.NewRequestClient(runConfig.UrlParsed, runConfig.VerifySsl, runConfig.HttpTimeoutSeconds, runConfig.ApiKey)
 	c := newTdarrCollectorWithAPI(runConfig, api)
 	// Wire the shutdown-cancellable context from the composition root so a scrape
 	// in flight when the process is terminating aborts instead of running to completion.
 	c.baseCtx = ctx
-	return c, nil
+	return c
 }
 
 // newTdarrCollectorWithAPI is the test-injection seam: it builds a fully wired

--- a/internal/collector/tdarr.go
+++ b/internal/collector/tdarr.go
@@ -96,8 +96,10 @@ type TdarrCollector struct {
 	// a context cancelled on shutdown so in-flight scrapes abort promptly; tests and
 	// the WithAPI constructor default it to context.Background().
 	baseCtx context.Context
-	// logger defaults to the package-global log.Logger and is shared with the node
-	// collector at construction. Injected so tests can silence or capture logs.
+	// logger defaults to the package-global log.Logger. The node collector gets its
+	// own copy of that value at construction (zerolog.Logger is a value type), so
+	// reassigning this field afterwards — as tests do to capture logs — does not
+	// affect node-collector output.
 	logger                zerolog.Logger
 	statsCache            *TdarrLibStatsCache
 	unknownStatusMu       sync.Mutex

--- a/internal/collector/tdarr_nodes.go
+++ b/internal/collector/tdarr_nodes.go
@@ -99,7 +99,10 @@ type TdarrNodeCollector struct {
 	nodePath string
 	api      tdarrAPI // shared with the parent TdarrCollector (same base URL)
 	metrics  *TdarrNodeMetrics
-	logger   zerolog.Logger // shared with the parent TdarrCollector
+	// logger is a construction-time copy of the parent TdarrCollector's logger
+	// (zerolog.Logger is a value type; later reassignment of the parent's field
+	// does not reach here).
+	logger zerolog.Logger
 }
 
 func NewTdarrNodeMetrics(runConfig config.Config) *TdarrNodeMetrics {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -415,6 +415,7 @@ func TestVersionFlagShortCircuits(t *testing.T) {
 }
 
 func TestListenAddress(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		args []string
@@ -428,6 +429,7 @@ func TestListenAddress(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			args := append([]string{"-url", "http://tdarr.test"}, tt.args...)
 			cfg, err := parseConfig(newFS(), args, envFunc(tt.env))
 			if err != nil {
@@ -441,6 +443,7 @@ func TestListenAddress(t *testing.T) {
 }
 
 func TestInstanceNameOverride(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		args []string
@@ -454,6 +457,7 @@ func TestInstanceNameOverride(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			args := append([]string{"-url", "http://tdarr.test:8265"}, tt.args...)
 			cfg, err := parseConfig(newFS(), args, envFunc(tt.env))
 			if err != nil {

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -52,18 +52,29 @@ func (r *responseRecorder) Unwrap() http.ResponseWriter {
 }
 
 // RequestLogger debug-logs each request with method, URI, proto, status and duration.
+//
+// The log call is deferred so a panicking handler still produces an access-log
+// line (Recovery, which wraps RequestLogger from the outside, owns the actual
+// recover()/500 conversion; this defer just rides the same unwind, including
+// for http.ErrAbortHandler panics that re-panic through Recovery).
+//
+// CAVEAT: on panic, the logged status is the recorder's value at unwind
+// time (200 unless the handler already called WriteHeader/Write before
+// panicking) — NOT the 500 Recovery's own outer recorder ends up writing.
 func RequestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rec := newResponseRecorder(w)
 		t := time.Now()
+		defer func() {
+			log.Debug().
+				Str("method", r.Method).
+				Str("request_uri", r.RequestURI).
+				Str("proto", r.Proto).
+				Int("status", rec.status).
+				Float64("duration_seconds", time.Since(t).Seconds()).
+				Msg("Incoming request")
+		}()
 		next.ServeHTTP(rec, r)
-		log.Debug().
-			Str("method", r.Method).
-			Str("request_uri", r.RequestURI).
-			Str("proto", r.Proto).
-			Int("status", rec.status).
-			Float64("duration_seconds", time.Since(t).Seconds()).
-			Msg("Incoming request")
 	})
 }
 

--- a/internal/handlers/middleware_test.go
+++ b/internal/handlers/middleware_test.go
@@ -1,10 +1,14 @@
 package handlers
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 // TestRequestLogger_ForwardsResponseUnchanged verifies RequestLogger is
@@ -53,6 +57,44 @@ func TestRequestLogger_ForwardsResponseUnchanged(t *testing.T) {
 				t.Fatalf("body = %q, want %q", rec.Body.String(), tc.wantBody)
 			}
 		})
+	}
+}
+
+// TestRequestLogger_PanicStillLogsAccessLine verifies the access log fires even
+// when the wrapped handler panics, by driving the real production composition
+// Recovery(RequestLogger(h)) so the panic actually unwinds through both
+// middlewares exactly as it would in production.
+//
+// This mutates the package-global log.Logger to capture output (matching the
+// only precedent for capturing zerolog output in this repo, see
+// internal/client/client_test.go and internal/collector/tdarr_test.go, both of
+// which inject a logger rather than touch the global — RequestLogger has no
+// injectable logger seam, so the global is the only capture point here).
+// Deliberately NOT t.Parallel(): go test runs all non-parallel top-level tests
+// to completion before any parallel-batch tests in this package resume
+// concurrently, so this global mutation cannot race with the t.Parallel()
+// tests elsewhere in this file as long as it stays non-parallel itself.
+func TestRequestLogger_PanicStillLogsAccessLine(t *testing.T) {
+	orig := log.Logger
+	defer func() { log.Logger = orig }()
+
+	var buf bytes.Buffer
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+
+	h := Recovery(RequestLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom-access-log")
+	})))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/panics", nil)
+	h.ServeHTTP(rec, req)
+
+	logged := buf.String()
+	if !strings.Contains(logged, "Incoming request") {
+		t.Fatalf("access log missing after panic; buffer = %q", logged)
+	}
+	if !strings.Contains(logged, "/panics") {
+		t.Fatalf("access log missing request_uri; buffer = %q", logged)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,7 +36,10 @@ func newMux(runConfig HttpServerConfig, registry *prometheus.Registry) http.Hand
 	mux.Handle("GET /healthz", handlers.HealthzHandler())
 	// Fallback for everything else (gin's old NoRoute behavior).
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		log.Warn().
+		// Debug, not Warn: this catch-all also matches internet scanners
+		// probing arbitrary paths, which is operationally routine, not a
+		// warning-worthy condition.
+		log.Debug().
 			Str("route", r.URL.Path).
 			Msg("Route Not Found")
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -49,7 +49,7 @@ func newMux(runConfig HttpServerConfig, registry *prometheus.Registry) http.Hand
 	return handlers.Recovery(handlers.RequestLogger(mux))
 }
 
-func ServeHttp(wg *sync.WaitGroup, registry *prometheus.Registry, runConfig HttpServerConfig, stopChan chan bool, errChan chan<- error) {
+func ServeHttp(wg *sync.WaitGroup, registry *prometheus.Registry, runConfig HttpServerConfig, stopChan chan struct{}, errChan chan<- error) {
 	defer wg.Done()
 
 	log.Info().

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -88,7 +88,7 @@ func TestServeHttpLifecycle(t *testing.T) {
 	addr := net.JoinHostPort("127.0.0.1", port)
 
 	wg := &sync.WaitGroup{}
-	stopChan := make(chan bool)
+	stopChan := make(chan struct{})
 	errChan := make(chan error, 1)
 	cfg := HttpServerConfig{
 		TdarrInstance:   "lifecycle",
@@ -122,7 +122,7 @@ func TestServeHttpLifecycle(t *testing.T) {
 
 	// Trigger graceful shutdown and assert the WaitGroup completes (i.e.
 	// ServeHttp returned via wg.Done, not os.Exit).
-	stopChan <- true
+	stopChan <- struct{}{}
 
 	done := make(chan struct{})
 	go func() {
@@ -158,7 +158,7 @@ func TestServeHttpListenErrorDeliveredOnChannel(t *testing.T) {
 	}
 
 	wg := &sync.WaitGroup{}
-	stopChan := make(chan bool, 1)
+	stopChan := make(chan struct{}, 1)
 	errChan := make(chan error, 1)
 	cfg := HttpServerConfig{
 		TdarrInstance:   "listen-error",
@@ -183,7 +183,7 @@ func TestServeHttpListenErrorDeliveredOnChannel(t *testing.T) {
 	// ServeHttp is still blocked on stopChan after the listen error (matching
 	// production wiring where main sends stop after receiving the error).
 	// Release it and confirm clean return.
-	stopChan <- true
+	stopChan <- struct{}{}
 
 	done := make(chan struct{})
 	go func() {
@@ -221,7 +221,7 @@ func TestServeHttpShutdownErrorSecondSendDoesNotBlock(t *testing.T) {
 	addr := net.JoinHostPort("127.0.0.1", port)
 
 	wg := &sync.WaitGroup{}
-	stopChan := make(chan bool)
+	stopChan := make(chan struct{})
 	// Mirror production wiring (cmd/exporter/main.go) and pre-fill one slot to
 	// simulate an earlier undrained send.
 	errChan := make(chan error, 2)
@@ -256,7 +256,7 @@ func TestServeHttpShutdownErrorSecondSendDoesNotBlock(t *testing.T) {
 	}()
 	<-bc.entered
 
-	stopChan <- true
+	stopChan <- struct{}{}
 
 	done := make(chan struct{})
 	go func() {


### PR DESCRIPTION
Final polish batch from the round-2 holistic review — the remaining low-severity findings (#9, #10, #12–#14, #15b/c). Two commits are `fix:` (log behavior); merged before the queued release PR they ride v3.1.0, otherwise they queue a patch release.

## Changes

- **`fix:` access log deferred** — `RequestLogger`'s Debug access-log call ran after `next.ServeHTTP`, so panicking handlers produced Recovery's error log but no access-log line. The call now runs in a `defer` and fires exactly once on normal, panic, and `http.ErrAbortHandler` re-panic paths. Documented caveat: on panic the logged `status` is the inner recorder's unwind-time value (seeded 200), not the 500 Recovery writes downstream. New regression test drives the real `Recovery(RequestLogger(...))` composition with a panicking handler.
- **`fix:` catch-all 404 log Warn → Debug** — internet scanners hitting unknown paths generated per-request warnings; now consistent with the access log's own Debug level. No test, doc, or alert asserted the old level.
- **`refactor:` dropped always-nil error returns** — `NewRequestClient` could never fail (transport clone + TLS config assignment have no error paths); its error return and the dead branches at all callers are removed. That made `NewTdarrCollector`'s error also unconditionally nil, so its signature and `main.go`'s dead error branch were cleaned up in the same commit. Both are `internal/` (not externally importable).
- **`refactor:` `chan bool` → `chan struct{}`** for the stop channels (`ServeHttp` param, `main.go`, tests). Signal-only; no site ever inspected the boolean. Buffering preserved.
- **`test:`** client-level connection-failure test (`DoRequest` against a closed `httptest` server must error with the target untouched); `t.Parallel()` added to the two config subtest tables that were missing it (both use injected env maps — no shared state).
- **`docs:`** struct comments corrected: the node collector's logger is a construction-time *copy* of the parent's (zerolog.Logger is a value type), not "shared". The review finding proposed passing `c.logger` instead of `log.Logger`, but both are copies of the identical value at that instant — the comment, not the code, was wrong.

## Motivation

Round-2 review findings, severity minor: a missing access-log line on panics, scanner noise at Warn, dead error plumbing, non-idiomatic signal channels, misleading logger comments, and two small test gaps.

## Verification

- `task ci` green (fmt, tidy, golangci-lint incl. errorlint/nolintlint from #121: 0 issues, race tests pass) on Go 1.26.5.
- Live e2e against a real Tdarr instance: two scrapes `tdarr_up=1` (205 `tdarr_` series), 404 hint response unchanged and now logged at debug, access-log lines present for all three requests, graceful shutdown exit 0.
- Adversarial review of the full diff: panic/defer semantics traced exactly-once on all paths; the non-parallel global-logger test verified race-free against the package's parallel tests (Go runs non-parallel top-level tests to completion first); error-return cascade confirmed complete with zero stale callers; connection-failure test confirmed deterministic. Verdict SHIP, zero findings.

## In-depth

- The access-log caveat (status 200 logged for panicking requests) is inherent to the middleware order `Recovery(RequestLogger(mux))` — Recovery writes its 500 to its own outer recorder after RequestLogger's frame has unwound. Reordering middleware was out of scope and would trade away Recovery's coverage of RequestLogger itself.
- A future TLS-options feature could reintroduce a real error path in `NewRequestClient`; the signature change is mechanical to revert when that lands (tracked separately in the native-TLS scoping doc).
